### PR TITLE
Option to keep temp files from thapbi classify

### DIFF
--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -133,11 +133,14 @@ def classify(args=None):
 
     if args.output:
         check_output_directory(args.output)
+    if args.temp:
+        check_output_directory(args.temp)
     return main(
         fasta=args.fasta,
         db_url=expand_database_argument(args.database, exist=True),
         method=args.method,
         out_dir=args.output,
+        tmp_dir=args.temp,
         debug=args.verbose,
         cpu=args.cpu,
     )
@@ -570,6 +573,15 @@ comma.
         metavar="DIRNAME",
         help="Directory to write output reports to, default (empty "
         "string) is next to each input file. Use '-' for stdout.",
+    )
+    parser_classify.add_argument(
+        "-t",
+        "--temp",
+        type=str,
+        required=False,
+        metavar="DIRNAME",
+        help="Debug option. Specify an (ideally empty) directory to "
+        "use for temporary files, which will not be deleted.",
     )
     parser_classify.add_argument(
         "-v", "--verbose", action="store_true", help="Verbose logging"

--- a/thapbi_pict/classify.py
+++ b/thapbi_pict/classify.py
@@ -653,45 +653,49 @@ def main(fasta, db_url, method, out_dir, tmp_dir, debug=False, cpu=0):
         if debug:
             sys.stderr.write("DEBUG: Output %s\n" % output_name)
 
-        # Context manager should remove this temp dir:
-        with tempfile.TemporaryDirectory(dir=shared_tmp) as tmp:
-            if debug:
-                sys.stderr.write("DEBUG: Temp folder of %s is %s\n" % (stem, tmp))
-            # Using same file names, but in tmp folder:
-            tmp_pred = os.path.join(tmp, "%s.%s.tsv" % (stem, method))
-            # Run the classifier and write the sequence report:
-            if output_name is None:
-                pred_handle = sys.stdout
-            else:
-                pred_handle = open(tmp_pred, "w")
+        tmp = os.path.join(shared_tmp, stem)
+        if not os.path.isdir(tmp):
+            # If using tempfile.TemporaryDirectory() for shared_tmp
+            # this will be deleted automatically, otherwise user must:
+            os.mkdir(tmp)
 
-            # Could write one column per db_sp_list entry, but would be very sparse.
-            pred_handle.write(
-                "#sequence-name\ttaxid\tgenus-species:%s\tnote\n" % ";".join(db_sp_list)
+        if debug:
+            sys.stderr.write("DEBUG: Temp folder of %s is %s\n" % (stem, tmp))
+        # Using same file names, but in tmp folder:
+        tmp_pred = os.path.join(tmp, "%s.%s.tsv" % (stem, method))
+        # Run the classifier and write the sequence report:
+        if output_name is None:
+            pred_handle = sys.stdout
+        else:
+            pred_handle = open(tmp_pred, "w")
+
+        # Could write one column per db_sp_list entry, but would be very sparse.
+        pred_handle.write(
+            "#sequence-name\ttaxid\tgenus-species:%s\tnote\n" % ";".join(db_sp_list)
+        )
+        if os.path.getsize(filename):
+            # There are sequences to classify
+            tax_counts = method_fn(
+                filename, session, pred_handle, tmp, shared_tmp, debug, cpu
             )
-            if os.path.getsize(filename):
-                # There are sequences to classify
-                tax_counts = method_fn(
-                    filename, session, pred_handle, tmp, shared_tmp, debug, cpu
-                )
-            else:
-                # No sequences, no taxonomy assignments
-                sys.stderr.write(
-                    "WARNING: Skipping %s classifier on %s as zero sequences\n"
-                    % (method, filename)
-                )
-                tax_counts = Counter()
-                pred_handle.write("#(no sequences to classify)\n")
+        else:
+            # No sequences, no taxonomy assignments
+            sys.stderr.write(
+                "WARNING: Skipping %s classifier on %s as zero sequences\n"
+                % (method, filename)
+            )
+            tax_counts = Counter()
+            pred_handle.write("#(no sequences to classify)\n")
 
-            # Record the taxonomy counts
-            count = sum(tax_counts.values())
-            seq_count += count
-            match_count += count - tax_counts.get("", 0)
+        # Record the taxonomy counts
+        count = sum(tax_counts.values())
+        seq_count += count
+        match_count += count - tax_counts.get("", 0)
 
-            if output_name is not None:
-                pred_handle.close()
-                # Move our temp file into position...
-                shutil.move(tmp_pred, output_name)
+        if output_name is not None:
+            pred_handle.close()
+            # Move our temp file into position...
+            shutil.move(tmp_pred, output_name)
 
     if tmp_dir:
         sys.stderr.write(


### PR DESCRIPTION
Wrote this as part of a branch which changed the classifier output.

Adding the option to preserve the temp files is extremely helpful for debugging.