### PR TITLE
Include NCBI taxid in the classifier output

### DIFF
--- a/thapbi_pict/__init__.py
+++ b/thapbi_pict/__init__.py
@@ -17,4 +17,4 @@ You would typically use THAPBI PICT via the command line tool it defines::
 
 """
 
-__version__ = "0.0.3"
+__version__ = "0.0.4"

--- a/thapbi_pict/assess.py
+++ b/thapbi_pict/assess.py
@@ -17,8 +17,9 @@ def parse_species_tsv(tabular_file):
         for line in handle:
             if line.startswith("#"):
                 continue
-            name, genus, species, etc = line.split("\t", 3)
-            yield name, genus, species
+            name, taxid, genus, species, etc = line.split("\t", 4)
+            taxid = int(taxid)
+            yield name, genus, species, taxid
 
 
 def tally_files(expected_file, predicted_file):
@@ -40,6 +41,7 @@ def tally_files(expected_file, predicted_file):
         # Might only have genus with species "", thus strip whitespace:
         expt_sp = ("%s %s" % (expt[1], expt[2])).strip()
         pred_sp = ("%s %s" % (pred[1], pred[2])).strip()
+        # TODO: Look at taxid, expt[3] and pred[3]
         counter[expt_sp, pred_sp] += 1
     return counter
 


### PR DESCRIPTION
Because I inserted this as the new second column, it requires matching changes to the known positive control "predictions" for running ``thapbi_pict assess``, so a version bump seems sensible (especially given the addition of the ``blast`` classifier and the ``thapbi_pict seq_import`` commands recently).

TODO: Lookup the taxonomy of any genus level prediction (currently returns zero).

This opens the way to using the taxid in the assessment, issue #61.