### PR TITLE
Simple dump DB as fasta format

### DIFF
--- a/tests/test_legacy-import.sh
+++ b/tests/test_legacy-import.sh
@@ -40,6 +40,7 @@ if [ `sqlite3 $DB "SELECT COUNT(id) FROM data_source;"` -ne "2" ]; then echo "Wr
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM its1_source;"` -ne "378" ]; then echo "Wrong its1_source count"; false; fi
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM its1_sequence;"` -ne "172" ]; then echo "Wrong its1_sequence count"; false; fi
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM taxonomy;"` -ne "166" ]; then echo "Wrong taxonomy count"; false; fi
+if [ `thapbi_pict dump -d $DB -f fasta | grep -c "^>"` -ne "378" ]; then echo "Wrong FASTA record count"; false; fi
 
 if [ ! -f "new_taxdump_2018-12-01.zip" ]; then curl -L -O "https://ftp.ncbi.nih.gov/pub/taxonomy/taxdump_archive/new_taxdump_2018-12-01.zip"; fi
 if [ ! -d "new_taxdump_2018-12-01" ]; then unzip new_taxdump_2018-12-01.zip -d new_taxdump_2018-12-01; fi
@@ -61,6 +62,7 @@ if [ `sqlite3 $DB "SELECT COUNT(DISTINCT species) FROM taxonomy;"` -ne "251" ]; 
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM data_source;"` -ne "2" ]; then echo "Wrong data_source count"; false; fi
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM its1_source;"` -ne "342" ]; then echo "Wrong its1_source count"; false; fi
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM its1_sequence;"` -ne "172" ]; then echo "Wrong its1_sequence count"; false; fi
+if [ `thapbi_pict dump -d $DB -f fasta | grep -c "^>"` -ne "342" ]; then echo "Wrong FASTA record count"; false; fi
 
 thapbi_pict dump 2>&1 | grep "the following arguments are required"
 thapbi_pict dump -d database/legacy/Phytophthora_ITS_database_v0.005.sqlite -o /dev/null

--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -60,7 +60,7 @@ def dump(args=None):
     """Subcommand to dump a database to a text file."""
     from .dump import main
     return main(db_url=expand_database_argument(args.database),
-                output_txt=args.output,
+                output_filename=args.output,
                 clade=args.clade,
                 genus=args.genus,
                 species=args.species,

--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -174,7 +174,7 @@ comma.
         help="File to write to (default '-' meaning stdout)")
     parser_dump.add_argument(
         "-f", "--format", type=str, default="txt",
-        choices=["txt"],
+        choices=["txt", "fasta"],
         help="Format to write out (default 'txt' for debugging).")
     parser_dump.add_argument(
         "-c", "--clade", type=str, default="",

--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -61,6 +61,7 @@ def dump(args=None):
     from .dump import main
     return main(db_url=expand_database_argument(args.database),
                 output_filename=args.output,
+                output_format=args.format,
                 clade=args.clade,
                 genus=args.genus,
                 species=args.species,
@@ -171,6 +172,10 @@ comma.
     parser_dump.add_argument(
         "-o", "--output", type=str, default="-",
         help="File to write to (default '-' meaning stdout)")
+    parser_dump.add_argument(
+        "-f", "--format", type=str, default="txt",
+        choices=["txt"],
+        help="Format to write out (default 'txt' for debugging).")
     parser_dump.add_argument(
         "-c", "--clade", type=str, default="",
         help="Which clade(s) to export (comma separated list, "

--- a/thapbi_pict/dump.py
+++ b/thapbi_pict/dump.py
@@ -75,21 +75,29 @@ def main(db_url, output_filename, output_format,
 
     for seq_source in view:
         entry_count += 1
-        if output_format == "fasta":
-            out_handle.write(">%s [clade=%s] [species=%s %s]\n%s\n"
-                             % (seq_source.source_accession,
-                                seq_source.current_taxonomy.clade,
-                                seq_source.current_taxonomy.genus,
-                                seq_source.current_taxonomy.species,
-                                seq_source.its1.sequence))
-        else:
-            out_handle.write("%s\t%s\t%s\t%s\t%s\t%s\n"
-                             % (seq_source.source_accession,
-                                seq_source.current_taxonomy.clade,
-                                seq_source.current_taxonomy.genus,
-                                seq_source.current_taxonomy.species,
-                                seq_source.its1.sequence,
-                                seq_source.sequence))
+        try:
+            if output_format == "fasta":
+                out_handle.write(">%s [clade=%s] [species=%s %s]\n%s\n"
+                                 % (seq_source.source_accession,
+                                    seq_source.current_taxonomy.clade,
+                                    seq_source.current_taxonomy.genus,
+                                    seq_source.current_taxonomy.species,
+                                    seq_source.its1.sequence))
+            else:
+                out_handle.write("%s\t%s\t%s\t%s\t%s\t%s\n"
+                                 % (seq_source.source_accession,
+                                    seq_source.current_taxonomy.clade,
+                                    seq_source.current_taxonomy.genus,
+                                    seq_source.current_taxonomy.species,
+                                    seq_source.its1.sequence,
+                                    seq_source.sequence))
+        except BrokenPipeError:
+            # Likely writing to stdout | head, or similar
+            # If so, stdout has been closed
+            sys.stderr.write("Aborting with broken pipe\n")
+            sys.stderr.close()
+            sys.exit(1)
+
         if clade_list:
             assert seq_source.current_taxonomy.clade in clade_list, \
                 seq_source.current_taxonomy

--- a/thapbi_pict/dump.py
+++ b/thapbi_pict/dump.py
@@ -75,13 +75,21 @@ def main(db_url, output_filename, output_format,
 
     for seq_source in view:
         entry_count += 1
-        out_handle.write("%s\t%s\t%s\t%s\t%s\t%s\n"
-                         % (seq_source.source_accession,
-                            seq_source.current_taxonomy.clade,
-                            seq_source.current_taxonomy.genus,
-                            seq_source.current_taxonomy.species,
-                            seq_source.its1.sequence,
-                            seq_source.sequence))
+        if output_format == "fasta":
+            out_handle.write(">%s [clade=%s] [species=%s %s]\n%s\n"
+                             % (seq_source.source_accession,
+                                seq_source.current_taxonomy.clade,
+                                seq_source.current_taxonomy.genus,
+                                seq_source.current_taxonomy.species,
+                                seq_source.its1.sequence))
+        else:
+            out_handle.write("%s\t%s\t%s\t%s\t%s\t%s\n"
+                             % (seq_source.source_accession,
+                                seq_source.current_taxonomy.clade,
+                                seq_source.current_taxonomy.genus,
+                                seq_source.current_taxonomy.species,
+                                seq_source.its1.sequence,
+                                seq_source.sequence))
         if clade_list:
             assert seq_source.current_taxonomy.clade in clade_list, \
                 seq_source.current_taxonomy

--- a/thapbi_pict/dump.py
+++ b/thapbi_pict/dump.py
@@ -10,7 +10,8 @@ from sqlalchemy.orm import aliased, contains_eager
 from .db_orm import ITS1, SequenceSource, Taxonomy, connect_to_db
 
 
-def main(db_url, output_filename, clade="", genus="", species="", debug=True):
+def main(db_url, output_filename, output_format,
+         clade="", genus="", species="", debug=True):
     """Run the database dump with arguments from the command line."""
     # Connect to the DB,
     Session = connect_to_db(db_url, echo=debug)
@@ -92,8 +93,9 @@ def main(db_url, output_filename, clade="", genus="", species="", debug=True):
                 seq_source.current_taxonomy
 
     if output_filename == "-":
-        sys.stderr.write("Wrote %i entries\n" % entry_count)
+        sys.stderr.write("Wrote %i %s format entries\n"
+                         % (entry_count, output_format))
     else:
         out_handle.close()
-        sys.stderr.write("Wrote %i entries to %r\n"
-                         % (entry_count, output_filename))
+        sys.stderr.write("Wrote %i %s format entries to %r\n"
+                         % (entry_count, output_format, output_filename))

--- a/thapbi_pict/dump.py
+++ b/thapbi_pict/dump.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import aliased, contains_eager
 from .db_orm import ITS1, SequenceSource, Taxonomy, connect_to_db
 
 
-def main(db_url, output_txt, clade="", genus="", species="", debug=True):
+def main(db_url, output_filename, clade="", genus="", species="", debug=True):
     """Run the database dump with arguments from the command line."""
     # Connect to the DB,
     Session = connect_to_db(db_url, echo=debug)
@@ -18,10 +18,10 @@ def main(db_url, output_txt, clade="", genus="", species="", debug=True):
 
     entry_count = 0
 
-    if output_txt == "-":
+    if output_filename == "-":
         out_handle = sys.stdout
     else:
-        out_handle = open(output_txt, "w")
+        out_handle = open(output_filename, "w")
 
     # Doing a join to pull in the ITS1 and Taxonomy tables too:
     cur_tax = aliased(Taxonomy)
@@ -91,9 +91,9 @@ def main(db_url, output_txt, clade="", genus="", species="", debug=True):
             assert seq_source.current_taxonomy.species in sp_list, \
                 seq_source.current_taxonomy
 
-    if output_txt == "-":
+    if output_filename == "-":
         sys.stderr.write("Wrote %i entries\n" % entry_count)
     else:
         out_handle.close()
         sys.stderr.write("Wrote %i entries to %r\n"
-                         % (entry_count, output_txt))
+                         % (entry_count, output_filename))

--- a/thapbi_pict/import_fasta.py
+++ b/thapbi_pict/import_fasta.py
@@ -252,15 +252,16 @@ def import_fasta_file(fasta_file, db_url, name=None, debug=True,
 
             # Note we use the original FASTA identifier for traceablity
             # but means the multi-entries get the same source accession
-            record_entry = SequenceSource(source_accession=idn,
-                                          source=db_source,
-                                          its1=its1,
-                                          sequence=seq,
-                                          original_taxonomy=taxonomy,
-                                          current_taxonomy=taxonomy,
-                                          seq_strategy=0,
-                                          seq_platform=0,
-                                          curated_trust=0)
+            record_entry = SequenceSource(
+                source_accession=entry.split(None, 1)[0],
+                source=db_source,
+                its1=its1,
+                sequence=seq,
+                original_taxonomy=taxonomy,
+                current_taxonomy=taxonomy,
+                seq_strategy=0,
+                seq_platform=0,
+                curated_trust=0)
             session.add(record_entry)
             good_entries += 1
             # print(clade, species, acc)


### PR DESCRIPTION
See #19. This works as follows:

```
$ head database/legacy/Phytophthora_ITS_database_v0.005.fasta
>9_Phytophthora_fallax_Voucher_HQ261559
CCACACCTAAAAAAATTCCACGTGAACTGTATTGTCAACCAAATTCGGGGATTCCTTGCT
AGCGTGCCTTCGGGCGTGCCGGTAGGTTGAGACCCATCAAACGAAAACATCGGCTGAAAG
GTCGGAGCCAGTAGTTACCTTTGTAAACCCTTTACTAAATACTGAAAA
>2a_Phytophthora_sp._aff._meadii_KC875839_2a_P._sp._mekongensis_type3_KM501564
CTTTCCACGTGAACCGTATCAACCCTTTTAGTTGGGGGTGTTGCTTGGCATTTTGCTGAG
CCGCGCCCTATCATGGCGAATGTTTGGACTTCGGTCTGGGCTAGTAGCTTTTTGTTTTAA
ACCATTTAACAATACTGATTATACT
>7b_Phytophthora_cajani_AF266765
CCACACCTAAAAAACTTTCCACGTGAACCGTATCAACAAGTAGTTGGGGGCCTGCTCTGT
```

Import,

```
$ rm -rf database/legacy/Phytophthora_ITS_database_v0.005.sqlite
$ thapbi_pict legacy-import -d "database/legacy/Phytophthora_ITS_database_v0.005.sqlite" database/legacy/Phytophthora_ITS_database_v0.005.fasta
```

Export,

```
$ thapbi_pict dump -d database/legacy/Phytophthora_ITS_database_v0.005.sqlite -f fasta | head
>9_Phytophthora_fallax_Voucher_HQ261559 [clade=9] [species=Phytophthora fallax Voucher]
CCACACCTAAAAAAATTCCACGTGAACTGTATTGTCAACCAAATTCGGGGATTCCTTGCTAGCGTGCCTTCGGGCGTGCCGGTAGGTTGAGACCCATCAAACGAAAACATCGGCTGAAAGGTCGGAGCCAGTAGTTACCTTTGTAAACCCTTTACTAAATACTGAAA
>2a_Phytophthora_sp._aff._meadii_KC875839 [clade=2a] [species=Phytophthora sp. aff. meadii]
CTTTCCACGTGAACCGTATCAACCCTTTTAGTTGGGGGTGTTGCTTGGCATTTTGCTGAGCCGCGCCCTATCATGGCGAATGTTTGGACTTCGGTCTGGGCTAGTAGCTTTTTGTTTTAAACCATTTAACAATACTGATTATACT
>2a_P._sp._mekongensis_type3_KM501564 [clade=2a] [species=Phytophthora sp. mekongensis type3]
CTTTCCACGTGAACCGTATCAACCCTTTTAGTTGGGGGTGTTGCTTGGCATTTTGCTGAGCCGCGCCCTATCATGGCGAATGTTTGGACTTCGGTCTGGGCTAGTAGCTTTTTGTTTTAAACCATTTAACAATACTGATTATACT
>7b_Phytophthora_cajani_AF266765 [clade=7b] [species=Phytophthora cajani]
CCACACCTAAAAAACTTTCCACGTGAACCGTATCAACAAGTAGTTGGGGGCCTGCTCTGTGTGGCTAGCTGTCGATGTCAAAGTCGGCGACTGGCTGCTATGTGGCGGGCTCTATCATGGCAATTGGTTTGGGTCCTCCTCGTGGGGAACTAGATCATGAGCCCACTTTTTAAACCCATTCTTGATTACTGAATATACT
>8a_Phytophthora_cryptogea_AY659433 [clade=8a] [species=Phytophthora cryptogea]
CCACACCTAAAAAACTTTCCACGTGAACCGTATCAACCTTTTTAAATTGGGGGCTTCCGTCTGGCCGGCCGGTTCTCGGCTGGCTGGGTGGCGGCTCTATCATGGCGACCGCTTGGGCCTCGGCCTGGGCTAGTAGCATATTTTTTAAACCCATTCCTAATTACTGAATATACT
...
```

Note this FASTA output shows the composite entries from the legacy FASTA file  like ``2a_Phytophthora_sp._aff._meadii_KC875839_2a_P._sp._mekongensis_type3_KM501564`` split into separate entries with the same sequence, here ``2a_Phytophthora_sp._aff._meadii_KC875839_2a`` and ``P._sp._mekongensis_type3_KM501564``.

Also note I am not currently line wrapping the FASTA sequence lines - they are just about short enough to see on a wide screen, and in some ways this is useful for inspection.