### PR TITLE
Supplement Hamming Loss with similar but ad hoc metric

### DIFF
--- a/tests/assess/assess_sample.tsv
+++ b/tests/assess/assess_sample.tsv
@@ -1,10 +1,10 @@
-#Species	TP	FP	FN	TN	sensitivity	specificity	precision	F1	Hamming-loss
-OVERALL	2	6	4	36	0.33	0.86	0.25	0.29	0.2083
-Phytophthora capsici	1	2	0	3	1.00	0.60	0.33	0.50	0.3333
-Phytophthora crassamura	0	1	0	5	0.00	0.83	0.00	0.00	0.1667
-Phytophthora europaea	0	0	1	5	0.00	1.00	0.00	0.00	0.1667
-Phytophthora fallax	0	0	1	5	0.00	1.00	0.00	0.00	0.1667
-Phytophthora flexuosa	0	0	1	5	0.00	1.00	0.00	0.00	0.1667
-Phytophthora glovera	0	2	1	3	0.00	0.60	0.00	0.00	0.5000
-Phytophthora infestans	0	1	0	5	0.00	0.83	0.00	0.00	0.1667
-Phytophthora megasperma	1	0	0	5	1.00	1.00	1.00	1.00	0.0000
+#Species	TP	FP	FN	TN	sensitivity	specificity	precision	F1	Hamming-loss	Ad-hoc-loss
+OVERALL	2	6	4	36	0.33	0.86	0.25	0.29	0.2083	0.83
+Phytophthora capsici	1	2	0	3	1.00	0.60	0.33	0.50	0.3333	0.67
+Phytophthora crassamura	0	1	0	5	0.00	0.83	0.00	0.00	0.1667	1.00
+Phytophthora europaea	0	0	1	5	0.00	1.00	0.00	0.00	0.1667	1.00
+Phytophthora fallax	0	0	1	5	0.00	1.00	0.00	0.00	0.1667	1.00
+Phytophthora flexuosa	0	0	1	5	0.00	1.00	0.00	0.00	0.1667	1.00
+Phytophthora glovera	0	2	1	3	0.00	0.60	0.00	0.00	0.5000	1.00
+Phytophthora infestans	0	1	0	5	0.00	0.83	0.00	0.00	0.1667	1.00
+Phytophthora megasperma	1	0	0	5	1.00	1.00	1.00	1.00	0.0000	0.00

--- a/tests/assess/assess_sequence.tsv
+++ b/tests/assess/assess_sequence.tsv
@@ -1,10 +1,10 @@
-#Species	TP	FP	FN	TN	sensitivity	specificity	precision	F1	Hamming-loss
-OVERALL	2	6	10	78	0.17	0.93	0.25	0.20	0.1667
-Phytophthora capsici	1	2	0	9	1.00	0.82	0.33	0.50	0.1667
-Phytophthora crassamura	0	1	0	11	0.00	0.92	0.00	0.00	0.0833
-Phytophthora europaea	0	0	1	11	0.00	1.00	0.00	0.00	0.0833
-Phytophthora fallax	0	0	4	8	0.00	1.00	0.00	0.00	0.3333
-Phytophthora flexuosa	0	0	1	11	0.00	1.00	0.00	0.00	0.0833
-Phytophthora glovera	0	2	1	9	0.00	0.82	0.00	0.00	0.2500
-Phytophthora infestans	0	1	0	11	0.00	0.92	0.00	0.00	0.0833
-Phytophthora megasperma	1	0	3	8	0.25	1.00	1.00	0.40	0.2500
+#Species	TP	FP	FN	TN	sensitivity	specificity	precision	F1	Hamming-loss	Ad-hoc-loss
+OVERALL	2	6	10	78	0.17	0.93	0.25	0.20	0.1667	0.89
+Phytophthora capsici	1	2	0	9	1.00	0.82	0.33	0.50	0.1667	0.67
+Phytophthora crassamura	0	1	0	11	0.00	0.92	0.00	0.00	0.0833	1.00
+Phytophthora europaea	0	0	1	11	0.00	1.00	0.00	0.00	0.0833	1.00
+Phytophthora fallax	0	0	4	8	0.00	1.00	0.00	0.00	0.3333	1.00
+Phytophthora flexuosa	0	0	1	11	0.00	1.00	0.00	0.00	0.0833	1.00
+Phytophthora glovera	0	2	1	9	0.00	0.82	0.00	0.00	0.2500	1.00
+Phytophthora infestans	0	1	0	11	0.00	0.92	0.00	0.00	0.0833	1.00
+Phytophthora megasperma	1	0	3	8	0.25	1.00	1.00	0.40	0.2500	0.75

--- a/tests/assess/ex1.assess.tsv
+++ b/tests/assess/ex1.assess.tsv
@@ -1,9 +1,9 @@
-#Species	TP	FP	FN	TN	sensitivity	specificity	precision	F1	Hamming-loss
-OVERALL	1	1	3	23	0.25	0.96	0.50	0.33	0.1429
-Phytophthora capsici	0	0	0	4	0.00	1.00	0.00	0.00	0.0000
-Phytophthora crassamura	0	1	0	3	0.00	0.75	0.00	0.00	0.2500
-Phytophthora europaea	0	0	0	4	0.00	1.00	0.00	0.00	0.0000
-Phytophthora flexuosa	0	0	0	4	0.00	1.00	0.00	0.00	0.0000
-Phytophthora glovera	0	0	0	4	0.00	1.00	0.00	0.00	0.0000
-Phytophthora infestans	0	0	0	4	0.00	1.00	0.00	0.00	0.0000
-Phytophthora megasperma	1	0	3	0	0.25	0.00	1.00	0.40	0.7500
+#Species	TP	FP	FN	TN	sensitivity	specificity	precision	F1	Hamming-loss	Ad-hoc-loss
+OVERALL	1	1	3	23	0.25	0.96	0.50	0.33	0.1429	0.80
+Phytophthora capsici	0	0	0	4	0.00	1.00	0.00	0.00	0.0000	0.00
+Phytophthora crassamura	0	1	0	3	0.00	0.75	0.00	0.00	0.2500	1.00
+Phytophthora europaea	0	0	0	4	0.00	1.00	0.00	0.00	0.0000	0.00
+Phytophthora flexuosa	0	0	0	4	0.00	1.00	0.00	0.00	0.0000	0.00
+Phytophthora glovera	0	0	0	4	0.00	1.00	0.00	0.00	0.0000	0.00
+Phytophthora infestans	0	0	0	4	0.00	1.00	0.00	0.00	0.0000	0.00
+Phytophthora megasperma	1	0	3	0	0.25	0.00	1.00	0.40	0.7500	0.75

--- a/tests/assess/ex2.assess.tsv
+++ b/tests/assess/ex2.assess.tsv
@@ -1,10 +1,10 @@
-#Species	TP	FP	FN	TN	sensitivity	specificity	precision	F1	Hamming-loss
-OVERALL	0	2	4	26	0.00	0.93	0.00	0.00	0.1875
-Phytophthora capsici	0	1	0	3	0.00	0.75	0.00	0.00	0.2500
-Phytophthora crassamura	0	0	0	4	0.00	1.00	0.00	0.00	0.0000
-Phytophthora europaea	0	0	0	4	0.00	1.00	0.00	0.00	0.0000
-Phytophthora fallax	0	0	4	0	0.00	0.00	0.00	0.00	1.0000
-Phytophthora flexuosa	0	0	0	4	0.00	1.00	0.00	0.00	0.0000
-Phytophthora glovera	0	1	0	3	0.00	0.75	0.00	0.00	0.2500
-Phytophthora infestans	0	0	0	4	0.00	1.00	0.00	0.00	0.0000
-Phytophthora megasperma	0	0	0	4	0.00	1.00	0.00	0.00	0.0000
+#Species	TP	FP	FN	TN	sensitivity	specificity	precision	F1	Hamming-loss	Ad-hoc-loss
+OVERALL	0	2	4	26	0.00	0.93	0.00	0.00	0.1875	1.00
+Phytophthora capsici	0	1	0	3	0.00	0.75	0.00	0.00	0.2500	1.00
+Phytophthora crassamura	0	0	0	4	0.00	1.00	0.00	0.00	0.0000	0.00
+Phytophthora europaea	0	0	0	4	0.00	1.00	0.00	0.00	0.0000	0.00
+Phytophthora fallax	0	0	4	0	0.00	0.00	0.00	0.00	1.0000	1.00
+Phytophthora flexuosa	0	0	0	4	0.00	1.00	0.00	0.00	0.0000	0.00
+Phytophthora glovera	0	1	0	3	0.00	0.75	0.00	0.00	0.2500	1.00
+Phytophthora infestans	0	0	0	4	0.00	1.00	0.00	0.00	0.0000	0.00
+Phytophthora megasperma	0	0	0	4	0.00	1.00	0.00	0.00	0.0000	0.00

--- a/tests/assess/ex3.assess.tsv
+++ b/tests/assess/ex3.assess.tsv
@@ -1,9 +1,9 @@
-#Species	TP	FP	FN	TN	sensitivity	specificity	precision	F1	Hamming-loss
-OVERALL	0	0	2	5	0.00	1.00	0.00	0.00	0.2857
-Phytophthora capsici	0	0	0	1	0.00	1.00	0.00	0.00	0.0000
-Phytophthora crassamura	0	0	0	1	0.00	1.00	0.00	0.00	0.0000
-Phytophthora europaea	0	0	1	0	0.00	0.00	0.00	0.00	1.0000
-Phytophthora flexuosa	0	0	1	0	0.00	0.00	0.00	0.00	1.0000
-Phytophthora glovera	0	0	0	1	0.00	1.00	0.00	0.00	0.0000
-Phytophthora infestans	0	0	0	1	0.00	1.00	0.00	0.00	0.0000
-Phytophthora megasperma	0	0	0	1	0.00	1.00	0.00	0.00	0.0000
+#Species	TP	FP	FN	TN	sensitivity	specificity	precision	F1	Hamming-loss	Ad-hoc-loss
+OVERALL	0	0	2	5	0.00	1.00	0.00	0.00	0.2857	1.00
+Phytophthora capsici	0	0	0	1	0.00	1.00	0.00	0.00	0.0000	0.00
+Phytophthora crassamura	0	0	0	1	0.00	1.00	0.00	0.00	0.0000	0.00
+Phytophthora europaea	0	0	1	0	0.00	0.00	0.00	0.00	1.0000	1.00
+Phytophthora flexuosa	0	0	1	0	0.00	0.00	0.00	0.00	1.0000	1.00
+Phytophthora glovera	0	0	0	1	0.00	1.00	0.00	0.00	0.0000	0.00
+Phytophthora infestans	0	0	0	1	0.00	1.00	0.00	0.00	0.0000	0.00
+Phytophthora megasperma	0	0	0	1	0.00	1.00	0.00	0.00	0.0000	0.00

--- a/tests/assess/ex4.assess.tsv
+++ b/tests/assess/ex4.assess.tsv
@@ -1,9 +1,9 @@
-#Species	TP	FP	FN	TN	sensitivity	specificity	precision	F1	Hamming-loss
-OVERALL	1	1	1	4	0.50	0.80	0.50	0.50	0.2857
-Phytophthora capsici	1	0	0	0	1.00	0.00	1.00	1.00	0.0000
-Phytophthora crassamura	0	0	0	1	0.00	1.00	0.00	0.00	0.0000
-Phytophthora europaea	0	0	0	1	0.00	1.00	0.00	0.00	0.0000
-Phytophthora flexuosa	0	0	0	1	0.00	1.00	0.00	0.00	0.0000
-Phytophthora glovera	0	0	1	0	0.00	0.00	0.00	0.00	1.0000
-Phytophthora infestans	0	1	0	0	0.00	0.00	0.00	0.00	1.0000
-Phytophthora megasperma	0	0	0	1	0.00	1.00	0.00	0.00	0.0000
+#Species	TP	FP	FN	TN	sensitivity	specificity	precision	F1	Hamming-loss	Ad-hoc-loss
+OVERALL	1	1	1	4	0.50	0.80	0.50	0.50	0.2857	0.67
+Phytophthora capsici	1	0	0	0	1.00	0.00	1.00	1.00	0.0000	0.00
+Phytophthora crassamura	0	0	0	1	0.00	1.00	0.00	0.00	0.0000	0.00
+Phytophthora europaea	0	0	0	1	0.00	1.00	0.00	0.00	0.0000	0.00
+Phytophthora flexuosa	0	0	0	1	0.00	1.00	0.00	0.00	0.0000	0.00
+Phytophthora glovera	0	0	1	0	0.00	0.00	0.00	0.00	1.0000	1.00
+Phytophthora infestans	0	1	0	0	0.00	0.00	0.00	0.00	1.0000	1.00
+Phytophthora megasperma	0	0	0	1	0.00	1.00	0.00	0.00	0.0000	0.00

--- a/tests/assess/fp.assess.tsv
+++ b/tests/assess/fp.assess.tsv
@@ -1,9 +1,9 @@
-#Species	TP	FP	FN	TN	sensitivity	specificity	precision	F1	Hamming-loss
-OVERALL	0	2	0	5	0.00	0.71	0.00	0.00	0.2857
-Phytophthora capsici	0	1	0	0	0.00	0.00	0.00	0.00	1.0000
-Phytophthora crassamura	0	0	0	1	0.00	1.00	0.00	0.00	0.0000
-Phytophthora europaea	0	0	0	1	0.00	1.00	0.00	0.00	0.0000
-Phytophthora flexuosa	0	0	0	1	0.00	1.00	0.00	0.00	0.0000
-Phytophthora glovera	0	1	0	0	0.00	0.00	0.00	0.00	1.0000
-Phytophthora infestans	0	0	0	1	0.00	1.00	0.00	0.00	0.0000
-Phytophthora megasperma	0	0	0	1	0.00	1.00	0.00	0.00	0.0000
+#Species	TP	FP	FN	TN	sensitivity	specificity	precision	F1	Hamming-loss	Ad-hoc-loss
+OVERALL	0	2	0	5	0.00	0.71	0.00	0.00	0.2857	1.00
+Phytophthora capsici	0	1	0	0	0.00	0.00	0.00	0.00	1.0000	1.00
+Phytophthora crassamura	0	0	0	1	0.00	1.00	0.00	0.00	0.0000	0.00
+Phytophthora europaea	0	0	0	1	0.00	1.00	0.00	0.00	0.0000	0.00
+Phytophthora flexuosa	0	0	0	1	0.00	1.00	0.00	0.00	0.0000	0.00
+Phytophthora glovera	0	1	0	0	0.00	0.00	0.00	0.00	1.0000	1.00
+Phytophthora infestans	0	0	0	1	0.00	1.00	0.00	0.00	0.0000	0.00
+Phytophthora megasperma	0	0	0	1	0.00	1.00	0.00	0.00	0.0000	0.00

--- a/tests/assess/unclassified.assess.tsv
+++ b/tests/assess/unclassified.assess.tsv
@@ -1,9 +1,9 @@
-#Species	TP	FP	FN	TN	sensitivity	specificity	precision	F1	Hamming-loss
-OVERALL	0	0	0	7	0.00	1.00	0.00	0.00	0.0000
-Phytophthora capsici	0	0	0	1	0.00	1.00	0.00	0.00	0.0000
-Phytophthora crassamura	0	0	0	1	0.00	1.00	0.00	0.00	0.0000
-Phytophthora europaea	0	0	0	1	0.00	1.00	0.00	0.00	0.0000
-Phytophthora flexuosa	0	0	0	1	0.00	1.00	0.00	0.00	0.0000
-Phytophthora glovera	0	0	0	1	0.00	1.00	0.00	0.00	0.0000
-Phytophthora infestans	0	0	0	1	0.00	1.00	0.00	0.00	0.0000
-Phytophthora megasperma	0	0	0	1	0.00	1.00	0.00	0.00	0.0000
+#Species	TP	FP	FN	TN	sensitivity	specificity	precision	F1	Hamming-loss	Ad-hoc-loss
+OVERALL	0	0	0	7	0.00	1.00	0.00	0.00	0.0000	0.00
+Phytophthora capsici	0	0	0	1	0.00	1.00	0.00	0.00	0.0000	0.00
+Phytophthora crassamura	0	0	0	1	0.00	1.00	0.00	0.00	0.0000	0.00
+Phytophthora europaea	0	0	0	1	0.00	1.00	0.00	0.00	0.0000	0.00
+Phytophthora flexuosa	0	0	0	1	0.00	1.00	0.00	0.00	0.0000	0.00
+Phytophthora glovera	0	0	0	1	0.00	1.00	0.00	0.00	0.0000	0.00
+Phytophthora infestans	0	0	0	1	0.00	1.00	0.00	0.00	0.0000	0.00
+Phytophthora megasperma	0	0	0	1	0.00	1.00	0.00	0.00	0.0000	0.00

--- a/thapbi_pict/assess.py
+++ b/thapbi_pict/assess.py
@@ -366,7 +366,8 @@ def main(
 
     handle.write(
         "#Species\tTP\tFP\tFN\tTN\t"
-        "sensitivity\tspecificity\tprecision\tF1\tHamming-loss\n"
+        "sensitivity\tspecificity\tprecision\tF1\t"
+        "Hamming-loss\tAd-hoc-loss\n"
     )
     multi_class_total1 = multi_class_total2 = 0
     for sp in [None] + sp_list:
@@ -390,8 +391,14 @@ def main(
         # Hamming Loss = (total number of mis-predicted class entries
         #                 / number of class-level predictions)
         hamming_loss = float(fp + fn) / (tp + fp + fn + tn)
+        # Ad-hoc Loss = (total number of mis-predicted class entries
+        #                 / number of class-level predictions ignoring TN
+        try:
+            ad_hoc_loss = float(fp + fn) / (tp + fp + fn)
+        except ZeroDivisionError:
+            ad_hoc_loss = 0.0
         handle.write(
-            "%s\t%i\t%i\t%i\t%i\t%0.2f\t%0.2f\t%0.2f\t%0.2f\t%0.4f\n"
+            "%s\t%i\t%i\t%i\t%i\t%0.2f\t%0.2f\t%0.2f\t%0.2f\t%0.4f\t%0.2f\n"
             % (
                 sp,
                 tp,
@@ -403,6 +410,7 @@ def main(
                 precision,
                 f1,
                 hamming_loss,
+                ad_hoc_loss,
             )
         )
 


### PR DESCRIPTION
In our data we have lots of negatives and very few positives - less than 10%. For instance, we might have perhaps 10 species present in a (mock) environmental sample, which means all the over species in the database should all be predicted as absent - giving lots and lots of TN scores (true negatives).

Taking a simple example, with a single sample, say there are 10 species expected from a database of 150. Say we get six correct (6 TP), miss four (4 FN) and wrongly predict another three (3 FP), that leaves 150-5-5-3 = 137 TN.

The vast number of TN classifications dilutes down the mis-predictions in computing the Hamming Loss, which can be expressed as:

*Hamming Loss = (total FP + FN) / (total TP + FP + FN + TN) = (3 + 4) / 150 = 0.0466*

Here by construction, *total TP + FP + FN + TN* = number of species times number of sequences (or samples if assessing at that level) = total number of individual class-level predictions, the typically way of expressing the Hamming Loss denominator. See detailed example on #71.

This loss (about 5%) is far lower than the intuitive assessment of the species classifier, we want something more like 50% in error.

If we instead  ignore the true negatives, we get a much larger loss score, which still ranges from 0 (perfect) to 1 (all wrong):

*Ad-hoc Loss =  (total FP + FN) / (total TP + FP + FN) = (3 + 4) / (6 + 3 + 4) = 0.5384*

This score says we got just over half wrong - which better captures what we want to measure. For our single isolate controls, the scoring difference is even more dramatic.

There probably is an official name for this score, we just haven't found it yet!