### PR TITLE
thapbi_pict plate-summary command (sequence vs sample abundance)

### DIFF
--- a/tests/test_plate-summary.sh
+++ b/tests/test_plate-summary.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+IFS=$'\n\t'
+set -eux
+# Note not using "set -o pipefile" until after check error message with grep
+
+export TMP=${TMP:-/tmp}
+
+echo "Checking plate-summary"
+thapbi_pict plate-summary 2>&1 | grep "the following arguments are required"
+set -o pipefail
+
+# One method:
+thapbi_pict plate-summary $TMP/DNAMIX_S95_L001.fasta $TMP/DNAMIX_S95_L001.identity.tsv -o $TMP/plate-summary_identity.tsv
+
+# Two methods:
+thapbi_pict plate-summary $TMP/DNAMIX_S95_L001.fasta  $TMP/thapbi_swarm/ $TMP/thapbi_blast/ -m blast,swarm -o $TMP/plate-summary_swarm_and_blast.tsv
+
+echo "$0 - test_plate-summary.sh passed"

--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -652,10 +652,11 @@ comma.
         "-a",
         "--abundance",
         type=int,
-        default="1",
+        default="100",
         help="Mininum sample level abundance to require for the report. "
-        "Default is one meaning look at everything, but rather than re-running "
-        "the classifier with a stricter minimum abundance you can apply it here.",
+        "Default 100 reflects default in prepare-reads. Rather than re-running "
+        "the prepare or classifier steps with a stricter minimum abundance you "
+        "can apply it here. Use zero or one look at everything.",
     )
     parser_plate_summary.add_argument(
         "-o",

--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -649,7 +649,8 @@ comma.
         "--method",
         type=str,
         default="identity",
-        help="Method to report (used to infer filenames), default is identity.",
+        help="Method(s) to report, comma separaed list (used to infer "
+        "filenames), default is identity (only).",
     )
     parser_plate_summary.add_argument(
         "-a",

--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -156,6 +156,19 @@ def assess_classification(args=None):
     )
 
 
+def plate_summary(args=None):
+    """Subcommand to run per-output-folder summary of classifiers."""
+    from .summary import main
+
+    return main(
+        inputs=args.inputs,
+        output=args.output,
+        method=args.method,
+        min_abundance=args.abundance,
+        debug=args.verbose,
+    )
+
+
 def main(args=None):
     """Execute the command line script thapbi_pict.
 
@@ -611,6 +624,53 @@ comma.
     )
     parser_assess.set_defaults(func=assess_classification)
     del parser_assess  # To prevent acidentally adding more
+
+    # plate-summary
+    parser_plate_summary = subparsers.add_parser(
+        "plate-summary",
+        description="Summary report on classifier output (per folder).",
+        epilog="Assumes you have run one or more classifier methods, "
+        "giving output folder(s) containing XXX.method-reads.tsv and "
+        "XXX.method-tax.tsv files. Expects one plate per folder.",
+    )
+    parser_plate_summary.add_argument(
+        "inputs",
+        type=str,
+        nargs="+",
+        help="One or more prepared read files (*.fasta), prediction "
+        "files (*.method.fasta)  or folder names. Expects to find "
+        "where the method extension can be set via -m / --method.",
+    )
+    parser_plate_summary.add_argument(
+        "-m",
+        "--method",
+        type=str,
+        default="identity",
+        help="Method to report (used to infer filenames), default is identity.",
+    )
+    parser_plate_summary.add_argument(
+        "-a",
+        "--abundance",
+        type=int,
+        default="1",
+        help="Mininum sample level abundance to require for the report. "
+        "Default is one meaning look at everything, but rather than re-running "
+        "the classifier with a stricter minimum abundance you can apply it here.",
+    )
+    parser_plate_summary.add_argument(
+        "-o",
+        "--output",
+        type=str,
+        default="-",
+        metavar="FILENAME",
+        help="File to write summary sequence vs samples table to. "
+        "Default is '-' meaning to stdout.",
+    )
+    parser_plate_summary.add_argument(
+        "-v", "--verbose", action="store_true", help="Verbose logging"
+    )
+    parser_plate_summary.set_defaults(func=plate_summary)
+    del parser_plate_summary  # To prevent acidentally adding more
 
     # What have we been asked to do?
     options = parser.parse_args(args)

--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -157,7 +157,7 @@ def assess_classification(args=None):
 
 
 def plate_summary(args=None):
-    """Subcommand to run per-output-folder summary of classifiers."""
+    """Subcommand to run per-output-folder summary at sequence level."""
     from .summary import main
 
     return main(
@@ -628,18 +628,21 @@ comma.
     # plate-summary
     parser_plate_summary = subparsers.add_parser(
         "plate-summary",
-        description="Summary report on classifier output (per folder).",
-        epilog="Assumes you have run one or more classifier methods, "
-        "giving output folder(s) containing XXX.method-reads.tsv and "
-        "XXX.method-tax.tsv files. Expects one plate per folder.",
+        description="Sequence-level summary report on classifier output.",
+        epilog="Assumes you've run prepare-reads and classify, and have "
+        "folders with XXX.fasta and XXX.method.tsv files from your plate(s). "
+        "The output is a table with one row per unique sequence (as trimmed "
+        "by the prepare-reads step, can be 1000s of rows) and one column "
+        "per sample (typically 96 samples).",
     )
     parser_plate_summary.add_argument(
         "inputs",
         type=str,
         nargs="+",
         help="One or more prepared read files (*.fasta), prediction "
-        "files (*.method.fasta)  or folder names. Expects to find "
-        "where the method extension can be set via -m / --method.",
+        "files (*.method.tsv) or folder names. If passing folder names, "
+        "it expects to find paired files using these extensions. "
+        "The classifier method extension can be set via -m / --method.",
     )
     parser_plate_summary.add_argument(
         "-m",
@@ -656,7 +659,8 @@ comma.
         help="Mininum sample level abundance to require for the report. "
         "Default 100 reflects default in prepare-reads. Rather than re-running "
         "the prepare or classifier steps with a stricter minimum abundance you "
-        "can apply it here. Use zero or one look at everything.",
+        "can apply it here. Use zero or one look at everything (but beware that "
+        "negative control samples will include low abundance entries).",
     )
     parser_plate_summary.add_argument(
         "-o",

--- a/thapbi_pict/summary.py
+++ b/thapbi_pict/summary.py
@@ -6,8 +6,14 @@ This implements the ``thapbi_pict plate-summary ...`` command.
 import sys
 import tempfile
 
+from collections import Counter
+
+from Bio.SeqIO.FastaIO import SimpleFastaParser
 
 from .utils import find_paired_files
+from .utils import parse_species_tsv
+from .utils import split_read_name_abundance
+from .utils import untangle_species
 
 
 def main(inputs, output, method, min_abundance=1, debug=False):
@@ -29,8 +35,63 @@ def main(inputs, output, method, min_abundance=1, debug=False):
     with tempfile.TemporaryDirectory() as shared_tmp:
         if debug:
             sys.stderr.write("DEBUG: Shared temp folder %s\n" % shared_tmp)
+
+        md5_abundance = Counter()
+        abundance_by_samples = dict()
+        md5_species = dict()
+        md5_to_seq = dict()
+
         for fasta_file, predicted_file in input_list:
             if debug:
                 sys.stderr.write(
                     "DEBUG: Reading %s %s\n" % (fasta_file, predicted_file)
                 )
+            sample = fasta_file.rsplit(".", 1)[0]
+            # Load the TSV
+            for name, taxid, genus, species in parse_species_tsv(
+                predicted_file, min_abundance
+            ):
+                md5, abundance = split_read_name_abundance(name)
+                sp_list = untangle_species(taxid, genus, species).split(";")
+                try:
+                    md5_species[md5].union(sp_list)
+                except KeyError:
+                    md5_species[md5] = set(sp_list)
+                abundance_by_samples[md5, sample] = abundance
+                md5_abundance[md5] += abundance
+            # Load the FASTA
+            with open(fasta_file) as handle:
+                for title, seq in SimpleFastaParser(handle):
+                    md5, abundance = split_read_name_abundance(title.split(None, 1)[0])
+                    assert abundance_by_samples[md5, sample] == abundance
+                    md5_to_seq[md5] = seq
+
+        if output == "-":
+            if debug:
+                sys.stderr.write("DEBUG: Output to stdout...\n")
+            handle = sys.stdout
+        else:
+            handle = open(output, "w")
+
+        handle.write("#ITS1-MD5\tTotal-abundance\t%s-predictions\n" % method)
+        for total_abundance, md5 in reversed(
+            sorted((v, k) for (k, v) in md5_abundance.items())
+        ):
+            handle.write(
+                "%s\t%i\t%s\n"
+                % (md5, total_abundance, ";".join(sorted(md5_species[md5])))
+            )
+
+        if output != "-":
+            handle.close()
+
+        try:
+            sys.stdout.flush()
+        except BrokenPipeError:
+            pass
+        try:
+            sys.stderr.flush()
+        except BrokenPipeError:
+            pass
+
+        return 0

--- a/thapbi_pict/summary.py
+++ b/thapbi_pict/summary.py
@@ -1,0 +1,36 @@
+"""Summarise ITS1 classification results at folder (plate) level.
+
+This implements the ``thapbi_pict plate-summary ...`` command.
+"""
+
+import sys
+import tempfile
+
+
+from .utils import find_paired_files
+
+
+def main(inputs, output, method, min_abundance=1, debug=False):
+    """Implement the thapbi_pict plate-summary command.
+
+    The expectation is that the inputs represent all the samples
+    from one (96 well) plate, or some other meaningful batch.
+    """
+    assert isinstance(inputs, list)
+
+    input_list = find_paired_files(inputs, ".fasta", ".%s.tsv" % method, debug=False)
+
+    if debug:
+        sys.stderr.write(
+            "Reporting on %i samples using %s classifier\n" % (len(input_list), method)
+        )
+
+    # Context manager should remove the temp dir:
+    with tempfile.TemporaryDirectory() as shared_tmp:
+        if debug:
+            sys.stderr.write("DEBUG: Shared temp folder %s\n" % shared_tmp)
+        for fasta_file, predicted_file in input_list:
+            if debug:
+                sys.stderr.write(
+                    "DEBUG: Reading %s %s\n" % (fasta_file, predicted_file)
+                )

--- a/thapbi_pict/summary.py
+++ b/thapbi_pict/summary.py
@@ -55,6 +55,7 @@ def main(inputs, output, method, min_abundance=1, debug=False):
                 predicted_file, min_abundance
             ):
                 md5, abundance = split_read_name_abundance(name)
+                assert min_abundance < 1 or min_abundance <= abundance, name
                 sp_list = untangle_species(taxid, genus, species).split(";")
                 try:
                     md5_species[md5].union(sp_list)
@@ -66,6 +67,8 @@ def main(inputs, output, method, min_abundance=1, debug=False):
             with open(fasta_file) as handle:
                 for title, seq in SimpleFastaParser(handle):
                     md5, abundance = split_read_name_abundance(title.split(None, 1)[0])
+                    if min_abundance > 1 and abundance < min_abundance:
+                        continue
                     assert abundance_by_samples[md5, sample] == abundance
                     md5_to_seq[md5] = seq
         samples = sorted(samples)

--- a/thapbi_pict/summary.py
+++ b/thapbi_pict/summary.py
@@ -81,7 +81,8 @@ def main(inputs, output, method, min_abundance=1, debug=False):
             handle = open(output, "w")
 
         handle.write(
-            "#ITS1-MD5\tSample-count\tTotal-abundance\t%s-predictions\n" % method
+            "#ITS1-MD5\tSample-count\tTotal-abundance\t%s\t%s-predictions\tSequence\n"
+            % ("\t".join(samples), method)
         )
         for total_abundance, md5 in reversed(
             sorted((v, k) for (k, v) in md5_abundance.items())
@@ -90,12 +91,16 @@ def main(inputs, output, method, min_abundance=1, debug=False):
                 1 for _ in samples if (md5, _) in abundance_by_samples
             )
             handle.write(
-                "%s\t%i\t%i\t%s\n"
+                "%s\t%i\t%i\t%s\t%s\t%s\n"
                 % (
                     md5,
                     md5_in_xxx_samples,
                     total_abundance,
+                    "\t".join(
+                        str(abundance_by_samples.get((md5, _), 0)) for _ in samples
+                    ),
                     ";".join(sorted(md5_species[md5])),
+                    md5_to_seq[md5],
                 )
             )
 

--- a/thapbi_pict/summary.py
+++ b/thapbi_pict/summary.py
@@ -81,8 +81,8 @@ def main(inputs, output, method, min_abundance=1, debug=False):
             handle = open(output, "w")
 
         handle.write(
-            "#ITS1-MD5\tSample-count\tTotal-abundance\t%s\t%s-predictions\tSequence\n"
-            % ("\t".join(samples), method)
+            "#ITS1-MD5\t%s-predictions\tSequence\tSample-count\tTotal-abundance\t%s\n"
+            % (method, "\t".join(samples))
         )
         for total_abundance, md5 in reversed(
             sorted((v, k) for (k, v) in md5_abundance.items())
@@ -91,16 +91,16 @@ def main(inputs, output, method, min_abundance=1, debug=False):
                 1 for _ in samples if (md5, _) in abundance_by_samples
             )
             handle.write(
-                "%s\t%i\t%i\t%s\t%s\t%s\n"
+                "%s\t%s\t%s\t%i\t%i\t%s\n"
                 % (
                     md5,
+                    ";".join(sorted(md5_species[md5])),
+                    md5_to_seq[md5],
                     md5_in_xxx_samples,
                     total_abundance,
                     "\t".join(
                         str(abundance_by_samples.get((md5, _), 0)) for _ in samples
                     ),
-                    ";".join(sorted(md5_species[md5])),
-                    md5_to_seq[md5],
                 )
             )
 


### PR DESCRIPTION
Produces a table, one row per unique ITS1 sequence, some standard columns plus one column for each sample.

Reports the union of the species predictions for each ITS1 sequence for the one or methods requested, otherwise rest of the table is from the prepared FASTA files - summary of the read abundance by sequence and sample.

For environmental plates, can quickly see which ITS1 sequences are wide spread - or find the most common/widespread ITS1 sequences for which no species prediction was made (potential novel species missing from the DB).