### PR TITLE
Take an output dir name for classify reads

### DIFF
--- a/tests/test_classify-reads.sh
+++ b/tests/test_classify-reads.sh
@@ -14,10 +14,18 @@ thapbi_pict classify-reads -d "sqlite:///:memory:" hypothetical_example.fasta 2>
 export DB=$TMP/legacy_004_and_005_validated.sqlite
 if [ ! -f $DB ]; then echo "Run test_legacy-import.sh to setup test DB"; false; fi
 
-# Passing one filename:
-thapbi_pict classify-reads -m identity -d $DB database/legacy/database.fasta | cut -f 5 | sort | uniq -c
+rm -rf database/legacy/*.identity-reads.tsv
+rm -rf database/legacy/*.identity-tax.tsv
+
+# Passing one filename; default output dir:
+thapbi_pict classify-reads -m identity -d $DB database/legacy/database.fasta
+cut -f 5 database/legacy/database.identity-reads.tsv | sort | uniq -c
+grep -c Phytophthora database/legacy/database.identity-tax.tsv
 
 # Passing one directory name (should get all three FASTA files):
-thapbi_pict classify-reads -m identity -d $DB database/legacy/ -r /dev/null -t - | grep -c Phytophthora
+rm -rf $TMP/legacy/*.identity-*.tsv
+mkdir -p $TMP/legacy
+thapbi_pict classify-reads -m identity -d $DB database/legacy/ -o $TMP/legacy
+ls -1 $TMP/legacy/*.identity-*.tsv  # Should be 6 pairs
 
 echo "$0 passed"

--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -73,8 +73,7 @@ def classify_reads(args=None):
     return main(fasta=args.fasta,
                 db_url=expand_database_argument(args.database),
                 method=args.method,
-                read_report=args.read_report,
-                tax_report=args.tax_report,
+                out_dir=args.output,
                 debug=args.verbose)
 
 
@@ -204,10 +203,13 @@ comma.
     # classify-reads
     parser_classify_reads = subparsers.add_parser(
         "classify-reads",
-        description="Classify FASTA file of ITS1 reads by species.")
+        description="Classify FASTA file of ITS1 reads by species.",
+        epilog="Each input file XXX.fasta will result in output files "
+               "namesd XXX.method-reads.tsv and XXX.method-tax.tsv in "
+               "the specified output directory (default input dir).")
     parser_classify_reads.add_argument(
         'fasta', type=str, nargs='+',
-        help='One or more ITS1 fasta filenames or folder names'
+        help='One or more ITS1 FASTA filenames or folder names'
              '(containing files named *.fasta).')
     parser_classify_reads.add_argument(
         "-d", "--database", type=str, required=True,
@@ -217,11 +219,9 @@ comma.
         choices=["identity"],
         help="Method to use, default uses simple identity.")
     parser_classify_reads.add_argument(
-        "-r", "--read_report", type=str, default="-", metavar="FILENAME",
-        help="File to write read-level report to (default '-' for stdout).")
-    parser_classify_reads.add_argument(
-        "-t", "--tax_report", type=str, default="", metavar="FILENAME",
-        help="File to write read-level report to (use '-' for stdout).")
+        "-o", "--output", type=str, default="-", metavar="DIRNAME",
+        help="Directory to write output reports to, default "
+             "is next to each input file.")
     parser_classify_reads.add_argument(
         "-v", "--verbose", action='store_true',
         help="Verbose logging")


### PR DESCRIPTION
This will make life easier for task splitting (see #28), and then for combined reporting after running the classifier (e.g. adding more FASTA files and wanting a new report), see #27 