### PR TITLE
Assess classifier performance at sample level or sequence level

### DIFF
--- a/tests/assess/assess_sample.tsv
+++ b/tests/assess/assess_sample.tsv
@@ -1,0 +1,10 @@
+#Species	TP	FP	FN	TN	sensitivity	specificity	precision	F1	Hamming-loss
+OVERALL	2	6	4	36	0.33	0.86	0.25	0.29	0.2083
+Phytophthora capsici	1	2	0	3	1.00	0.60	0.33	0.50	0.0417
+Phytophthora crassamura	0	1	0	5	0.00	0.83	0.00	0.00	0.0208
+Phytophthora europaea	0	0	1	5	0.00	1.00	0.00	0.00	0.0208
+Phytophthora fallax	0	0	1	5	0.00	1.00	0.00	0.00	0.0208
+Phytophthora flexuosa	0	0	1	5	0.00	1.00	0.00	0.00	0.0208
+Phytophthora glovera	0	2	1	3	0.00	0.60	0.00	0.00	0.0625
+Phytophthora infestans	0	1	0	5	0.00	0.83	0.00	0.00	0.0208
+Phytophthora megasperma	1	0	0	5	1.00	1.00	1.00	1.00	0.0000

--- a/tests/assess/assess_sample.tsv
+++ b/tests/assess/assess_sample.tsv
@@ -1,10 +1,10 @@
 #Species	TP	FP	FN	TN	sensitivity	specificity	precision	F1	Hamming-loss
 OVERALL	2	6	4	36	0.33	0.86	0.25	0.29	0.2083
-Phytophthora capsici	1	2	0	3	1.00	0.60	0.33	0.50	0.0417
-Phytophthora crassamura	0	1	0	5	0.00	0.83	0.00	0.00	0.0208
-Phytophthora europaea	0	0	1	5	0.00	1.00	0.00	0.00	0.0208
-Phytophthora fallax	0	0	1	5	0.00	1.00	0.00	0.00	0.0208
-Phytophthora flexuosa	0	0	1	5	0.00	1.00	0.00	0.00	0.0208
-Phytophthora glovera	0	2	1	3	0.00	0.60	0.00	0.00	0.0625
-Phytophthora infestans	0	1	0	5	0.00	0.83	0.00	0.00	0.0208
+Phytophthora capsici	1	2	0	3	1.00	0.60	0.33	0.50	0.3333
+Phytophthora crassamura	0	1	0	5	0.00	0.83	0.00	0.00	0.1667
+Phytophthora europaea	0	0	1	5	0.00	1.00	0.00	0.00	0.1667
+Phytophthora fallax	0	0	1	5	0.00	1.00	0.00	0.00	0.1667
+Phytophthora flexuosa	0	0	1	5	0.00	1.00	0.00	0.00	0.1667
+Phytophthora glovera	0	2	1	3	0.00	0.60	0.00	0.00	0.5000
+Phytophthora infestans	0	1	0	5	0.00	0.83	0.00	0.00	0.1667
 Phytophthora megasperma	1	0	0	5	1.00	1.00	1.00	1.00	0.0000

--- a/tests/assess/assess_sequence.tsv
+++ b/tests/assess/assess_sequence.tsv
@@ -1,0 +1,10 @@
+#Species	TP	FP	FN	TN	sensitivity	specificity	precision	F1	Hamming-loss
+OVERALL	2	6	10	78	0.17	0.93	0.25	0.20	0.1667
+Phytophthora capsici	1	2	0	9	1.00	0.82	0.33	0.50	0.0208
+Phytophthora crassamura	0	1	0	11	0.00	0.92	0.00	0.00	0.0104
+Phytophthora europaea	0	0	1	11	0.00	1.00	0.00	0.00	0.0104
+Phytophthora fallax	0	0	4	8	0.00	1.00	0.00	0.00	0.0417
+Phytophthora flexuosa	0	0	1	11	0.00	1.00	0.00	0.00	0.0104
+Phytophthora glovera	0	2	1	9	0.00	0.82	0.00	0.00	0.0312
+Phytophthora infestans	0	1	0	11	0.00	0.92	0.00	0.00	0.0104
+Phytophthora megasperma	1	0	3	8	0.25	1.00	1.00	0.40	0.0312

--- a/tests/assess/assess_sequence.tsv
+++ b/tests/assess/assess_sequence.tsv
@@ -1,10 +1,10 @@
 #Species	TP	FP	FN	TN	sensitivity	specificity	precision	F1	Hamming-loss
 OVERALL	2	6	10	78	0.17	0.93	0.25	0.20	0.1667
-Phytophthora capsici	1	2	0	9	1.00	0.82	0.33	0.50	0.0208
-Phytophthora crassamura	0	1	0	11	0.00	0.92	0.00	0.00	0.0104
-Phytophthora europaea	0	0	1	11	0.00	1.00	0.00	0.00	0.0104
-Phytophthora fallax	0	0	4	8	0.00	1.00	0.00	0.00	0.0417
-Phytophthora flexuosa	0	0	1	11	0.00	1.00	0.00	0.00	0.0104
-Phytophthora glovera	0	2	1	9	0.00	0.82	0.00	0.00	0.0312
-Phytophthora infestans	0	1	0	11	0.00	0.92	0.00	0.00	0.0104
-Phytophthora megasperma	1	0	3	8	0.25	1.00	1.00	0.40	0.0312
+Phytophthora capsici	1	2	0	9	1.00	0.82	0.33	0.50	0.1667
+Phytophthora crassamura	0	1	0	11	0.00	0.92	0.00	0.00	0.0833
+Phytophthora europaea	0	0	1	11	0.00	1.00	0.00	0.00	0.0833
+Phytophthora fallax	0	0	4	8	0.00	1.00	0.00	0.00	0.3333
+Phytophthora flexuosa	0	0	1	11	0.00	1.00	0.00	0.00	0.0833
+Phytophthora glovera	0	2	1	9	0.00	0.82	0.00	0.00	0.2500
+Phytophthora infestans	0	1	0	11	0.00	0.92	0.00	0.00	0.0833
+Phytophthora megasperma	1	0	3	8	0.25	1.00	1.00	0.40	0.2500

--- a/tests/assess/confusion_sample.tsv
+++ b/tests/assess/confusion_sample.tsv
@@ -1,6 +1,6 @@
-#Expected vs predicted	(TN)	(FN)	Phytophthora capsici	Phytophthora crassamura	Phytophthora glovera	Phytophthora infestans	Phytophthora megasperma
-(None)	14	0	1	0	1	0	0
-Phytophthora fallax	5	1	1	0	1	0	0
-Phytophthora megasperma	6	0	0	1	0	0	1
-Phytophthora capsici;Phytophthora glovera	5	1	1	0	0	1	0
-Phytophthora europaea;Phytophthora flexuosa	6	2	0	0	0	0	0
+#Expected vs predicted	sample count	(TN)	(FN)	Phytophthora capsici	Phytophthora crassamura	Phytophthora glovera	Phytophthora infestans	Phytophthora megasperma
+(None)	2	14	0	1	0	1	0	0
+Phytophthora fallax	1	5	1	1	0	1	0	0
+Phytophthora megasperma	1	6	0	0	1	0	0	1
+Phytophthora capsici;Phytophthora glovera	1	5	1	1	0	0	1	0
+Phytophthora europaea;Phytophthora flexuosa	1	6	2	0	0	0	0	0

--- a/tests/assess/confusion_sample.tsv
+++ b/tests/assess/confusion_sample.tsv
@@ -1,0 +1,6 @@
+#Expected vs predicted	(TN)	(FN)	Phytophthora capsici	Phytophthora crassamura	Phytophthora glovera	Phytophthora infestans	Phytophthora megasperma
+(None)	14	0	1	0	1	0	0
+Phytophthora fallax	5	1	1	0	1	0	0
+Phytophthora megasperma	6	0	0	1	0	0	1
+Phytophthora capsici;Phytophthora glovera	5	1	1	0	0	1	0
+Phytophthora europaea;Phytophthora flexuosa	6	2	0	0	0	0	0

--- a/tests/assess/confusion_sequence.tsv
+++ b/tests/assess/confusion_sequence.tsv
@@ -1,6 +1,6 @@
-#Expected vs predicted	(TN)	(FN)	Phytophthora capsici	Phytophthora crassamura	Phytophthora glovera	Phytophthora infestans	Phytophthora megasperma
-(None)	14	0	1	0	1	0	0
-Phytophthora fallax	26	4	1	0	1	0	0
-Phytophthora megasperma	27	3	0	1	0	0	1
-Phytophthora capsici;Phytophthora glovera	5	1	1	0	0	1	0
-Phytophthora europaea;Phytophthora flexuosa	6	2	0	0	0	0	0
+#Expected vs predicted	sequence count	(TN)	(FN)	Phytophthora capsici	Phytophthora crassamura	Phytophthora glovera	Phytophthora infestans	Phytophthora megasperma
+(None)	2	14	0	1	0	1	0	0
+Phytophthora fallax	4	26	4	1	0	1	0	0
+Phytophthora megasperma	4	27	3	0	1	0	0	1
+Phytophthora capsici;Phytophthora glovera	1	5	1	1	0	0	1	0
+Phytophthora europaea;Phytophthora flexuosa	1	6	2	0	0	0	0	0

--- a/tests/assess/confusion_sequence.tsv
+++ b/tests/assess/confusion_sequence.tsv
@@ -1,0 +1,6 @@
+#Expected vs predicted	(TN)	(FN)	Phytophthora capsici	Phytophthora crassamura	Phytophthora glovera	Phytophthora infestans	Phytophthora megasperma
+(None)	14	0	1	0	1	0	0
+Phytophthora fallax	26	4	1	0	1	0	0
+Phytophthora megasperma	27	3	0	1	0	0	1
+Phytophthora capsici;Phytophthora glovera	5	1	1	0	0	1	0
+Phytophthora europaea;Phytophthora flexuosa	6	2	0	0	0	0	0

--- a/tests/assess/ex1.assess.tsv
+++ b/tests/assess/ex1.assess.tsv
@@ -1,9 +1,9 @@
 #Species	TP	FP	FN	TN	sensitivity	specificity	precision	F1	Hamming-loss
 OVERALL	1	1	3	23	0.25	0.96	0.50	0.33	0.1429
 Phytophthora capsici	0	0	0	4	0.00	1.00	0.00	0.00	0.0000
-Phytophthora crassamura	0	1	0	3	0.00	0.75	0.00	0.00	0.0357
+Phytophthora crassamura	0	1	0	3	0.00	0.75	0.00	0.00	0.2500
 Phytophthora europaea	0	0	0	4	0.00	1.00	0.00	0.00	0.0000
 Phytophthora flexuosa	0	0	0	4	0.00	1.00	0.00	0.00	0.0000
 Phytophthora glovera	0	0	0	4	0.00	1.00	0.00	0.00	0.0000
 Phytophthora infestans	0	0	0	4	0.00	1.00	0.00	0.00	0.0000
-Phytophthora megasperma	1	0	3	0	0.25	0.00	1.00	0.40	0.1071
+Phytophthora megasperma	1	0	3	0	0.25	0.00	1.00	0.40	0.7500

--- a/tests/assess/ex2.assess.tsv
+++ b/tests/assess/ex2.assess.tsv
@@ -1,10 +1,10 @@
 #Species	TP	FP	FN	TN	sensitivity	specificity	precision	F1	Hamming-loss
 OVERALL	0	2	4	26	0.00	0.93	0.00	0.00	0.1875
-Phytophthora capsici	0	1	0	3	0.00	0.75	0.00	0.00	0.0312
+Phytophthora capsici	0	1	0	3	0.00	0.75	0.00	0.00	0.2500
 Phytophthora crassamura	0	0	0	4	0.00	1.00	0.00	0.00	0.0000
 Phytophthora europaea	0	0	0	4	0.00	1.00	0.00	0.00	0.0000
-Phytophthora fallax	0	0	4	0	0.00	0.00	0.00	0.00	0.1250
+Phytophthora fallax	0	0	4	0	0.00	0.00	0.00	0.00	1.0000
 Phytophthora flexuosa	0	0	0	4	0.00	1.00	0.00	0.00	0.0000
-Phytophthora glovera	0	1	0	3	0.00	0.75	0.00	0.00	0.0312
+Phytophthora glovera	0	1	0	3	0.00	0.75	0.00	0.00	0.2500
 Phytophthora infestans	0	0	0	4	0.00	1.00	0.00	0.00	0.0000
 Phytophthora megasperma	0	0	0	4	0.00	1.00	0.00	0.00	0.0000

--- a/tests/assess/ex3.assess.tsv
+++ b/tests/assess/ex3.assess.tsv
@@ -2,8 +2,8 @@
 OVERALL	0	0	2	5	0.00	1.00	0.00	0.00	0.2857
 Phytophthora capsici	0	0	0	1	0.00	1.00	0.00	0.00	0.0000
 Phytophthora crassamura	0	0	0	1	0.00	1.00	0.00	0.00	0.0000
-Phytophthora europaea	0	0	1	0	0.00	0.00	0.00	0.00	0.1429
-Phytophthora flexuosa	0	0	1	0	0.00	0.00	0.00	0.00	0.1429
+Phytophthora europaea	0	0	1	0	0.00	0.00	0.00	0.00	1.0000
+Phytophthora flexuosa	0	0	1	0	0.00	0.00	0.00	0.00	1.0000
 Phytophthora glovera	0	0	0	1	0.00	1.00	0.00	0.00	0.0000
 Phytophthora infestans	0	0	0	1	0.00	1.00	0.00	0.00	0.0000
 Phytophthora megasperma	0	0	0	1	0.00	1.00	0.00	0.00	0.0000

--- a/tests/assess/ex4.assess.tsv
+++ b/tests/assess/ex4.assess.tsv
@@ -4,6 +4,6 @@ Phytophthora capsici	1	0	0	0	1.00	0.00	1.00	1.00	0.0000
 Phytophthora crassamura	0	0	0	1	0.00	1.00	0.00	0.00	0.0000
 Phytophthora europaea	0	0	0	1	0.00	1.00	0.00	0.00	0.0000
 Phytophthora flexuosa	0	0	0	1	0.00	1.00	0.00	0.00	0.0000
-Phytophthora glovera	0	0	1	0	0.00	0.00	0.00	0.00	0.1429
-Phytophthora infestans	0	1	0	0	0.00	0.00	0.00	0.00	0.1429
+Phytophthora glovera	0	0	1	0	0.00	0.00	0.00	0.00	1.0000
+Phytophthora infestans	0	1	0	0	0.00	0.00	0.00	0.00	1.0000
 Phytophthora megasperma	0	0	0	1	0.00	1.00	0.00	0.00	0.0000

--- a/tests/assess/fp.assess.tsv
+++ b/tests/assess/fp.assess.tsv
@@ -1,9 +1,9 @@
 #Species	TP	FP	FN	TN	sensitivity	specificity	precision	F1	Hamming-loss
 OVERALL	0	2	0	5	0.00	0.71	0.00	0.00	0.2857
-Phytophthora capsici	0	1	0	0	0.00	0.00	0.00	0.00	0.1429
+Phytophthora capsici	0	1	0	0	0.00	0.00	0.00	0.00	1.0000
 Phytophthora crassamura	0	0	0	1	0.00	1.00	0.00	0.00	0.0000
 Phytophthora europaea	0	0	0	1	0.00	1.00	0.00	0.00	0.0000
 Phytophthora flexuosa	0	0	0	1	0.00	1.00	0.00	0.00	0.0000
-Phytophthora glovera	0	1	0	0	0.00	0.00	0.00	0.00	0.1429
+Phytophthora glovera	0	1	0	0	0.00	0.00	0.00	0.00	1.0000
 Phytophthora infestans	0	0	0	1	0.00	1.00	0.00	0.00	0.0000
 Phytophthora megasperma	0	0	0	1	0.00	1.00	0.00	0.00	0.0000

--- a/tests/assess/tally_sample.tsv
+++ b/tests/assess/tally_sample.tsv
@@ -1,4 +1,4 @@
-#Count	Expected	Predicted
+#sample-count	Expected	Predicted
 1		
 1		Phytophthora capsici;Phytophthora glovera
 1	Phytophthora capsici;Phytophthora glovera	Phytophthora capsici;Phytophthora infestans

--- a/tests/assess/tally_sample.tsv
+++ b/tests/assess/tally_sample.tsv
@@ -1,0 +1,7 @@
+#Count	Expected	Predicted
+1		
+1		Phytophthora capsici;Phytophthora glovera
+1	Phytophthora capsici;Phytophthora glovera	Phytophthora capsici;Phytophthora infestans
+1	Phytophthora europaea;Phytophthora flexuosa	
+1	Phytophthora fallax	Phytophthora capsici;Phytophthora glovera
+1	Phytophthora megasperma	Phytophthora crassamura;Phytophthora megasperma

--- a/tests/assess/tally_sequence.tsv
+++ b/tests/assess/tally_sequence.tsv
@@ -1,4 +1,4 @@
-#Count	Expected	Predicted
+#sequence-count	Expected	Predicted
 1		
 1		Phytophthora capsici;Phytophthora glovera
 1	Phytophthora capsici;Phytophthora glovera	Phytophthora capsici;Phytophthora infestans

--- a/tests/assess/tally_sequence.tsv
+++ b/tests/assess/tally_sequence.tsv
@@ -1,0 +1,10 @@
+#Count	Expected	Predicted
+1		
+1		Phytophthora capsici;Phytophthora glovera
+1	Phytophthora capsici;Phytophthora glovera	Phytophthora capsici;Phytophthora infestans
+1	Phytophthora europaea;Phytophthora flexuosa	
+3	Phytophthora fallax	
+1	Phytophthora fallax	Phytophthora capsici;Phytophthora glovera
+2	Phytophthora megasperma	
+1	Phytophthora megasperma	Phytophthora crassamura
+1	Phytophthora megasperma	Phytophthora megasperma

--- a/tests/test_assess.sh
+++ b/tests/test_assess.sh
@@ -17,6 +17,14 @@ diff tests/assess/ex4.assess.tsv <(thapbi_pict assess tests/assess/ex4.known.tsv
 diff tests/assess/unclassified.assess.tsv <(thapbi_pict assess tests/assess/unclassified.known.tsv tests/assess/unclassified.identity.tsv -c /dev/null)
 diff tests/assess/fp.assess.tsv <(thapbi_pict assess tests/assess/fp.known.tsv tests/assess/fp.identity.tsv -c /dev/null)
 
+echo "Checking sequence level vs sample level assessment"
+for LEVEL in sequence sample; do
+    thapbi_pict assess tests/assess/ -o $TMP/assess.tsv -t $TMP/tally.tsv -c $TMP/confusion.tsv -l $LEVEL
+    diff tests/assess/tally_$LEVEL.tsv $TMP/tally.tsv
+    diff tests/assess/assess_$LEVEL.tsv $TMP/assess.tsv
+    diff tests/assess/confusion_$LEVEL.tsv $TMP/confusion.tsv
+done
+
 echo "Checking warning for unexpected species"
 set +o pipefail
 thapbi_pict assess tests/assess/*.identity.tsv tests/assess/*.known.tsv 2>&1 | grep "Expected species Phytophthora fallax was not a possible prediction"

--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -146,6 +146,7 @@ def assess_classification(args=None):
 
     return main(
         inputs=args.inputs,
+        level=args.level,
         known=args.known,
         method=args.method,
         min_abundance=args.abundance,
@@ -568,6 +569,15 @@ comma.
         "find matching files *.method.tsv to be assessed against "
         "*.known.tsv, where these filenames can be set via "
         "-m / --method and -k / --known arguments. ",
+    )
+    parser_assess.add_argument(
+        "-l",
+        "--level",
+        type=str,
+        default="sequence",
+        choices=["sequence", "sample"],
+        help="Assess at unique sequence level, or at sample level (taking "
+        "the union of the speces predicted by sequences from each sample).",
     )
     parser_assess.add_argument(
         "-k",

--- a/thapbi_pict/assess.py
+++ b/thapbi_pict/assess.py
@@ -70,10 +70,10 @@ def class_list_from_tally_and_db_list(tally, db_sp_list):
     return sorted(classes)
 
 
-def save_mapping(tally, filename, debug=False):
+def save_mapping(tally, filename, level, debug=False):
     """Output tally table of expected species to predicted sp."""
     with open(filename, "w") as handle:
-        handle.write("#Count\tExpected\tPredicted\n")
+        handle.write("#%s-count\tExpected\tPredicted\n" % level)
         for expt, pred in sorted(tally):
             handle.write("%i\t%s\t%s\n" % (tally[expt, pred], expt, pred))
     if debug:
@@ -332,9 +332,9 @@ def main(
         sys.exit("ERROR: Could not find files to assess\n")
 
     if map_output == "-":
-        save_mapping(global_tally, "/dev/stdout", debug=debug)
+        save_mapping(global_tally, "/dev/stdout", level, debug=debug)
     elif map_output:
-        save_mapping(global_tally, map_output, debug=debug)
+        save_mapping(global_tally, map_output, level, debug=debug)
 
     if confusion_output == "-":
         save_confusion_matrix(

--- a/thapbi_pict/assess.py
+++ b/thapbi_pict/assess.py
@@ -83,7 +83,9 @@ def save_mapping(tally, filename, debug=False):
         )
 
 
-def save_confusion_matrix(tally, db_sp_list, sp_list, filename, exp_total, debug=False):
+def save_confusion_matrix(
+    tally, db_sp_list, sp_list, filename, exp_total, level, debug=False
+):
     """Output a multi-class confusion matrix as a tab-separated table."""
     total = 0
 
@@ -136,10 +138,23 @@ def save_confusion_matrix(tally, db_sp_list, sp_list, filename, exp_total, debug
     total = sum(values.values())
 
     with open(filename, "w") as handle:
-        handle.write("#Expected vs predicted\t%s\n" % "\t".join(cols))
+        handle.write(
+            "#Expected vs predicted\t%s count\t%s\n" % (level, "\t".join(cols))
+        )
         for expt in rows:
+            if expt == "(None)":
+                level_count = sum(count for ((e, _), count) in tally.items() if not e)
+            else:
+                level_count = sum(
+                    count for ((e, _), count) in tally.items() if e == expt
+                )
             handle.write(
-                "%s\t%s\n" % (expt, "\t".join(str(values[expt, pred]) for pred in cols))
+                "%s\t%i\t%s\n"
+                % (
+                    expt,
+                    level_count,
+                    "\t".join(str(values[expt, pred]) for pred in cols),
+                )
             )
 
     if debug:
@@ -328,6 +343,7 @@ def main(
             sp_list,
             "/dev/stdout",
             number_of_classes_and_examples,
+            level,
             debug=debug,
         )
     elif confusion_output:
@@ -337,6 +353,7 @@ def main(
             sp_list,
             confusion_output,
             number_of_classes_and_examples,
+            level,
             debug=debug,
         )
 

--- a/thapbi_pict/assess.py
+++ b/thapbi_pict/assess.py
@@ -389,7 +389,7 @@ def main(
         f1 = tp * 2.0 / (2 * tp + fp + fn) if tp else 0.0
         # Hamming Loss = (total number of mis-predicted class entries
         #                 / number of class-level predictions)
-        hamming_loss = float(fp + fn) / number_of_classes_and_examples
+        hamming_loss = float(fp + fn) / (tp + fp + fn + tn)
         handle.write(
             "%s\t%i\t%i\t%i\t%i\t%0.2f\t%0.2f\t%0.2f\t%0.2f\t%0.4f\n"
             % (
@@ -406,6 +406,11 @@ def main(
             )
         )
 
+    if multi_class_total1 != number_of_classes_and_examples:
+        sys.exit(
+            "ERROR: Overall TP+FP+FN+TP = %i, but species times samples = %i\n"
+            % (multi_class_total1, number_of_classes_and_examples)
+        )
     if multi_class_total1 != multi_class_total2 and multi_class_total2:
         sys.exit(
             "ERROR: Overall TP+FP+FN+TP = %i, but sum for species was %i\n"

--- a/thapbi_pict/assess.py
+++ b/thapbi_pict/assess.py
@@ -234,6 +234,7 @@ assert extract_global_tally({("A;B", "A;C"): 1}, ["A", "B", "C", "D"]) == (1, 1,
 
 def main(
     inputs,
+    level,
     known,
     method,
     min_abundance,
@@ -244,6 +245,7 @@ def main(
 ):
     """Implement the thapbi_pict assess command."""
     assert isinstance(inputs, list)
+    assert level in ["sequence", "sample"], level
 
     input_list = find_paired_files(
         inputs, ".%s.tsv" % method, ".%s.tsv" % known, debug=False


### PR DESCRIPTION
Addes new ``-l`` / ``--level`` argument to ``thapbi_pict assess``, default is ``-l sequence`` as before (scores classifiers at the unique sequence per sample level), new mode is ``-l sample`` which takes the union of species predictions for all the sequence in each sample.

This should be more useful for assessing performance on (mock) communities of multiple species.