### PR TITLE
Simplify generated filenames, drop sample level tax output

### DIFF
--- a/tests/test_assess.sh
+++ b/tests/test_assess.sh
@@ -9,7 +9,6 @@ export TMP=${TMP:-/tmp}
 
 echo "Checking assess"
 
-if [ ! -f $TMP/DNAMIX_S95_L001.fasta ]; then echo "Run test_prepare.sh to setup test input"; false; fi
 if [ ! -f $TMP/DNAMIX_S95_L001.swarm.tsv ]; then echo "Run test_classify.sh to setup test input"; false; fi
 if [ ! -f $TMP/DNAMIX_S95_L001.identity.tsv ]; then echo "Run test_classify.sh to setup test input"; false; fi
 

--- a/tests/test_assess.sh
+++ b/tests/test_assess.sh
@@ -9,22 +9,22 @@ export TMP=${TMP:-/tmp}
 
 echo "Checking assess"
 
-if [ ! -f $TMP/DNAMIX_S95_L001.prepared.fasta ]; then echo "Run test_prepare-reads.sh to setup test input"; false; fi
-if [ ! -f $TMP/DNAMIX_S95_L001.prepared.swarm-reads.tsv ]; then echo "Run test_classify.sh to setup test input"; false; fi
-if [ ! -f $TMP/DNAMIX_S95_L001.prepared.identity-reads.tsv ]; then echo "Run test_classify.sh to setup test input"; false; fi
+if [ ! -f $TMP/DNAMIX_S95_L001.fasta ]; then echo "Run test_prepare-reads.sh to setup test input"; false; fi
+if [ ! -f $TMP/DNAMIX_S95_L001.swarm-reads.tsv ]; then echo "Run test_classify.sh to setup test input"; false; fi
+if [ ! -f $TMP/DNAMIX_S95_L001.identity-reads.tsv ]; then echo "Run test_classify.sh to setup test input"; false; fi
 
 rm -rf $TMP/assess_swarm_vs_identity.tsv
 rm -rf $TMP/confusion_swarm_vs_identity.tsv
 
 # Don't have a gold standard known truth to test this against, so test swarm vs identity
-thapbi_pict assess $TMP/DNAMIX_S95_L001.prepared.swarm-reads.tsv -m swarm -k identity -o $TMP/assess_swarm_vs_identity.tsv -c $TMP/confusion_swarm_vs_identity.tsv
+thapbi_pict assess $TMP/DNAMIX_S95_L001.swarm-reads.tsv -m swarm -k identity -o $TMP/assess_swarm_vs_identity.tsv -c $TMP/confusion_swarm_vs_identity.tsv
 
 # Check assessment output to stdout works (default):
-thapbi_pict assess $TMP/DNAMIX_S95_L001.prepared.swarm-reads.tsv -m swarm -k identity > $TMP/stdout.txt
+thapbi_pict assess $TMP/DNAMIX_S95_L001.swarm-reads.tsv -m swarm -k identity > $TMP/stdout.txt
 diff $TMP/stdout.txt $TMP/assess_swarm_vs_identity.tsv
 
 # Check confusion matrix output to stdout works:
-thapbi_pict assess $TMP/DNAMIX_S95_L001.prepared.swarm-reads.tsv -m swarm -k identity -o $TMP/assess_swarm_vs_identity.tsv -c - > $TMP/stdout.txt
+thapbi_pict assess $TMP/DNAMIX_S95_L001.swarm-reads.tsv -m swarm -k identity -o $TMP/assess_swarm_vs_identity.tsv -c - > $TMP/stdout.txt
 diff $TMP/stdout.txt $TMP/confusion_swarm_vs_identity.tsv
 
 echo "$0 passed"

--- a/tests/test_assess.sh
+++ b/tests/test_assess.sh
@@ -9,22 +9,22 @@ export TMP=${TMP:-/tmp}
 
 echo "Checking assess"
 
-if [ ! -f $TMP/DNAMIX_S95_L001.fasta ]; then echo "Run test_prepare-reads.sh to setup test input"; false; fi
-if [ ! -f $TMP/DNAMIX_S95_L001.swarm-reads.tsv ]; then echo "Run test_classify.sh to setup test input"; false; fi
-if [ ! -f $TMP/DNAMIX_S95_L001.identity-reads.tsv ]; then echo "Run test_classify.sh to setup test input"; false; fi
+if [ ! -f $TMP/DNAMIX_S95_L001.fasta ]; then echo "Run test_prepare.sh to setup test input"; false; fi
+if [ ! -f $TMP/DNAMIX_S95_L001.swarm.tsv ]; then echo "Run test_classify.sh to setup test input"; false; fi
+if [ ! -f $TMP/DNAMIX_S95_L001.identity.tsv ]; then echo "Run test_classify.sh to setup test input"; false; fi
 
 rm -rf $TMP/assess_swarm_vs_identity.tsv
 rm -rf $TMP/confusion_swarm_vs_identity.tsv
 
 # Don't have a gold standard known truth to test this against, so test swarm vs identity
-thapbi_pict assess $TMP/DNAMIX_S95_L001.swarm-reads.tsv -m swarm -k identity -o $TMP/assess_swarm_vs_identity.tsv -c $TMP/confusion_swarm_vs_identity.tsv
+thapbi_pict assess $TMP/DNAMIX_S95_L001.swarm.tsv -m swarm -k identity -o $TMP/assess_swarm_vs_identity.tsv -c $TMP/confusion_swarm_vs_identity.tsv
 
 # Check assessment output to stdout works (default):
-thapbi_pict assess $TMP/DNAMIX_S95_L001.swarm-reads.tsv -m swarm -k identity > $TMP/stdout.txt
+thapbi_pict assess $TMP/DNAMIX_S95_L001.swarm.tsv -m swarm -k identity > $TMP/stdout.txt
 diff $TMP/stdout.txt $TMP/assess_swarm_vs_identity.tsv
 
 # Check confusion matrix output to stdout works:
-thapbi_pict assess $TMP/DNAMIX_S95_L001.swarm-reads.tsv -m swarm -k identity -o $TMP/assess_swarm_vs_identity.tsv -c - > $TMP/stdout.txt
+thapbi_pict assess $TMP/DNAMIX_S95_L001.swarm.tsv -m swarm -k identity -o $TMP/assess_swarm_vs_identity.tsv -c - > $TMP/stdout.txt
 diff $TMP/stdout.txt $TMP/confusion_swarm_vs_identity.tsv
 
 echo "$0 passed"

--- a/tests/test_classify.sh
+++ b/tests/test_classify.sh
@@ -22,18 +22,18 @@ thapbi_pict classify -m identity -d $DB database/legacy/database.fasta
 # Now fails as we expect reads to have been prepared and trimmed with HMM
 if [ `wc -l database/legacy/database.identity-reads.tsv` -ne "0" ]; then echo "Expected no matches"; false; fi
 
-if [ ! -f $TMP/DNAMIX_S95_L001.prepared.fasta ]; then echo "Run test_prepare-reads.sh to setup test input"; false; fi
-rm -rf $TMP/DNAMIX_S95_L001.prepared.swarm-reads.tsv
-rm -rf $TMP/DNAMIX_S95_L001.prepared.swarm-tax.tsv
-rm -rf $TMP/DNAMIX_S95_L001.prepared.identity-reads.tsv
-rm -rf $TMP/DNAMIX_S95_L001.prepared.identity-tax.tsv
+if [ ! -f $TMP/DNAMIX_S95_L001.fasta ]; then echo "Run test_prepare-reads.sh to setup test input"; false; fi
+rm -rf $TMP/DNAMIX_S95_L001.swarm-reads.tsv
+rm -rf $TMP/DNAMIX_S95_L001.swarm-tax.tsv
+rm -rf $TMP/DNAMIX_S95_L001.identity-reads.tsv
+rm -rf $TMP/DNAMIX_S95_L001.identity-tax.tsv
 
 # Explicitly setting output directory, would be here anyway:
-thapbi_pict classify -m identity -d $DB $TMP/DNAMIX_S95_L001.prepared.fasta -o $TMP/
+thapbi_pict classify -m identity -d $DB $TMP/DNAMIX_S95_L001.fasta -o $TMP/
 
-thapbi_pict classify -m swarm -d $DB $TMP/DNAMIX_S95_L001.prepared.fasta
-cut -f 5 $TMP/DNAMIX_S95_L001.prepared.swarm-reads.tsv | sort | uniq -c
-# grep -c Phytophthora $TMP/DNAMIX_S95_L001.prepared.swarm-tax.tsv
+thapbi_pict classify -m swarm -d $DB $TMP/DNAMIX_S95_L001.fasta
+cut -f 5 $TMP/DNAMIX_S95_L001.swarm-reads.tsv | sort | uniq -c
+# grep -c Phytophthora $TMP/DNAMIX_S95_L001.swarm-tax.tsv
 
 # Passing one directory name (should get all three FASTA files):
 rm -rf $TMP/legacy/*.identity-*.tsv

--- a/tests/test_classify.sh
+++ b/tests/test_classify.sh
@@ -15,7 +15,6 @@ export DB=$TMP/legacy_004_and_005_validated.sqlite
 if [ ! -f $DB ]; then echo "Run test_legacy-import.sh to setup test DB"; false; fi
 
 rm -rf database/legacy/*.identity.tsv
-rm -rf database/legacy/*.identity-tax.tsv
 
 # Passing one filename; default output dir:
 thapbi_pict classify -m identity -d $DB database/legacy/database.fasta
@@ -24,21 +23,18 @@ if [ `wc -l database/legacy/database.identity.tsv` -ne "0" ]; then echo "Expecte
 
 if [ ! -f $TMP/DNAMIX_S95_L001.fasta ]; then echo "Run test_prepare.sh to setup test input"; false; fi
 rm -rf $TMP/DNAMIX_S95_L001.swarm.tsv
-rm -rf $TMP/DNAMIX_S95_L001.swarm-tax.tsv
 rm -rf $TMP/DNAMIX_S95_L001.identity.tsv
-rm -rf $TMP/DNAMIX_S95_L001.identity-tax.tsv
 
 # Explicitly setting output directory, would be here anyway:
 thapbi_pict classify -m identity -d $DB $TMP/DNAMIX_S95_L001.fasta -o $TMP/
 
 thapbi_pict classify -m swarm -d $DB $TMP/DNAMIX_S95_L001.fasta
 cut -f 5 $TMP/DNAMIX_S95_L001.swarm.tsv | sort | uniq -c
-# grep -c Phytophthora $TMP/DNAMIX_S95_L001.swarm-tax.tsv
 
 # Passing one directory name (should get all three FASTA files):
-rm -rf $TMP/legacy/*.identity-*.tsv
+rm -rf $TMP/legacy/*.identity.tsv
 mkdir -p $TMP/legacy
 thapbi_pict classify -m identity -d $DB database/legacy/ -o $TMP/legacy
-ls -1 $TMP/legacy/*.identity-*.tsv  # Should be 6 pairs
+if [ `ls -1 $TMP/legacy/*.identity.tsv | wc -l` -ne `3` ]; then echo "Expected 3 files;" false; fi
 
 echo "$0 passed"

--- a/tests/test_classify.sh
+++ b/tests/test_classify.sh
@@ -14,25 +14,25 @@ thapbi_pict classify -d "sqlite:///:memory:" hypothetical_example.fasta 2>&1 | g
 export DB=$TMP/legacy_004_and_005_validated.sqlite
 if [ ! -f $DB ]; then echo "Run test_legacy-import.sh to setup test DB"; false; fi
 
-rm -rf database/legacy/*.identity-reads.tsv
+rm -rf database/legacy/*.identity.tsv
 rm -rf database/legacy/*.identity-tax.tsv
 
 # Passing one filename; default output dir:
 thapbi_pict classify -m identity -d $DB database/legacy/database.fasta
 # Now fails as we expect reads to have been prepared and trimmed with HMM
-if [ `wc -l database/legacy/database.identity-reads.tsv` -ne "0" ]; then echo "Expected no matches"; false; fi
+if [ `wc -l database/legacy/database.identity.tsv` -ne "0" ]; then echo "Expected no matches"; false; fi
 
-if [ ! -f $TMP/DNAMIX_S95_L001.fasta ]; then echo "Run test_prepare-reads.sh to setup test input"; false; fi
-rm -rf $TMP/DNAMIX_S95_L001.swarm-reads.tsv
+if [ ! -f $TMP/DNAMIX_S95_L001.fasta ]; then echo "Run test_prepare.sh to setup test input"; false; fi
+rm -rf $TMP/DNAMIX_S95_L001.swarm.tsv
 rm -rf $TMP/DNAMIX_S95_L001.swarm-tax.tsv
-rm -rf $TMP/DNAMIX_S95_L001.identity-reads.tsv
+rm -rf $TMP/DNAMIX_S95_L001.identity.tsv
 rm -rf $TMP/DNAMIX_S95_L001.identity-tax.tsv
 
 # Explicitly setting output directory, would be here anyway:
 thapbi_pict classify -m identity -d $DB $TMP/DNAMIX_S95_L001.fasta -o $TMP/
 
 thapbi_pict classify -m swarm -d $DB $TMP/DNAMIX_S95_L001.fasta
-cut -f 5 $TMP/DNAMIX_S95_L001.swarm-reads.tsv | sort | uniq -c
+cut -f 5 $TMP/DNAMIX_S95_L001.swarm.tsv | sort | uniq -c
 # grep -c Phytophthora $TMP/DNAMIX_S95_L001.swarm-tax.tsv
 
 # Passing one directory name (should get all three FASTA files):

--- a/tests/test_prepare-reads.sh
+++ b/tests/test_prepare-reads.sh
@@ -11,28 +11,28 @@ echo "Checking prepare-reads"
 thapbi_pict prepare-reads 2>&1 | grep "the following arguments are required"
 
 # Try a real example
-rm -rf $TMP/DNAMIX_S95_L001.prepared.fasta
+rm -rf $TMP/DNAMIX_S95_L001.fasta
 thapbi_pict prepare-reads -o $TMP tests/reads/DNAMIX_S95_L001_*.fastq.gz -a 0
-if [ `grep -c "^>" $TMP/DNAMIX_S95_L001.prepared.fasta` -ne "921" ]; then echo "Wrong FASTA output count"; false; fi
+if [ `grep -c "^>" $TMP/DNAMIX_S95_L001.fasta` -ne "921" ]; then echo "Wrong FASTA output count"; false; fi
 
-rm -rf $TMP/DNAMIX_S95_L001.prepared.fasta
+rm -rf $TMP/DNAMIX_S95_L001.fasta
 thapbi_pict prepare-reads -o $TMP tests/reads/DNAMIX_S95_L001_*.fastq.gz -a 5
-if [ `grep -c "^>" $TMP/DNAMIX_S95_L001.prepared.fasta` -ne "27" ]; then echo "Wrong FASTA output count"; false; fi
+if [ `grep -c "^>" $TMP/DNAMIX_S95_L001.fasta` -ne "27" ]; then echo "Wrong FASTA output count"; false; fi
 
 echo "Generating mock control file"
 # Using just 50 real reads (50 * 4 = 200 lines)
 zcat tests/reads/DNAMIX_S95_L001_R1_001.fastq.gz | head -n 200 > $TMP/MOCK_CONTROL_R1.fastq
 zcat tests/reads/DNAMIX_S95_L001_R2_001.fastq.gz | head -n 200 > $TMP/MOCK_CONTROL_R2.fastq
 
-rm -rf $TMP/DNAMIX_S95_L001.prepared.fasta
-rm -rf $TMP/MOCK_CONTROL.prepared.fasta
+rm -rf $TMP/DNAMIX_S95_L001.fasta
+rm -rf $TMP/MOCK_CONTROL.fasta
 # Starting low threshold, should be increased to 19, so get new output count...
 thapbi_pict prepare-reads -o $TMP tests/reads/DNAMIX_S95_L001_*.fastq.gz -a 5 -c $TMP/MOCK_CONTROL_R?.fastq
-if [ `grep -c "^>" $TMP/MOCK_CONTROL.prepared.fasta` -ne "16" ]; then echo "Wrong FASTA control output count"; false; fi
-if [ `grep -c "^>" $TMP/DNAMIX_S95_L001.prepared.fasta` -ne "9" ]; then echo "Wrong FASTA output count"; false; fi
+if [ `grep -c "^>" $TMP/MOCK_CONTROL.fasta` -ne "16" ]; then echo "Wrong FASTA control output count"; false; fi
+if [ `grep -c "^>" $TMP/DNAMIX_S95_L001.fasta` -ne "9" ]; then echo "Wrong FASTA output count"; false; fi
 
-rm -rf $TMP/DNAMIX_S95_L001.prepared.fasta
+rm -rf $TMP/DNAMIX_S95_L001.fasta
 thapbi_pict prepare-reads -o $TMP tests/reads/DNAMIX_S95_L001_*.fastq.gz -a 100
-if [ `grep -c "^>" $TMP/DNAMIX_S95_L001.prepared.fasta` -ne "7" ]; then echo "Wrong FASTA output count"; false; fi
+if [ `grep -c "^>" $TMP/DNAMIX_S95_L001.fasta` -ne "7" ]; then echo "Wrong FASTA output count"; false; fi
 
 echo "$0 passed"

--- a/thapbi_pict/__init__.py
+++ b/thapbi_pict/__init__.py
@@ -17,4 +17,4 @@ You would typically use THAPBI PICT via the command line tool it defines::
 
 """
 
-__version__ = "0.0.2"
+__version__ = "0.0.3"

--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -392,9 +392,9 @@ comma.
     parser_classify = subparsers.add_parser(
         "classify",
         description="Classify FASTA file of ITS1 sequences by species.",
-        epilog="Each input file XXX.fasta will result in output files "
-        "namesd XXX.method.tsv and XXX.method-tax.tsv in "
-        "the specified output directory (default input dir).",
+        epilog="Each input file XXX.fasta will result in an output file "
+        "named XXX.method.tsv in the specified output directory (default "
+        "input dir).",
     )
     parser_classify.add_argument(
         "fasta",

--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -393,7 +393,7 @@ comma.
         "classify",
         description="Classify FASTA file of ITS1 sequences by species.",
         epilog="Each input file XXX.fasta will result in output files "
-        "namesd XXX.method-reads.tsv and XXX.method-tax.tsv in "
+        "namesd XXX.method.tsv and XXX.method-tax.tsv in "
         "the specified output directory (default input dir).",
     )
     parser_classify.add_argument(
@@ -442,8 +442,8 @@ comma.
     parser_assess = subparsers.add_parser(
         "assess",
         description="Assess accuracy of ITS1 read classification.",
-        epilog="Takes as input XXX.known-reads.tsv and matching "
-        "predictions in XXX.method-reads.tsv (in same directory) "
+        epilog="Takes as input XXX.known.tsv and matching "
+        "predictions in XXX.method.tsv (in same directory) "
         "to produce a multi-species confusion matrix named "
         "XXX.method-vs-known.tsv, and a summary to stdout. You can "
         "deliberately compare to prediction methods to each other "
@@ -454,8 +454,8 @@ comma.
         type=str,
         nargs="+",
         help="One or more prediction folder names. Expects to find "
-        "matching files *.method-reads.tsv to be assessed against "
-        "*.known-reads.tsv, where these filenames can be set via "
+        "matching files *.method.tsv to be assessed against "
+        "*.known.tsv, where these filenames can be set via "
         "-m / --method and -k / --known arguments. ",
     )
     parser_assess.add_argument(

--- a/thapbi_pict/assess.py
+++ b/thapbi_pict/assess.py
@@ -132,7 +132,7 @@ def main(inputs, known, method, assess_output, confusion_output, debug=False):
     """Implement the thapbi_pict assess command."""
     assert isinstance(inputs, list)
 
-    input_list = find_requested_files(inputs, ext=".%s-reads.tsv" % method, debug=debug)
+    input_list = find_requested_files(inputs, ext=".%s.tsv" % method, debug=debug)
 
     count = 0
     global_tally = Counter()
@@ -143,11 +143,11 @@ def main(inputs, known, method, assess_output, confusion_output, debug=False):
             sys.stderr.write("DEBUG: Shared temp folder %s\n" % shared_tmp)
         for predicted_file in input_list:
             stem = predicted_file.rsplit(".", 2)[0]
-            assert predicted_file == stem + ".%s-reads.tsv" % method, "%s vs %s" % (
+            assert predicted_file == stem + ".%s.tsv" % method, "%s vs %s" % (
                 predicted_file,
-                stem + ".%s-reads.tsv" % method,
+                stem + ".%s.tsv" % method,
             )
-            expected_file = stem + ".%s-reads.tsv" % known
+            expected_file = stem + ".%s.tsv" % known
             # Not aborting here as typically in a folder while should have
             # full set of predictions, will only have expected results for
             # control subset.

--- a/thapbi_pict/classify.py
+++ b/thapbi_pict/classify.py
@@ -327,7 +327,7 @@ def main(fasta, db_url, method, out_dir, debug=False, cpu=0):
             stem = os.path.splitext(stem)[0]
             if out_dir and out_dir != "-":
                 folder = out_dir
-            read_name = os.path.join(folder, "%s.%s-reads.tsv" % (stem, method))
+            read_name = os.path.join(folder, "%s.%s.tsv" % (stem, method))
             tax_name = os.path.join(folder, "%s.%s-tax.tsv" % (stem, method))
 
             if os.path.isfile(read_name) and os.path.isfile(tax_name):
@@ -346,7 +346,7 @@ def main(fasta, db_url, method, out_dir, debug=False, cpu=0):
                 if debug:
                     sys.stderr.write("DEBUG: Temp folder of %s is %s\n" % (stem, tmp))
                 # Using same file names, but in tmp folder:
-                tmp_reads = os.path.join(tmp, "%s.%s-reads.tsv" % (stem, method))
+                tmp_reads = os.path.join(tmp, "%s.%s.tsv" % (stem, method))
                 tmp_tax = os.path.join(tmp, "%s.%s-tax.tsv" % (stem, method))
                 # Run the classifier and write the read report:
                 with open(tmp_reads, "w") as reads_handle:

--- a/thapbi_pict/prepare.py
+++ b/thapbi_pict/prepare.py
@@ -281,7 +281,7 @@ def main(fastq, controls, out_dir, min_abundance=100, debug=False, cpu=0):
         folder, stem = os.path.split(stem)
         if out_dir and out_dir != "-":
             folder = out_dir
-        fasta_name = os.path.join(folder, "%s.prepared.fasta" % stem)
+        fasta_name = os.path.join(folder, "%s.fasta" % stem)
 
         if os.path.isfile(fasta_name):
             if control:


### PR DESCRIPTION
These simplifications are intended to help with setting up multi-way comparisons of methods and databases.

Given the filename and associated command line changes (already on master branch), also bumping the version.