### PR TITLE
1bp difference classifier

### DIFF
--- a/tests/test_classify.sh
+++ b/tests/test_classify.sh
@@ -21,13 +21,16 @@ if [ "`grep -c -v '^#' database/legacy/database.identity.tsv`" -ne "`grep -c '^>
 
 if [ ! -f $TMP/DNAMIX_S95_L001.fasta ]; then echo "Run test_prepare-reads.sh to setup test input"; false; fi
 rm -rf $TMP/DNAMIX_S95_L001.identity.tsv
+rm -rf $TMP/thapbi_onebp
 rm -rf $TMP/thapbi_swarm
 rm -rf $TMP/thapbi_blast
+mkdir -p $TMP/thapbi_onebp
 mkdir -p $TMP/thapbi_swarm
 mkdir -p $TMP/thapbi_blast
 
 # Explicitly setting output directory, would be here anyway:
 thapbi_pict classify -m identity -d $DB $TMP/DNAMIX_S95_L001.fasta -o $TMP/
+thapbi_pict classify -m onebp -d $DB $TMP/DNAMIX_S95_L001.fasta -o $TMP/thapbi_onebp
 thapbi_pict classify -m blast -d $DB $TMP/DNAMIX_S95_L001.fasta -o $TMP/thapbi_blast
 thapbi_pict classify -m swarm -d $DB $TMP/DNAMIX_S95_L001.fasta -o $TMP/thapbi_swarm
 cut -f 5 $TMP/thapbi_swarm/DNAMIX_S95_L001.swarm.tsv | sort | uniq -c

--- a/thapbi_pict/db_import.py
+++ b/thapbi_pict/db_import.py
@@ -15,6 +15,7 @@ from .db_orm import DataSource, ITS1, SequenceSource
 from .db_orm import Taxonomy
 from .db_orm import connect_to_db
 from .hmm import filter_for_ITS1
+from .utils import md5seq
 
 
 def md5_hexdigest(filename, chunk_size=1024):
@@ -258,7 +259,7 @@ def import_fasta_file(
 
         its1_seq_count += 1
 
-        its1_md5 = hashlib.md5(its1_seq.upper().encode("ascii")).hexdigest()
+        its1_md5 = md5seq(its1_seq)
 
         # Is is already there? e.g. duplicate sequences in FASTA file
         its1 = (

--- a/thapbi_pict/prepare.py
+++ b/thapbi_pict/prepare.py
@@ -3,7 +3,6 @@
 This implementes the ``thapbi_pict prepare-reads ...`` command.
 """
 
-import hashlib
 import os
 import subprocess
 import shutil
@@ -15,6 +14,7 @@ from Bio.SeqIO.QualityIO import FastqGeneralIterator
 from .hmm import filter_for_ITS1
 from .utils import abundance_from_read_name
 from .utils import abundance_values_in_fasta
+from .utils import md5seq
 from .utils import run
 
 
@@ -149,8 +149,7 @@ def save_nr_fasta(counts, output_fasta, min_abundance=0):
             if -count < min_abundance:
                 # Sorted, so everything hereafter is too rare
                 break
-            md5 = hashlib.md5(seq.encode("ascii")).hexdigest()
-            out_handle.write(">%s_%i\n%s\n" % (md5, -count, seq))
+            out_handle.write(">%s_%i\n%s\n" % (md5seq(seq), -count, seq))
             accepted += 1
     return len(counts), accepted  # number of unique seqs, accepted
 

--- a/thapbi_pict/utils.py
+++ b/thapbi_pict/utils.py
@@ -1,10 +1,16 @@
 """Helper functions for THAPB-PICT code."""
 
 import os
+import hashlib
 import subprocess
 import sys
 
 from Bio.SeqIO.FastaIO import SimpleFastaParser
+
+
+def md5seq(seq):
+    """Return MD5 hash of the (upper case) sequence."""
+    return hashlib.md5(seq.upper().encode("ascii")).hexdigest()
 
 
 def cmd_as_string(cmd):


### PR DESCRIPTION
Adds a new ``onebp`` method to ``thapbi_pict classify``, for database matches allowing 1bp difference.

Based on the ``identity`` classifier, if a prepared read matches a database sequence, uses the taxonomy hit(s) from that just like the identity classifier.
    
However, if that fails, uses a pre-built dictionary to see if the prepared read is only 1bp away from a DB entry. If so, it reports the taxonomy results for those 1bp different DB entries.
    
Considers 1bp substitutions, deletions, and insertions (including adding 1bp to the start, or the end).

On our control plate this seems to do quite well, as expected somewhere between the ``identity`` classifier (which misses a lot) and the ``blast`` & ``swarm`` classifiers which generate a lot more false positives.