### PR TITLE
Initial classification command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,3 +53,4 @@ jobs:
             tests/test_load-tax.sh
             tests/test_legacy-import.sh
             tests/test_ncbi-import.sh
+            tests/test_classify-reads.sh

--- a/tests/test_classify-reads.sh
+++ b/tests/test_classify-reads.sh
@@ -9,6 +9,7 @@ export TMP=${TMP:-/tmp}
 
 echo "Checking classify-reads"
 thapbi_pict classify-reads 2>&1 | grep "the following arguments are required"
+thapbi_pict classify-reads -d "sqlite:///:memory:" hypothetical_example.fasta 2>&1 | grep "cannot classify anything"
 
 # Passing one filename:
 thapbi_pict classify-reads -m identity -d $TMP/legacy_004_and_005_validated.sqlite database/legacy/database.fasta

--- a/tests/test_classify-reads.sh
+++ b/tests/test_classify-reads.sh
@@ -11,10 +11,13 @@ echo "Checking classify-reads"
 thapbi_pict classify-reads 2>&1 | grep "the following arguments are required"
 thapbi_pict classify-reads -d "sqlite:///:memory:" hypothetical_example.fasta 2>&1 | grep "cannot classify anything"
 
+export DB=$TMP/legacy_004_and_005_validated.sqlite
+if [ ! -f $DB ]; then echo "Run test_legacy-import.sh to setup test DB"; false; fi
+
 # Passing one filename:
-thapbi_pict classify-reads -m identity -d $TMP/legacy_004_and_005_validated.sqlite database/legacy/database.fasta
+thapbi_pict classify-reads -m identity -d $DB database/legacy/database.fasta
 
 # Passing one directory name (should get all three FASTA files):
-thapbi_pict classify-reads -m identity -d $TMP/legacy_004_and_005_validated.sqlite database/legacy/
+thapbi_pict classify-reads -m identity -d $DB database/legacy/
 
 echo "$0 passed"

--- a/tests/test_classify-reads.sh
+++ b/tests/test_classify-reads.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+IFS=$'\n\t'
+set -eux
+
+# Note not using "set -o pipefile" as want to use that
+# with grep to check error messages
+
+export TMP=${TMP:-/tmp}
+
+echo "Checking classify-reads"
+thapbi_pict classify-reads 2>&1 | grep "the following arguments are required"
+
+# Passing one filename:
+thapbi_pict classify-reads -m identity -d $TMP/legacy_004_and_005_validated.sqlite database/legacy/database.fasta
+
+# Passing one directory name (should get all three FASTA files):
+thapbi_pict classify-reads -m identity -d $TMP/legacy_004_and_005_validated.sqlite database/legacy/
+
+echo "$0 passed"

--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -67,6 +67,15 @@ def dump(args=None):
                 debug=args.verbose)
 
 
+def classify_reads(args=None):
+    """Subcommand to classify reads using an ITS1 database."""
+    from .classify import main
+    return main(fasta=args.fasta,
+                db_url=expand_database_argument(args.database),
+                method=args.method,
+                debug=args.verbose)
+
+
 def main(args=None):
     """Execute the command line script thapbi_pict.
 
@@ -189,6 +198,26 @@ comma.
         "-v", "--verbose", action='store_true',
         help="Verbose logging")
     parser_dump.set_defaults(func=dump)
+
+    # classify-reads
+    parser_classify_reads = subparsers.add_parser(
+        "classify-reads",
+        description="Classify FASTA file of ITS1 reads by species.")
+    parser_classify_reads.add_argument(
+        'fasta', type=str, nargs='+',
+        help='One or more ITS1 fasta filenames or folder names'
+             '(containing files named *.fasta).')
+    parser_classify_reads.add_argument(
+        "-d", "--database", type=str, required=True,
+        help="Which ITS1 database to use for species classification.")
+    parser_classify_reads.add_argument(
+        "-m", "--method", type=str, default="identity",
+        choices=["identity"],
+        help="Method to use, default uses simple identity.")
+    parser_classify_reads.add_argument(
+        "-v", "--verbose", action='store_true',
+        help="Verbose logging")
+    parser_classify_reads.set_defaults(func=classify_reads)
 
     # What have we been asked to do?
     options = parser.parse_args(args)

--- a/thapbi_pict/classify.py
+++ b/thapbi_pict/classify.py
@@ -7,15 +7,52 @@ import os
 import sys
 
 from .db_orm import connect_to_db
+from .db_orm import ITS1, SequenceSource, Taxonomy
+from .hmm import filter_for_ITS1
 
 
-def method_identity(filename, session, debug=False):
+def method_identity(fasta_file, session, debug=False):
     """Classify using perfect identity.
 
     This is a deliberately simple approach, in part for testing
-    purposes.
+    purposes. It uses HMMER3 to find any ITS1 match, and then
+    looks for a perfect identical entry in the database.
     """
-    return 0
+    # The FASTA file should have long sequences which might
+    # contain a known ITS1 sequence as a substring. If the
+    # search were inverted, the SQL LIKE command could likely
+    # be used (e.g. via SQLalchemey's contains operator).
+    #
+    # Plan B is brute force - we can run hmmscan to find any
+    # ITS1 matchs, and then look for 100% equality in the DB.
+    count = 0
+    matched = 0
+    for title, seq, its1_seq in filter_for_ITS1(fasta_file):
+        count += 1
+        idn = title.split(None, 1)[0]
+        if not its1_seq:
+            # TODO - Handle multiple HMM matches here
+            print(idn, "No single ITS1 HMM match")
+            continue
+        assert its1_seq == its1_seq.upper()
+        # Now, does this match any of the ITS1 seq in our DB?
+        its1 = session.query(ITS1).filter_by(
+            sequence=its1_seq).one_or_none()
+        if its1 is None:
+            print(idn, "No ITS1 database match")
+            continue
+        # its1 -> one or more SequenceSource
+        # each SequenceSource -> one current taxonomy
+        sp_list = [
+            ("%s %s" % (_.current_taxonomy.genus,
+                        _.current_taxonomy.species))
+            for _ in session.query(
+                    SequenceSource).filter_by(its1=its1)]
+        if not sp_list:
+            print(idn, "No taxonomy for ITS1 database match")
+        print(idn, "/".join(sorted(set(sp_list))))
+        matched += 1
+    return count, matched
 
 
 methods = {
@@ -52,23 +89,43 @@ def main(fasta, db_url, method, debug=False):
             % (method, ", ".join(sorted(methods))))
     method_fn = methods[method]
 
+    # Connect to the DB,
+    Session = connect_to_db(db_url, echo=debug)
+    session = Session()
+
+    count = session.query(Taxonomy).distinct(
+        Taxonomy.genus, Taxonomy.species).count()
+    if debug:
+        sys.stderr.write(
+            "Taxonomy table contains %i distinct species.\n" % count)
+    if not count:
+        sys.exit(
+            "ERROR: Taxonomy table empty, cannot classify anything.\n")
+
+    count = session.query(ITS1).count()
+    if debug:
+        sys.stderr.write(
+            "ITS1 table contains %i distinct sequences.\n" % count)
+    if not count:
+        sys.exit(
+            "ERROR: ITS1 table empty, cannot classify anything.\n")
+
     fasta_files = find_fasta_files(fasta, debug=debug)
     if debug:
         sys.stderr.write(
             "Classifying %i input FASTA files\n" % len(fasta_files))
 
-    # Connect to the DB,
-    Session = connect_to_db(db_url, echo=debug)
-    session = Session()
-
     read_count = 0
+    match_count = 0
     for filename in fasta_files:
         if debug:
             sys.stderr.write("%s classifer on %s\n" % (method, filename))
-        read_count += method_fn(filename, session, debug)
+        r_count, m_count = method_fn(filename, session, debug)
+        read_count += r_count
+        match_count += m_count
 
     sys.stderr.write(
-        "%s classifier ran on %i reads from %i files\n"
-        % (method, read_count, len(fasta_files)))
+        "%s classifier assigned species to %i of %i reads from %i files\n"
+        % (method, match_count, read_count, len(fasta_files)))
 
     return 0

--- a/thapbi_pict/classify.py
+++ b/thapbi_pict/classify.py
@@ -1,0 +1,74 @@
+"""Classifying prepared ITS1 reads using an ITS1 database.
+
+This implementes the ``thapbi_pict classify-reads ...`` command.
+"""
+
+import os
+import sys
+
+from .db_orm import connect_to_db
+
+
+def method_identity(filename, session, debug=False):
+    """Classify using perfect identity.
+
+    This is a deliberately simple approach, in part for testing
+    purposes.
+    """
+    return 0
+
+
+methods = {
+    "identity": method_identity
+}
+
+
+def find_fasta_files(filenames_or_folders, ext=".fasta", debug=False):
+    """Interpret a list of filenames and/or foldernames."""
+    answer = []
+    for x in filenames_or_folders:
+        if os.path.isdir(x):
+            if debug:
+                sys.stderr.write("Walking directory %r\n" % x)
+            for f in os.listdir(x):
+                if f.endswith(ext):
+                    # Check not a directory?
+                    answer.append(os.path.join(x, f))
+        elif os.path.isfile(x):
+            answer.append(x)
+        else:
+            sys.exit("ERROR: %r is not a file or a directory\n" % x)
+    # Warn if there were duplicates?
+    return sorted(set(answer))
+
+
+def main(fasta, db_url, method, debug=False):
+    """Implement the thapbi_pict classify-reads command."""
+    assert isinstance(fasta, list)
+
+    if method not in methods:
+        sys.exit(
+            "ERROR: Invalid method name %r, should be one of: %s\n"
+            % (method, ", ".join(sorted(methods))))
+    method_fn = methods[method]
+
+    fasta_files = find_fasta_files(fasta, debug=debug)
+    if debug:
+        sys.stderr.write(
+            "Classifying %i input FASTA files\n" % len(fasta_files))
+
+    # Connect to the DB,
+    Session = connect_to_db(db_url, echo=debug)
+    session = Session()
+
+    read_count = 0
+    for filename in fasta_files:
+        if debug:
+            sys.stderr.write("%s classifer on %s\n" % (method, filename))
+        read_count += method_fn(filename, session, debug)
+
+    sys.stderr.write(
+        "%s classifier ran on %i reads from %i files\n"
+        % (method, read_count, len(fasta_files)))
+
+    return 0

--- a/thapbi_pict/hmm/__init__.py
+++ b/thapbi_pict/hmm/__init__.py
@@ -85,7 +85,7 @@ def filter_for_ITS1(input_fasta, bitscore_threshold="6", debug=False):
                 bitscore_threshold=bitscore_threshold,
                 debug=debug):
         title = record.description
-        seq = str(record.seq)
+        seq = str(record.seq).upper()
         if not result:
             yield title, seq, None
             continue
@@ -153,6 +153,7 @@ def filter_fasta_for_ITS1(input_fasta, output_fasta,
             hsp = hit[0]
             # print(hsp.query_id, hsp.bitscore, hsp.query_start, hsp.query_end)
             assert record.id == hsp.query_id
+            record.seq = record.seq.upper()
             old_len = len(record)
             if trim:
                 record = record[hsp.query_start:hsp.query_end]


### PR DESCRIPTION
Still unfinished, but fleshes out the ideas on #27 by defining ``thapbi_pict  classify-reads`` with a default method which runs ``hmmscan`` with the same HMM used in the FASTA import code, and looks for perfect matches to the ITS1 sequences in the DB.

Needs to produce some sort of semi-standardised report which would be extensible for multiple methods, many of which will have some sort of score or confidence value (this is just a binary classification - it either matched the DB, or did not).

Probably,
- read-level report, e.g. read name, and the unique clade, genus, species assigned
- taxonomy report, e.g. number of reads assigned to each genus/clade/species