### PR TITLE
Only trim 21bp left primer (not 32bp of 18S gene)

### DIFF
--- a/tests/test_prepare-reads.sh
+++ b/tests/test_prepare-reads.sh
@@ -12,7 +12,7 @@ set -o pipefail
 # Try a real example
 rm -rf $TMP/DNAMIX_S95_L001.fasta
 thapbi_pict prepare-reads -o $TMP tests/reads/DNAMIX_S95_L001_*.fastq.gz -a 0
-if [ `grep -c "^>" $TMP/DNAMIX_S95_L001.fasta` -ne "867" ]; then echo "Wrong FASTA output count"; false; fi
+if [ `grep -c "^>" $TMP/DNAMIX_S95_L001.fasta` -ne "919" ]; then echo "Wrong FASTA output count"; false; fi
 
 rm -rf $TMP/DNAMIX_S95_L001.fasta
 thapbi_pict prepare-reads -o $TMP tests/reads/DNAMIX_S95_L001_*.fastq.gz -a 5

--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -491,15 +491,12 @@ comma.
         "-l",
         "--left",
         type=str,
-        default="GAAGGTGAAGTCGTAACAAGGTTTCCGTAGGTGAACCTGCGGAAGGATCATTA",
+        default="GAAGGTGAAGTCGTAACAAGG",
         metavar="PRIMER",
-        help="Left primer sequence, expected to form the start of merged "
-        "read pairs, and will be removed. This can be defined with IUPAC "
-        "ambiguity codes. Default 53bp value "
-        "GAAGGTGAAGTCGTAACAAGGTTTCCGTAGGTGAACCTGCGGAAGGATCATTA "
-        "consists of 21bp primer GAAGGTGAAGTCGTAACAAGG followed by "
-        "32bp near-static TTTCCGTAGGTGAACCTGCGGAAGGATCATTA from the "
-        "18S gene (which we remove).",
+        help="Left primer sequence, finds and removes from start of "
+        "merged read pairs. Can use IUPAC ambiguity codes. "
+        "Default 21bp ITS6 'GAAGGTGAAGTCGTAACAAGG' from Cooke "
+        "et al. 2000 https://doi.org/10.1006/fgbi.2000.1202",
     )
     parser_prepare_reads.add_argument(
         "-r",
@@ -507,11 +504,12 @@ comma.
         type=str,
         default="GCARRGACTTTCGTCCCYRC",
         metavar="PRIMER",
-        help="Right primer sequence, we expect to find its reverse "
-        "complement at the end of merged read pairs, and remove this. "
-        "Can be defined with IUPAC ambiguity codes, as in 20bp "
-        "default GCARRGACTTTCGTCCCYRC, meaning we look for the reverse "
-        "complement GYRGGGACGAAAGTCYYTGC.",
+        help="Right primer sequence, finds and removes reverse "
+        "complement from end of merged read pairs. Can use "
+        "IUPAC ambiguity codes. Default 20bp 5.8S-1R primer "
+        "'GCARRGACTTTCGTCCCYRC' from Scibetta et al. 2012 "
+        "https://doi.org/10.1016/j.mimet.2011.12.012 - meaning "
+        "looks for 'GYRGGGACGAAAGTCYYTGC' in merged reads.",
     )
     parser_prepare_reads.add_argument(
         "-v", "--verbose", action="store_true", help="Verbose logging"

--- a/thapbi_pict/prepare.py
+++ b/thapbi_pict/prepare.py
@@ -291,6 +291,8 @@ def filter_fasta_for_its1(input_fasta, output_fasta, stem, debug=False):
 
     Returns the number of unique ITS1 sequences (integer),
     """
+    exp_left = 32
+    exp_right = 0
     margin = 10
     cropping_warning = 0
     max_indiv_abundance = 0
@@ -310,14 +312,22 @@ def filter_fasta_for_its1(input_fasta, output_fasta, stem, debug=False):
 
             left = full_seq.index(hmm_seq)
             right = len(full_seq) - left - len(hmm_seq)
-            if margin < left or margin < right:
+            if not (
+                exp_left - margin < left < exp_left + margin
+                and exp_right - margin < right < exp_right + margin
+            ):
                 cropping_warning += 1
-                if debug:
-                    sys.stderr.write(
-                        "WARNING: %s has HMM cropping %i left, %i right "
-                        "(on top of fixed trimming)\n"
-                        % (title.split(None, 1)[0], left, right)
+                sys.stderr.write(
+                    "WARNING: %r has HMM cropping %i left, %i right, "
+                    "giving %i, vs %i bp from fixed trimming\n"
+                    % (
+                        title.split(None, 1)[0],
+                        left,
+                        right,
+                        len(hmm_seq),
+                        len(full_seq) - exp_left - exp_right,
                     )
+                )
 
     if cropping_warning:
         sys.stderr.write(


### PR DESCRIPTION
This would close #85.

Also includes the primer citations in the command line help.

Updates the HMM cropping warning with the new post-trimming expected values (the HMM still assumes the 32bp of 18S has been cropped).