### PR TITLE
Simplistic classifier using top BLAST+ hit(s)

### DIFF
--- a/requirements-ext.txt
+++ b/requirements-ext.txt
@@ -3,6 +3,7 @@
 # $ conda install --file requirements-ext.txt
 #
 
+blast
 entrez-direct
 hmmer
 pear=0.9.6

--- a/tests/test_classify.sh
+++ b/tests/test_classify.sh
@@ -23,10 +23,13 @@ if [ `wc -l database/legacy/database.identity.tsv` -ne "0" ]; then echo "Expecte
 
 if [ ! -f $TMP/DNAMIX_S95_L001.fasta ]; then echo "Run test_prepare.sh to setup test input"; false; fi
 rm -rf $TMP/DNAMIX_S95_L001.swarm.tsv
+rm -rf $TMP/DNAMIX_S95_L001.blast.tsv
 rm -rf $TMP/DNAMIX_S95_L001.identity.tsv
 
 # Explicitly setting output directory, would be here anyway:
 thapbi_pict classify -m identity -d $DB $TMP/DNAMIX_S95_L001.fasta -o $TMP/
+
+thapbi_pict classify -m blast -d $DB $TMP/DNAMIX_S95_L001.fasta
 
 thapbi_pict classify -m swarm -d $DB $TMP/DNAMIX_S95_L001.fasta
 cut -f 5 $TMP/DNAMIX_S95_L001.swarm.tsv | sort | uniq -c

--- a/thapbi_pict/classify.py
+++ b/thapbi_pict/classify.py
@@ -225,7 +225,7 @@ def method_blast(
 
     tax_counts = Counter()
     with open(fasta_file) as handle:
-        for title, seq in SimpleFastaParser(handle):
+        for title, _ in SimpleFastaParser(handle):
             idn = title.split(None, 1)[0]
             abundance = abundance_from_read_name(idn)
             if idn in blast_hits:

--- a/thapbi_pict/classify.py
+++ b/thapbi_pict/classify.py
@@ -196,6 +196,8 @@ def method_blast(
         "-out",
         blast_out,
     ]
+    if cpu:
+        cmd += ["-num_threads", str(cpu)]
     run(cmd, debug)
 
     if not os.path.isfile(blast_out):


### PR DESCRIPTION
Compared to the perfect identity classifier and the swarm classifier, this generally makes more species level calls, so in assessment it gets more TP and FP, giving better sensitivity at the expense of lower specificity.

I doubt we'll end up using this method, but it is helpful to have available right now while working on the ``thapbi_pict assess`` command.