### PR TITLE
Primer based trimming

### DIFF
--- a/tests/test_prepare-reads.sh
+++ b/tests/test_prepare-reads.sh
@@ -12,11 +12,11 @@ set -o pipefail
 # Try a real example
 rm -rf $TMP/DNAMIX_S95_L001.fasta
 thapbi_pict prepare-reads -o $TMP tests/reads/DNAMIX_S95_L001_*.fastq.gz -a 0
-if [ `grep -c "^>" $TMP/DNAMIX_S95_L001.fasta` -ne "921" ]; then echo "Wrong FASTA output count"; false; fi
+if [ `grep -c "^>" $TMP/DNAMIX_S95_L001.fasta` -ne "903" ]; then echo "Wrong FASTA output count"; false; fi
 
 rm -rf $TMP/DNAMIX_S95_L001.fasta
 thapbi_pict prepare-reads -o $TMP tests/reads/DNAMIX_S95_L001_*.fastq.gz -a 5
-if [ `grep -c "^>" $TMP/DNAMIX_S95_L001.fasta` -ne "27" ]; then echo "Wrong FASTA output count"; false; fi
+if [ `grep -c "^>" $TMP/DNAMIX_S95_L001.fasta` -ne "25" ]; then echo "Wrong FASTA output count"; false; fi
 
 echo "Generating mock control file"
 # Using just 50 real reads (50 * 4 = 200 lines)
@@ -29,7 +29,7 @@ rm -rf $TMP/DNAMIX_S95_L001.fasta
 rm -rf $TMP/MOCK_CONTROL.fasta
 # Starting low threshold, should be increased to 19, so get new output count...
 thapbi_pict prepare-reads -o $TMP tests/reads/DNAMIX_S95_L001_*.fastq.gz -a 5 -c $TMP/MOCK_CONTROL_R?.fastq
-if [ `grep -c "^>" $TMP/MOCK_CONTROL.fasta` -ne "16" ]; then echo "Wrong FASTA control output count"; false; fi
+if [ `grep -c "^>" $TMP/MOCK_CONTROL.fasta` -ne "15" ]; then echo "Wrong FASTA control output count"; false; fi
 if [ `grep -c "^>" $TMP/DNAMIX_S95_L001.fasta` -ne "9" ]; then echo "Wrong FASTA output count"; false; fi
 
 rm -rf $TMP/DNAMIX_S95_L001.fasta

--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -495,8 +495,11 @@ comma.
         metavar="PRIMER",
         help="Left primer sequence, expected to form start of merged "
         "read pairs, and will be removed. This can be defined with IUPAC "
-        "ambiguity codes, as in the default 53bp left primer sequence, "
-        "GAAGGTGAAGTCGTAACAAGGTTTCCGTAGGTGAACCTGCGGAAGGATCATTA.",
+        "ambiguity codes. Default 53bp left value "
+        "GAAGGTGAAGTCGTAACAAGGTTTCCGTAGGTGAACCTGCGGAAGGATCATTA "
+        "consists of 21bp primer GAAGGTGAAGTCGTAACAAGG followed by "
+        "32bp near-static TTTCCGTAGGTGAACCTGCGGAAGGATCATTA from the "
+        "18S gene (which we remove).",
     )
     parser_prepare_reads.add_argument(
         "-r",

--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -118,6 +118,8 @@ def prepare_reads(args=None):
         fastq=args.fastq,
         controls=args.controls,
         out_dir=args.output,
+        left_primer=args.left,
+        right_primer=args.right,
         min_abundance=args.abundance,
         debug=args.verbose,
         cpu=args.cpu,
@@ -484,6 +486,28 @@ comma.
         help="Mininum abundance to apply to final candidate ITS1 "
         "sequences in the output FASTA file (default 100). "
         "This may be increased based on any FASTQ controls.",
+    )
+    parser_prepare_reads.add_argument(
+        "-l",
+        "--left",
+        type=str,
+        default="GAAGGTGAAGTCGTAACAAGGTTTCCGTAGGTGAACCTGCGGAAGGATCATTA",
+        metavar="PRIMER",
+        help="Left primer sequence, expected to form start of merged "
+        "read pairs, and will be removed. This can be defined with IUPAC "
+        "ambiguity codes, as in the default 53bp left primer sequence, "
+        "GAAGGTGAAGTCGTAACAAGGTTTCCGTAGGTGAACCTGCGGAAGGATCATTA.",
+    )
+    parser_prepare_reads.add_argument(
+        "-r",
+        "--right",
+        type=str,
+        default="GYRGGGACGAAAGTCYYTGC",
+        metavar="PRIMER",
+        help="Right primer sequence, expected to form end of merged "
+        "read pairs, and will be removed. This can be defined with IUPAC "
+        "ambiguity codes, as in the default 20bp value using Y and R "
+        "characters, GYRGGGACGAAAGTCYYTGC.",
     )
     parser_prepare_reads.add_argument(
         "-v", "--verbose", action="store_true", help="Verbose logging"

--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -493,9 +493,9 @@ comma.
         type=str,
         default="GAAGGTGAAGTCGTAACAAGGTTTCCGTAGGTGAACCTGCGGAAGGATCATTA",
         metavar="PRIMER",
-        help="Left primer sequence, expected to form start of merged "
+        help="Left primer sequence, expected to form the start of merged "
         "read pairs, and will be removed. This can be defined with IUPAC "
-        "ambiguity codes. Default 53bp left value "
+        "ambiguity codes. Default 53bp value "
         "GAAGGTGAAGTCGTAACAAGGTTTCCGTAGGTGAACCTGCGGAAGGATCATTA "
         "consists of 21bp primer GAAGGTGAAGTCGTAACAAGG followed by "
         "32bp near-static TTTCCGTAGGTGAACCTGCGGAAGGATCATTA from the "
@@ -505,12 +505,13 @@ comma.
         "-r",
         "--right",
         type=str,
-        default="GYRGGGACGAAAGTCYYTGC",
+        default="GCARRGACTTTCGTCCCYRC",
         metavar="PRIMER",
-        help="Right primer sequence, expected to form end of merged "
-        "read pairs, and will be removed. This can be defined with IUPAC "
-        "ambiguity codes, as in the default 20bp value using Y and R "
-        "characters, GYRGGGACGAAAGTCYYTGC.",
+        help="Right primer sequence, we expect to find its reverse "
+        "complement at the end of merged read pairs, and remove this. "
+        "Can be defined with IUPAC ambiguity codes, as in 20bp "
+        "default GCARRGACTTTCGTCCCYRC, meaning we look for the reverse "
+        "complement GYRGGGACGAAAGTCYYTGC.",
     )
     parser_prepare_reads.add_argument(
         "-v", "--verbose", action="store_true", help="Verbose logging"

--- a/thapbi_pict/classify.py
+++ b/thapbi_pict/classify.py
@@ -22,6 +22,7 @@ from .utils import abundance_from_read_name
 from .utils import cmd_as_string, run
 from .utils import find_requested_files
 from .utils import md5seq
+from .utils import onebp_variants
 
 
 fuzzy_matches = None  # global variable for onebp classifier
@@ -154,54 +155,6 @@ def method_identity(
         read_report.write("%s\t%s\t%s\t%s\n" % (idn, str(taxid), genus_species, note))
     assert count == sum(tax_counts.values())
     return tax_counts
-
-
-def onebp_variants(seq):
-    """Generate all 1bp variants of the sequence (substitution, deletion or insertion).
-
-    Assumes unambiguous IUPAC codes A, C, G, T only.
-    """
-    seq = seq.upper()
-    variants = set()
-    for i in range(len(seq)):
-        # One base deletion
-        variants.add(seq[:i] + seq[i + 1 :])
-        for s in "ACGT":
-            # One base substitions
-            variants.add(seq[:i] + s + seq[i + 1 :])
-            # One base insertions
-            variants.add(seq[:i] + s + seq[i:])
-    for s in "ACGT":
-        # One base "insertion" at the end
-        variants.add(seq + s)
-    variants.remove(seq)
-    return variants
-
-
-assert set(onebp_variants("A")) == set(
-    ["", "C", "G", "T", "AA", "CA", "GA", "TA", "AC", "AG", "AT"]
-)
-assert set(onebp_variants("AA")) == set(
-    [
-        "A",
-        "CA",
-        "GA",
-        "TA",
-        "AC",
-        "AG",
-        "AT",
-        "AAA",
-        "CAA",
-        "GAA",
-        "TAA",
-        "ACA",
-        "AGA",
-        "ATA",
-        "AAC",
-        "AAG",
-        "AAT",
-    ]
-)
 
 
 def setup_onebp(session, shared_tmp_dir, debug=False, cpu=0):

--- a/thapbi_pict/prepare.py
+++ b/thapbi_pict/prepare.py
@@ -219,7 +219,6 @@ def filter_fasta_for_its1(input_fasta, output_fasta, stem, debug=False):
                     sys.stderr.write(
                         "WARNING: %s has HMM cropping %i left, %i right "
                         "(on top of fixed trimming)\n"
-                        "giving %i, vs %i bp from fixed trimming\n"
                         % (title.split(None, 1)[0], left, right)
                     )
 

--- a/thapbi_pict/prepare.py
+++ b/thapbi_pict/prepare.py
@@ -11,6 +11,7 @@ import tempfile
 
 from collections import Counter
 
+from Bio.Seq import reverse_complement
 from Bio.SeqIO.QualityIO import FastqGeneralIterator
 
 from .hmm import filter_for_ITS1
@@ -219,6 +220,10 @@ def make_nr_fastq_to_fasta(
 
     The FASTQ read names are ignored and treated as abundance one!
 
+    Expects to find the left-primer at the start of each merged read.
+    Expects to find the reverse complement of the right-primer at the
+    end of each read.
+
     Applies the specified fixed triming, then makes a non-redundant
     FASTA file with the sequences named MD5_abundance.
 
@@ -231,7 +236,7 @@ def make_nr_fastq_to_fasta(
     trim_left = len(left_primer)
     trim_right = len(right_primer)
     trim_starts = tuple(expand_IUPAC_ambiguity_codes(left_primer))
-    trim_ends = tuple(expand_IUPAC_ambiguity_codes(right_primer))
+    trim_ends = tuple(expand_IUPAC_ambiguity_codes(reverse_complement(right_primer)))
 
     trim_starts_1s = set()
     trim_starts_1del = set()

--- a/thapbi_pict/utils.py
+++ b/thapbi_pict/utils.py
@@ -10,6 +10,54 @@ from Bio.Data.IUPACData import ambiguous_dna_values
 from Bio.SeqIO.FastaIO import SimpleFastaParser
 
 
+def onebp_variants(seq):
+    """Generate all 1bp variants of the sequence (substitution, deletion or insertion).
+
+    Assumes unambiguous IUPAC codes A, C, G, T only.
+    """
+    seq = seq.upper()
+    variants = set()
+    for i in range(len(seq)):
+        # One base deletion
+        variants.add(seq[:i] + seq[i + 1 :])
+        for s in "ACGT":
+            # One base substitions
+            variants.add(seq[:i] + s + seq[i + 1 :])
+            # One base insertions
+            variants.add(seq[:i] + s + seq[i:])
+    for s in "ACGT":
+        # One base "insertion" at the end
+        variants.add(seq + s)
+    variants.remove(seq)
+    return variants
+
+
+assert set(onebp_variants("A")) == set(
+    ["", "C", "G", "T", "AA", "CA", "GA", "TA", "AC", "AG", "AT"]
+)
+assert set(onebp_variants("AA")) == set(
+    [
+        "A",
+        "CA",
+        "GA",
+        "TA",
+        "AC",
+        "AG",
+        "AT",
+        "AAA",
+        "CAA",
+        "GAA",
+        "TAA",
+        "ACA",
+        "AGA",
+        "ATA",
+        "AAC",
+        "AAG",
+        "AAT",
+    ]
+)
+
+
 def expand_IUPAC_ambiguity_codes(seq):
     """Convert to upper case and iterate over possible unabmigous interpretations.
 

--- a/thapbi_pict/utils.py
+++ b/thapbi_pict/utils.py
@@ -10,6 +10,51 @@ from Bio.Data.IUPACData import ambiguous_dna_values
 from Bio.SeqIO.FastaIO import SimpleFastaParser
 
 
+def onebp_substitutions(seq):
+    """Generate all 1bp substitutions of the sequence.
+
+    Assumes unambiguous IUPAC codes A, C, G, T only.
+    """
+    seq = seq.upper()
+    variants = set()
+    for i in range(len(seq)):
+        for s in "ACGT":
+            # One base substitions
+            variants.add(seq[:i] + s + seq[i + 1 :])
+    variants.remove(seq)
+    return variants
+
+
+def onebp_deletions(seq):
+    """Generate all variants of sequence with 1bp deletion.
+
+    Assumes unambiguous IUPAC codes A, C, G, T only.
+    """
+    seq = seq.upper()
+    variants = set()
+    for i in range(len(seq)):
+        # One base deletion
+        variants.add(seq[:i] + seq[i + 1 :])
+    return variants
+
+
+def onebp_inserts(seq):
+    """Generate all variants of sequence with 1bp insert.
+
+    Assumes unambiguous IUPAC codes A, C, G, T only.
+    """
+    seq = seq.upper()
+    variants = set()
+    for i in range(len(seq)):
+        for s in "ACGT":
+            # One base insertions
+            variants.add(seq[:i] + s + seq[i:])
+    for s in "ACGT":
+        # One base "insertion" at the end
+        variants.add(seq + s)
+    return variants
+
+
 def onebp_variants(seq):
     """Generate all 1bp variants of the sequence (substitution, deletion or insertion).
 


### PR DESCRIPTION
This would address #45, and in doing so confirms that on typical libraries 95% of the merged reads have perfect matches to the expected primer sequences, even higher allowing a 1bp substitution, so the original fixed trimming was generally correct.

Practically speaking, in this change we now look for 1bp deletions and 1bp insertions, and adjust the trimming accordingly. This collapses a few rare variants so the unique sequence count goes down, but the individual abundances increase.

Note currently if the primer is not recognised at the start/end, we still apply the same fixed trimming. As noted on #82, there is scope for further improvement as the primer isn't always at the end of the merged reads...