### PR TITLE
New classifier 'swarmid'

### DIFF
--- a/tests/test_classify.sh
+++ b/tests/test_classify.sh
@@ -33,7 +33,7 @@ thapbi_pict classify -m identity -d $DB $TMP/DNAMIX_S95_L001.fasta -o $TMP/
 thapbi_pict classify -m onebp -d $DB $TMP/DNAMIX_S95_L001.fasta -o $TMP/thapbi_onebp
 thapbi_pict classify -m blast -d $DB $TMP/DNAMIX_S95_L001.fasta -o $TMP/thapbi_blast
 thapbi_pict classify -m swarm -d $DB $TMP/DNAMIX_S95_L001.fasta -o $TMP/thapbi_swarm
-cut -f 5 $TMP/thapbi_swarm/DNAMIX_S95_L001.swarm.tsv | sort | uniq -c
+thapbi_pict classify -m swarmid -d $DB $TMP/DNAMIX_S95_L001.fasta
 
 # Passing one directory name (should get all three FASTA files):
 rm -rf $TMP/legacy/*.identity.tsv


### PR DESCRIPTION
Acts like the 100% match 'identity' classifier with the fuzzy 'swarm' classifier as a fall back.

Proceeds as per the simple SWARM classifier, with each cluster being assigned species. However, before using the cluster species, checks if the sequence has a 100% identical match in the DB and if so, uses that in preference.

Performance wise, this is a massive improvement on the 'swarm' classifier which is clearly the worst performing classifier (too many FP due to fuzzy matching). This puts the 'swarmid' on a par with the 'onebp' and 'blast' classifiers (exact ranking depends on test set and database), with 'identity' generally behind due to too many FN (things that don't quite match the DB).