### PR TITLE
Validate species names when importing FASTA files

### DIFF
--- a/tests/test_legacy-import.sh
+++ b/tests/test_legacy-import.sh
@@ -33,6 +33,16 @@ if [ `sqlite3 $TMP/legacy_004_and_005.sqlite "SELECT COUNT(id) FROM its1_source;
 if [ `sqlite3 $TMP/legacy_004_and_005.sqlite "SELECT COUNT(id) FROM its1_sequence;"` -ne "172" ]; then echo "Wrong its1_sequence count"; false; fi
 if [ `sqlite3 $TMP/legacy_004_and_005.sqlite "SELECT COUNT(id) FROM taxonomy;"` -ne "166" ]; then echo "Wrong taxonomy count"; false; fi
 
+# Now test with species name validation, load with Phytophthora
+rm -rf $TMP/legacy_004_and_005_validated.sqlite
+thapbi_pict load-tax -d $TMP/legacy_004_and_005_validated.sqlite -t new_taxdump_2018-12-01 -a 4783
+thapbi_pict legacy-import -d $TMP/legacy_004_and_005_validated.sqlite database/legacy/Phytophthora_ITS_database_v0.005.fasta -n "Legacy DB v0.005" -s
+thapbi_pict legacy-import -d $TMP/legacy_004_and_005_validated.sqlite database/legacy/Phytophthora_ITS_database_v0.004.fasta -n "Legacy DB v0.004" -s
+if [ `sqlite3 $TMP/legacy_004_and_005_validated.sqlite "SELECT COUNT(id) FROM data_source;"` -ne "2" ]; then echo "Wrong data_source count"; false; fi
+if [ `sqlite3 $TMP/legacy_004_and_005_validated.sqlite "SELECT COUNT(id) FROM its1_source;"` -ne "378" ]; then echo "Wrong its1_source count"; false; fi
+if [ `sqlite3 $TMP/legacy_004_and_005_validated.sqlite "SELECT COUNT(id) FROM its1_sequence;"` -ne "172" ]; then echo "Wrong its1_sequence count"; false; fi
+# TODO: Species count
+
 thapbi_pict dump 2>&1 | grep "the following arguments are required"
 thapbi_pict dump -d database/legacy/Phytophthora_ITS_database_v0.005.sqlite -o /dev/null
 thapbi_pict dump -d "sqlite:///database/legacy/Phytophthora_ITS_database_v0.005.sqlite" -o /dev/null -c 8a,8b

--- a/tests/test_load-tax.sh
+++ b/tests/test_load-tax.sh
@@ -10,12 +10,12 @@ export TMP=${TMP:-/tmp}
 echo "Checking load-tax"
 thapbi_pict load-tax 2>&1 | grep "the following arguments are required"
 
-if [ ! -f "new_taxdump_2018-12-01.zip" ]; then curl -L -O "ftp://ftp.ncbi.nih.gov/pub/taxonomy/taxdump_archive/new_taxdump_2018-12-01.zip"; fi
+if [ ! -f "new_taxdump_2018-12-01.zip" ]; then curl -L -O "https://ftp.ncbi.nih.gov/pub/taxonomy/taxdump_archive/new_taxdump_2018-12-01.zip"; fi
 if [ ! -d "new_taxdump_2018-12-01" ]; then unzip new_taxdump_2018-12-01.zip -d new_taxdump_2018-12-01; fi
 
 thapbi_pict load-tax -d "sqlite:///:memory:" -t new_taxdump_2018-12-01
 
-if [ ! -f "taxdmp_2014-08-01.zip" ]; then curl -L -O "ftp://ftp.ncbi.nih.gov/pub/taxonomy/taxdump_archive/taxdmp_2014-08-01.zip"; fi
+if [ ! -f "taxdmp_2014-08-01.zip" ]; then curl -L -O "https://ftp.ncbi.nih.gov/pub/taxonomy/taxdump_archive/taxdmp_2014-08-01.zip"; fi
 if [ ! -d "taxdmp_2014-08-01" ]; then unzip taxdmp_2014-08-01.zip -d taxdmp_2014-08-01; fi
 
 # Defaults to all Phytophthora

--- a/tests/test_ncbi-import.sh
+++ b/tests/test_ncbi-import.sh
@@ -19,8 +19,18 @@ thapbi_pict ncbi-import -d $TMP/ncbi_sample.sqlite $TMP/ncbi_sample.fasta
 
 if [ `sqlite3 $TMP/ncbi_sample.sqlite "SELECT COUNT(id) FROM data_source;"` -ne "1" ]; then echo "Wrong data_source count"; false; fi
 if [ `sqlite3 $TMP/ncbi_sample.sqlite "SELECT COUNT(id) FROM taxonomy;"` -lt "100" ]; then echo "Taxonomy count too low"; false; fi
+# Other values subject to change
 
 thapbi_pict dump 2>&1 | grep "the following arguments are required"
 thapbi_pict dump -d $TMP/ncbi_sample.sqlite -o /dev/null
+
+rm -rf $TMP/ncbi_sample_validated.sqlite
+thapbi_pict load-tax -d $TMP/ncbi_sample_validated.sqlite -t new_taxdump_2018-12-01 -a 4783
+thapbi_pict ncbi-import -d $TMP/ncbi_sample_validated.sqlite $TMP/ncbi_sample.fasta -s
+if [ `sqlite3 $TMP/ncbi_sample.sqlite "SELECT COUNT(id) FROM data_source;"` -ne "1" ]; then echo "Wrong data_source count"; false; fi
+if [ `sqlite3 $TMP/ncbi_sample.sqlite "SELECT COUNT(id) FROM taxonomy;"` -lt "100" ]; then echo "Taxonomy count too low"; false; fi
+# Other values subject to change
+
+thapbi_pict dump -d $TMP/ncbi_sample_validated.sqlite -o /dev/null
 
 echo "$0 passed"

--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -41,6 +41,7 @@ def ncbi_import(args=None):
         fasta_file=args.fasta,
         db_url=expand_database_argument(args.database),
         name=args.name,
+        validate_species=args.validate_species,
         debug=args.verbose)
 
 
@@ -51,6 +52,7 @@ def legacy_import(args=None):
         fasta_file=args.fasta,
         db_url=expand_database_argument(args.database),
         name=args.name,
+        validate_species=args.validate_species,
         debug=args.verbose)
 
 
@@ -119,6 +121,9 @@ def main(args=None):
         "-n", "--name", type=str, default="",
         help="Data source name (string, ideally avoiding spaces etc)")
     parser_ncbi_import.add_argument(
+        "-s", "--validate_species", default=False, action="store_true",
+        help="Validate species names against existing DB entries")
+    parser_ncbi_import.add_argument(
         "-v", "--verbose", action='store_true',
         help="Verbose logging")
     parser_ncbi_import.set_defaults(func=ncbi_import)
@@ -136,6 +141,9 @@ def main(args=None):
     parser_legacy_import.add_argument(
         "-n", "--name", type=str, default="",
         help="Data source name (string, ideally avoiding spaces etc)")
+    parser_legacy_import.add_argument(
+        "-s", "--validate_species", default=False, action="store_true",
+        help="Validate species names against existing DB entries")
     parser_legacy_import.add_argument(
         "-v", "--verbose", action='store_true',
         help="Verbose logging")

--- a/thapbi_pict/import_fasta.py
+++ b/thapbi_pict/import_fasta.py
@@ -31,7 +31,8 @@ def md5_hexdigest(filename, chunk_size=1024):
 
 
 def import_fasta_file(fasta_file, db_url, name=None, debug=True,
-                      fasta_split_fn=None, fasta_parse_fn=None):
+                      fasta_split_fn=None, fasta_parse_fn=None,
+                      validate_species=False):
     """Import a FASTA file into the database.
 
     Optional argument fasta_split_fn is given the full FASTA

--- a/thapbi_pict/import_fasta.py
+++ b/thapbi_pict/import_fasta.py
@@ -49,6 +49,20 @@ def find_taxonomy(session, clade, genus, species, validate_species):
             # There was a unique entry already, use it.
             return taxonomy
 
+        # Can we find a match without the clade?
+        if clade:
+            # If there is a unique match without the clade,
+            # use it to get the NCBI taxid:
+            taxonomy = session.query(Taxonomy).filter_by(
+                clade="", genus=genus, species=species).one_or_none()
+            if taxonomy is not None and taxonomy.ncbi_taxid:
+                # There was a unique entry already, use as template!
+                taxonomy = Taxonomy(
+                    clade=clade, genus=genus, species=species,
+                    ncbi_taxid=taxonomy.ncbi_taxid)
+                session.add(taxonomy)  # Can we refactor this?
+                return taxonomy
+
         if not validate_species:
             # If the DB has not been preloaded, we don't
             # want to try trimming the species - it would

--- a/thapbi_pict/import_fasta.py
+++ b/thapbi_pict/import_fasta.py
@@ -124,6 +124,7 @@ def import_fasta_file(fasta_file, db_url, name=None, debug=True,
     entry_count = 0
     bad_entry_count = 0
     idn_set = set()
+    bad_sp = 0
 
     for title, seq, its1_seq in filter_for_ITS1(fasta_file):
         if title.startswith("Control_"):
@@ -182,6 +183,7 @@ def import_fasta_file(fasta_file, db_url, name=None, debug=True,
                     sys.stderr.write("WARNING: Could not validate %r from %r\n"
                                      % (name, entry))
                     # TODO - Find any unclassified genus entry, and use that
+                bad_sp += 1
                 taxonomy = Taxonomy(
                     clade=clade, genus=genus, species=species,
                     ncbi_taxid=0)
@@ -203,3 +205,6 @@ def import_fasta_file(fasta_file, db_url, name=None, debug=True,
     session.commit()
     sys.stderr.write("%i sequences, %i entries including %i bad\n"
                      % (seq_count, entry_count, bad_entry_count))
+    if validate_species:
+        sys.stderr.write("Had to add %i unvalidated species entries\n"
+                         % bad_sp)

--- a/thapbi_pict/legacy.py
+++ b/thapbi_pict/legacy.py
@@ -97,10 +97,15 @@ assert (split_composite_entry('4_Phytophthora_alticola_HQ013214_'
 def parse_fasta_entry(text):
     """Split an entry of Clade_SpeciesName_Accession into fields.
 
+    Returns a tuple of Clade, Species, and an empty string
+    (since any extra text in the species is already included,
+    unlike the NCBI FASTA parser where the end of the species
+    is not well defined). Discards the accession.
+
     Will also convert the underscores in the species name into spaces:
 
     >>> parse_fasta_entry('4_P._arenaria_HQ013219')
-    ('4', 'P. arenaria', 'HQ013219')
+    ('4', 'P. arenaria', '')
 
     Note - this assumes function ``split_composite_entry`` has already
     been used to break up any multiple species composite entries.
@@ -109,17 +114,17 @@ def parse_fasta_entry(text):
     underscore between the clade and species:
 
     >>> parse_fasta_entry('1Phytophthora_aff_infestans_P13660')
-    ('1', 'Phytophthora aff infestans', 'P13660')
+    ('1', 'Phytophthora aff infestans', '')
 
     And the old variant without any clade at the start, e.g.
 
     >>> parse_fasta_entry('P._amnicola_CBS131652')
-    ('', 'P. amnicola', 'CBS131652')
+    ('', 'P. amnicola', '')
 
     And the old variant with just an accession, e.g.
 
     >>> parse_fasta_entry('VHS17779')
-    ('', '', 'VHS17779')
+    ('', '', '')
 
     Dividing the species name into genus, species, strain etc
     is not handled here.
@@ -131,7 +136,7 @@ def parse_fasta_entry(text):
 
     if len(parts) == 1:
         # Legacy variant with just an accession
-        return ("", "", text)
+        return ("", "", "")
 
     clade = parts[0]
 
@@ -148,7 +153,7 @@ def parse_fasta_entry(text):
         parts = [clade] + parts
 
     name = parts[1:-1]
-    acc = parts[-1]
+    # acc = parts[-1]
 
     if name[0] == "P.":
         name[0] = "Phytophthora"
@@ -160,16 +165,16 @@ def parse_fasta_entry(text):
 
     if clade and not clade_re.fullmatch(clade):
         raise ValueError("Clade %s not recognised from %r" % (clade, text))
-    return (clade, " ".join(name), acc)
+    return (clade, " ".join(name), "")
 
 
 assert (parse_fasta_entry('4_P._arenaria_HQ013219')
-        == ('4', 'Phytophthora arenaria', 'HQ013219'))
+        == ('4', 'Phytophthora arenaria', ''))
 assert (parse_fasta_entry('1Phytophthora_aff_infestans_P13660')
-        == ('1', 'Phytophthora aff infestans', 'P13660'))
+        == ('1', 'Phytophthora aff infestans', ''))
 assert (parse_fasta_entry('P._amnicola_CBS131652')
-        == ('', 'Phytophthora amnicola', 'CBS131652'))
-assert (parse_fasta_entry('ACC-ONLY') == ('', '', 'ACC-ONLY'))
+        == ('', 'Phytophthora amnicola', ''))
+assert (parse_fasta_entry('ACC-ONLY') == ('', '', ''))
 
 
 def main(fasta_file, db_url, name=None, validate_species=False, debug=True):

--- a/thapbi_pict/legacy.py
+++ b/thapbi_pict/legacy.py
@@ -167,8 +167,10 @@ assert (parse_fasta_entry('P._amnicola_CBS131652')
 assert (parse_fasta_entry('ACC-ONLY') == ('', '', 'ACC-ONLY'))
 
 
-def main(fasta_file, db_url, name=None, debug=True):
+def main(fasta_file, db_url, name=None, validate_species=False, debug=True):
     """Run the script with command line arguments."""
-    return(import_fasta_file(fasta_file, db_url, name=name, debug=debug,
-                             fasta_split_fn=split_composite_entry,
-                             fasta_parse_fn=parse_fasta_entry))
+    return import_fasta_file(
+        fasta_file, db_url, name=name, debug=debug,
+        fasta_split_fn=split_composite_entry,
+        fasta_parse_fn=parse_fasta_entry,
+        validate_species=validate_species)

--- a/thapbi_pict/legacy.py
+++ b/thapbi_pict/legacy.py
@@ -152,6 +152,11 @@ def parse_fasta_entry(text):
 
     if name[0] == "P.":
         name[0] = "Phytophthora"
+    # NCBI uses lower case "x" for hybrid species names,
+    # while the legacy FASTA files used upper case "X":
+    for i in range(len(name)):
+        if name[i] == "X":
+            name[i] = "x"
 
     if clade and not clade_re.fullmatch(clade):
         raise ValueError("Clade %s not recognised from %r" % (clade, text))

--- a/thapbi_pict/ncbi.py
+++ b/thapbi_pict/ncbi.py
@@ -56,8 +56,10 @@ assert parse_fasta_entry('LC159493.1 Phytophthora drechsleri genes') == \
     ('', 'Phytophthora drechsleri', 'LC159493.1')
 
 
-def main(fasta_file, db_url, name=None, debug=True):
+def main(fasta_file, db_url, name=None, validate_species=False, debug=True):
     """Run the script with command line arguments."""
-    return(import_fasta_file(fasta_file, db_url, name=name, debug=debug,
-                             # fasta_split_fn=split_composite_entry,
-                             fasta_parse_fn=parse_fasta_entry))
+    return import_fasta_file(
+        fasta_file, db_url, name=name, debug=debug,
+        # fasta_split_fn=split_composite_entry,
+        fasta_parse_fn=parse_fasta_entry,
+        validate_species=validate_species)


### PR DESCRIPTION
Using the names in our database pre-loaded from an NCBI tax dump via ``thapbi_pict load-tax ...`` this is a big step towards validating species names during FASTA import (both for our legacy databases, and an NCBI FASTA file).

This does not address synonyms (#21), which ``thapbi_pict load-tax ...`` does not record.

Legacy import example:

```
$ rm -rf /tmp/legacy_004_and_005_validated.sqlite
scottishdumpling:thapbi-pict pc40583$ thapbi_pict load-tax -d /tmp/legacy_004_and_005_validated.sqlite -t new_taxdump_2018-12-01 -a 4783
WARNING: Treating no rank 'unclassified Phytophthora' (txid211524) as a species.
Loaded 251 species entries into DB (none already there)
scottishdumpling:thapbi-pict pc40583$ thapbi_pict legacy-import -d /tmp/legacy_004_and_005_validated.sqlite database/legacy/Phytophthora_ITS_database_v0.004.fasta -n 'Legacy DB v0.004' -s
WARNING: Could not validate 'Phytophthora austrocedri' from '8d_Phytophthora_austrocedri_DQ995184'
WARNING: Could not validate 'Phytophthora taxon paludosa' from '6_Phytophthora_taxon_paludosa_HQ012953'
WARNING: Could not validate 'Phytophthora sp. aff. meadii' from '2a_Phytophthora_sp._aff._meadii_KC875839'
WARNING: Could not validate 'Phytophthora sp. mekongensis type3' from '2a_P._sp._mekongensis_type3_KM501564'
WARNING: Could not validate 'Phytophthora sp Pecan' from '4_Phytophthora_sp_Pecan_GU997621'
WARNING: Could not validate 'Phytophthora x stagnum' from '6b_Phytophthora_X_stagnum_KJ705085'
WARNING: Could not validate 'Phytophthora caryae' from '2_Phytophthora_caryae_KJ631538'
WARNING: Could not validate 'Phytophthora sp. personii' from '6_Phytophthora_sp._personii_EU301169'
WARNING: Could not validate 'Phytophthora taxon cyperaceae' from '6_Phytophthora_taxon_cyperaceae_KJ372258'
WARNING: Could not validate 'Phytophthora taxon cuyabensis' from '9_Phytophthora_taxon_cuyabensis_FJ801995'
WARNING: Could not validate 'Phytophthora taxon pocumtuck' from '6_Phytophthora_taxon_pocumtuck_KP749380'
WARNING: Could not validate 'Phytophthora sp. mekongensis type1' from '2a_Phytophthora_sp._mekongensis_type1_KC875838'
WARNING: Could not validate 'Phytophthora taxon kunnunara' from '9_Phytophthora_taxon_kunnunara_EF437222'
WARNING: Could not validate 'Phytophthora taxon aquatilis' from '2c_Phytophthora_taxon_aquatilis_FJ666126'
WARNING: Could not validate 'Phytophthora taxon umtamvuna' from '9_Phytophthora_taxon_umtamvuna_KC855181'
170 sequences, 188 entries including 0 bad
scottishdumpling:thapbi-pict pc40583$ thapbi_pict legacy-import -d /tmp/legacy_004_and_005_validated.sqlite database/legacy/Phytophthora_ITS_database_v0.005.fasta -n 'Legacy DB v0.005' -s
172 sequences, 190 entries including 0 bad
```