### PR TITLE
multi-species prediction and assessment

### DIFF
--- a/tests/assess/ex1.assess.tsv
+++ b/tests/assess/ex1.assess.tsv
@@ -1,4 +1,4 @@
 #Species	TP	FP	FN	TN	sensitivity	specificity	precision	F1
-OVERALL	1	1	2	0	0.33	0.00	0.50	0.40
+OVERALL	1	1	3	0	0.25	0.00	0.50	0.33
 Phytophthora crassamura	0	1	0	3	0.00	0.75	0.00	0.00
 Phytophthora megasperma	1	0	3	0	0.25	0.00	1.00	0.40

--- a/tests/assess/ex2.assess.tsv
+++ b/tests/assess/ex2.assess.tsv
@@ -1,0 +1,5 @@
+#Species	TP	FP	FN	TN	sensitivity	specificity	precision	F1
+OVERALL	0	2	3	0	0.00	0.00	0.00	0.00
+Phytophthora capsici	0	1	0	3	0.00	0.75	0.00	0.00
+Phytophthora fallax	0	0	4	0	0.00	0.00	0.00	0.00
+Phytophthora glovera	0	1	0	3	0.00	0.75	0.00	0.00

--- a/tests/assess/ex2.assess.tsv
+++ b/tests/assess/ex2.assess.tsv
@@ -1,5 +1,5 @@
 #Species	TP	FP	FN	TN	sensitivity	specificity	precision	F1
-OVERALL	0	2	3	0	0.00	0.00	0.00	0.00
+OVERALL	0	2	4	0	0.00	0.00	0.00	0.00
 Phytophthora capsici	0	1	0	3	0.00	0.75	0.00	0.00
 Phytophthora fallax	0	0	4	0	0.00	0.00	0.00	0.00
 Phytophthora glovera	0	1	0	3	0.00	0.75	0.00	0.00

--- a/tests/assess/ex2.identity.tsv
+++ b/tests/assess/ex2.identity.tsv
@@ -1,0 +1,5 @@
+#sequence-name	taxid	genus	species	clade	note
+pf1_100000	0				No ITS1 database match
+pf2_10000	0				No ITS1 database match
+pf3_2000	0				No ITS1 database match
+pf4_1000	4784;132615	Phytophthora	capsici;glovera	2	

--- a/tests/assess/ex2.known.tsv
+++ b/tests/assess/ex2.known.tsv
@@ -1,0 +1,4 @@
+pf1_100000	360399	Phytophthora	fallax		
+pf2_10000	360399	Phytophthora	fallax		
+pf3_2000	360399	Phytophthora	fallax		
+pf4_1000	360399	Phytophthora	fallax		

--- a/tests/assess/ex3.assess.tsv
+++ b/tests/assess/ex3.assess.tsv
@@ -1,0 +1,4 @@
+#Species	TP	FP	FN	TN	sensitivity	specificity	precision	F1
+OVERALL	0	0	2	0	0.00	0.00	0.00	0.00
+Phytophthora europaea	0	0	1	0	0.00	0.00	0.00	0.00
+Phytophthora flexuosa	0	0	1	0	0.00	0.00	0.00	0.00

--- a/tests/assess/ex3.identity.tsv
+++ b/tests/assess/ex3.identity.tsv
@@ -1,0 +1,2 @@
+#sequence-name	taxid	genus	species	clade	note
+ambig_1000	0				No ITS1 database match

--- a/tests/assess/ex3.known.tsv
+++ b/tests/assess/ex3.known.tsv
@@ -1,0 +1,1 @@
+ambig_1000	180900;1861859	Phytophthora	europaea;flexuosa	7

--- a/tests/assess/ex4.assess.tsv
+++ b/tests/assess/ex4.assess.tsv
@@ -1,0 +1,5 @@
+#Species	TP	FP	FN	TN	sensitivity	specificity	precision	F1
+OVERALL	1	1	0	0	1.00	0.00	0.50	0.67
+Phytophthora capsici	1	0	0	0	1.00	0.00	1.00	1.00
+Phytophthora glovera	0	0	1	0	0.00	0.00	0.00	0.00
+Phytophthora infestans	0	1	0	0	0.00	0.00	0.00	0.00

--- a/tests/assess/ex4.assess.tsv
+++ b/tests/assess/ex4.assess.tsv
@@ -1,5 +1,5 @@
 #Species	TP	FP	FN	TN	sensitivity	specificity	precision	F1
-OVERALL	1	1	0	0	1.00	0.00	0.50	0.67
+OVERALL	1	1	1	0	0.50	0.00	0.50	0.50
 Phytophthora capsici	1	0	0	0	1.00	0.00	1.00	1.00
 Phytophthora glovera	0	0	1	0	0.00	0.00	0.00	0.00
 Phytophthora infestans	0	1	0	0	0.00	0.00	0.00	0.00

--- a/tests/assess/ex4.identity.tsv
+++ b/tests/assess/ex4.identity.tsv
@@ -1,0 +1,2 @@
+#sequence-name	taxid	genus	species	clade	note
+tricky_1000	4784;4787	Phytophthora	capsici;infestans	2	one right (Pc), one wrong (Pi), one missed (Pg)

--- a/tests/assess/ex4.known.tsv
+++ b/tests/assess/ex4.known.tsv
@@ -1,0 +1,2 @@
+#sequence-name	taxid	genus	species	clade	note
+tricky_1000	4784;132615	Phytophthora	capsici;glovera	2	

--- a/tests/assess/fp.assess.tsv
+++ b/tests/assess/fp.assess.tsv
@@ -1,0 +1,4 @@
+#Species	TP	FP	FN	TN	sensitivity	specificity	precision	F1
+OVERALL	0	2	0	0	0.00	0.00	0.00	0.00
+Phytophthora capsici	0	1	0	0	0.00	0.00	0.00	0.00
+Phytophthora glovera	0	1	0	0	0.00	0.00	0.00	0.00

--- a/tests/assess/fp.identity.tsv
+++ b/tests/assess/fp.identity.tsv
@@ -1,0 +1,1 @@
+fp_1000	4784;132615	Phytophthora	capsici;glovera	2	two FP

--- a/tests/assess/fp.known.tsv
+++ b/tests/assess/fp.known.tsv
@@ -1,0 +1,2 @@
+#sequence-name	taxid	genus	species	clade	note
+fp_1000	0				No ITS1 database match

--- a/tests/test_assess.sh
+++ b/tests/test_assess.sh
@@ -12,6 +12,7 @@ set -o pipefail
 # Simple examples with expected output to compare against:
 diff tests/assess/ex1.assess.tsv <(thapbi_pict assess tests/assess/ex1.known.tsv tests/assess/ex1.identity.tsv)
 diff tests/assess/ex2.assess.tsv <(thapbi_pict assess tests/assess/ex2.known.tsv tests/assess/ex2.identity.tsv)
+diff tests/assess/ex3.assess.tsv <(thapbi_pict assess tests/assess/ex3.known.tsv tests/assess/ex3.identity.tsv)
 diff tests/assess/unclassified.assess.tsv <(thapbi_pict assess tests/assess/unclassified.known.tsv tests/assess/unclassified.identity.tsv)
 
 if [ ! -f $TMP/thapbi_swarm/DNAMIX_S95_L001.swarm.tsv ]; then echo "Run test_classify.sh to setup test input"; false; fi

--- a/tests/test_assess.sh
+++ b/tests/test_assess.sh
@@ -11,6 +11,7 @@ set -o pipefail
 
 # Simple examples with expected output to compare against:
 diff tests/assess/ex1.assess.tsv <(thapbi_pict assess tests/assess/ex1.known.tsv tests/assess/ex1.identity.tsv)
+diff tests/assess/ex2.assess.tsv <(thapbi_pict assess tests/assess/ex2.known.tsv tests/assess/ex2.identity.tsv)
 diff tests/assess/unclassified.assess.tsv <(thapbi_pict assess tests/assess/unclassified.known.tsv tests/assess/unclassified.identity.tsv)
 
 if [ ! -f $TMP/thapbi_swarm/DNAMIX_S95_L001.swarm.tsv ]; then echo "Run test_classify.sh to setup test input"; false; fi

--- a/tests/test_assess.sh
+++ b/tests/test_assess.sh
@@ -13,6 +13,7 @@ set -o pipefail
 diff tests/assess/ex1.assess.tsv <(thapbi_pict assess tests/assess/ex1.known.tsv tests/assess/ex1.identity.tsv)
 diff tests/assess/ex2.assess.tsv <(thapbi_pict assess tests/assess/ex2.known.tsv tests/assess/ex2.identity.tsv)
 diff tests/assess/ex3.assess.tsv <(thapbi_pict assess tests/assess/ex3.known.tsv tests/assess/ex3.identity.tsv)
+diff tests/assess/ex4.assess.tsv <(thapbi_pict assess tests/assess/ex4.known.tsv tests/assess/ex4.identity.tsv)
 diff tests/assess/unclassified.assess.tsv <(thapbi_pict assess tests/assess/unclassified.known.tsv tests/assess/unclassified.identity.tsv)
 
 if [ ! -f $TMP/thapbi_swarm/DNAMIX_S95_L001.swarm.tsv ]; then echo "Run test_classify.sh to setup test input"; false; fi

--- a/tests/test_assess.sh
+++ b/tests/test_assess.sh
@@ -10,12 +10,12 @@ thapbi_pict assess 2>&1 | grep "the following arguments are required"
 set -o pipefail
 
 # Simple examples with expected output to compare against:
-diff tests/assess/ex1.assess.tsv <(thapbi_pict assess tests/assess/ex1.known.tsv tests/assess/ex1.identity.tsv)
-diff tests/assess/ex2.assess.tsv <(thapbi_pict assess tests/assess/ex2.known.tsv tests/assess/ex2.identity.tsv)
-diff tests/assess/ex3.assess.tsv <(thapbi_pict assess tests/assess/ex3.known.tsv tests/assess/ex3.identity.tsv)
-diff tests/assess/ex4.assess.tsv <(thapbi_pict assess tests/assess/ex4.known.tsv tests/assess/ex4.identity.tsv)
-diff tests/assess/unclassified.assess.tsv <(thapbi_pict assess tests/assess/unclassified.known.tsv tests/assess/unclassified.identity.tsv)
-diff tests/assess/fp.assess.tsv <(thapbi_pict assess tests/assess/fp.known.tsv tests/assess/fp.identity.tsv)
+diff tests/assess/ex1.assess.tsv <(thapbi_pict assess tests/assess/ex1.known.tsv tests/assess/ex1.identity.tsv -c /dev/null)
+diff tests/assess/ex2.assess.tsv <(thapbi_pict assess tests/assess/ex2.known.tsv tests/assess/ex2.identity.tsv -c /dev/null)
+diff tests/assess/ex3.assess.tsv <(thapbi_pict assess tests/assess/ex3.known.tsv tests/assess/ex3.identity.tsv -c /dev/null)
+diff tests/assess/ex4.assess.tsv <(thapbi_pict assess tests/assess/ex4.known.tsv tests/assess/ex4.identity.tsv -c /dev/null)
+diff tests/assess/unclassified.assess.tsv <(thapbi_pict assess tests/assess/unclassified.known.tsv tests/assess/unclassified.identity.tsv -c /dev/null)
+diff tests/assess/fp.assess.tsv <(thapbi_pict assess tests/assess/fp.known.tsv tests/assess/fp.identity.tsv -c /dev/null)
 
 if [ ! -f $TMP/thapbi_swarm/DNAMIX_S95_L001.swarm.tsv ]; then echo "Run test_classify.sh to setup test input"; false; fi
 if [ ! -f $TMP/DNAMIX_S95_L001.identity.tsv ]; then echo "Run test_classify.sh to setup test input"; false; fi

--- a/tests/test_assess.sh
+++ b/tests/test_assess.sh
@@ -15,6 +15,7 @@ diff tests/assess/ex2.assess.tsv <(thapbi_pict assess tests/assess/ex2.known.tsv
 diff tests/assess/ex3.assess.tsv <(thapbi_pict assess tests/assess/ex3.known.tsv tests/assess/ex3.identity.tsv)
 diff tests/assess/ex4.assess.tsv <(thapbi_pict assess tests/assess/ex4.known.tsv tests/assess/ex4.identity.tsv)
 diff tests/assess/unclassified.assess.tsv <(thapbi_pict assess tests/assess/unclassified.known.tsv tests/assess/unclassified.identity.tsv)
+diff tests/assess/fp.assess.tsv <(thapbi_pict assess tests/assess/fp.known.tsv tests/assess/fp.identity.tsv)
 
 if [ ! -f $TMP/thapbi_swarm/DNAMIX_S95_L001.swarm.tsv ]; then echo "Run test_classify.sh to setup test input"; false; fi
 if [ ! -f $TMP/DNAMIX_S95_L001.identity.tsv ]; then echo "Run test_classify.sh to setup test input"; false; fi

--- a/thapbi_pict/__init__.py
+++ b/thapbi_pict/__init__.py
@@ -17,4 +17,4 @@ You would typically use THAPBI PICT via the command line tool it defines::
 
 """
 
-__version__ = "0.0.4"
+__version__ = "0.0.5"

--- a/thapbi_pict/assess.py
+++ b/thapbi_pict/assess.py
@@ -18,7 +18,6 @@ def parse_species_tsv(tabular_file):
             if line.startswith("#"):
                 continue
             name, taxid, genus, species, etc = line.split("\t", 4)
-            taxid = int(taxid)
             yield name, genus, species, taxid
 
 
@@ -44,6 +43,7 @@ def tally_files(expected_file, predicted_file):
         pred_sp = ("%s %s" % (pred[1], pred[2])) if pred[2] else ""
         assert species_level(pred_sp) or not pred_sp, pred_sp
         # TODO: Look at taxid, expt[3] and pred[3]
+        # TODO: Handle ambiguous entries with ; separated entries
         counter[expt_sp, pred_sp] += 1
     return counter
 

--- a/thapbi_pict/assess.py
+++ b/thapbi_pict/assess.py
@@ -106,10 +106,10 @@ def save_confusion_matrix(tally, filename, debug=False):
     species = class_list_from_tally(tally)
     with open(filename, "w") as handle:
         handle.write("#\t%s\n" % "\t".join(species))
-        for pred in species:
+        for expt in species:
             handle.write(
                 "%s\t%s\n"
-                % (pred, "\t".join(str(tally[pred, expt]) for expt in species))
+                % (expt, "\t".join(str(tally[expt, pred]) for pred in species))
             )
     if debug:
         sys.stderr.write(

--- a/thapbi_pict/assess.py
+++ b/thapbi_pict/assess.py
@@ -127,7 +127,7 @@ def save_confusion_matrix(tally, filename, debug=False):
 
 
 def species_level(prediction):
-    """Is this prediction atspecies level.
+    """Is this prediction at species level.
 
     Returns True for a binomial name (at least one space), false for genus
     only or no prediction.
@@ -136,10 +136,13 @@ def species_level(prediction):
 
 
 def extract_binary_tally(class_name, tally):
-    """Compress a multi-class confusion matrix to a single-species binary one.
+    """Extact single-class TP, FP, FN, TN from multi-class confusion tally.
+
+    Reduces the mutli-class expectation/prediction to binary - did they
+    include the class of interest, or not?
 
     Returns a 4-tuple of values, True Positives (TP), False Positves (FP),
-    False Negatives (FN), True Negatives (TN)
+    False Negatives (FN), True Negatives (TN), which sum to the tally total.
     """
     bt = Counter()
     for (expt, pred), count in tally.items():
@@ -151,10 +154,19 @@ def extract_global_tally(tally):
     """Process multi-label confusion matrix (tally dict) to TP, FP, DN, TN.
 
     If the input data has no negative controls, all there will be no
-    true negatives.
+    true negatives (TN).
 
     Returns a 4-tuple of values, True Positives (TP), False Positves (FP),
     False Negatives (FN), True Negatives (TN).
+
+    These values are analagous to the classical binary classifier approach,
+    but are NOT the same.
+
+    The TP, FP, FN, TN sum will exceed the tally total.  For each tally
+    entry, rather than one of TP, FP, FN, TN being incremented (weighted
+    by the tally count), several can be increased.
+
+    If the input data has no negative controls, all there will be no TN.
     """
     tp = fp = fn = tn = 0
     for (expt, pred), count in tally.items():

--- a/thapbi_pict/assess.py
+++ b/thapbi_pict/assess.py
@@ -268,7 +268,10 @@ def main(
 
     handle.write("#Species\tTP\tFP\tFN\tTN\tsensitivity\tspecificity\tprecision\tF1\n")
     sp_list = class_list_from_tally(global_tally)
-    assert "" in sp_list
+    # Ensure "" special case is at the start of the list (will be first if sorted)
+    if "" in sp_list:
+        sp_list.remove("")
+    sp_list = [""] + sp_list
     for sp in sp_list:
         if sp:
             assert species_level(sp)

--- a/thapbi_pict/assess.py
+++ b/thapbi_pict/assess.py
@@ -214,6 +214,17 @@ def extract_global_tally(tally):
     return tp, fp, fn, tn
 
 
+assert extract_global_tally({("", ""): 1}) == (0, 0, 0, 1)
+assert extract_global_tally({("", "A"): 1}) == (0, 1, 0, 0)
+assert extract_global_tally({("A", ""): 1}) == (0, 0, 1, 0)
+assert extract_global_tally({("A", "A"): 1}) == (1, 0, 0, 0)
+assert extract_global_tally({("A", "B"): 1}) == (0, 1, 0, 0)  # Bubious
+assert extract_global_tally({("A", "A;B"): 1}) == (1, 1, 0, 0)
+assert extract_global_tally({("A;B", "A;B"): 1}) == (2, 0, 0, 0)
+assert extract_global_tally({("A;B", "A"): 1}) == (1, 0, 0, 0)  # Wrong?
+assert extract_global_tally({("A;B", "A;C"): 1}) == (1, 1, 0, 0)  # Dubious
+
+
 def main(
     inputs, known, method, assess_output, map_output, confusion_output, debug=False
 ):


### PR DESCRIPTION
Previously when generating equally good predictions, would report their LCA - i.e. genus level prediction of *Phytophthora* only, now returns multiple predictions using semi-colon separation. This will close #62 

This has the knock on effect of forcing us to consider multi-class classifier performance, and how to assess it rigorously.

This pull request also bumps the version number to v0.0.5