### PR TITLE
Use Flash instead of Pear

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ This should automatically find the installed copy of the Python code.
 | v0.0.8  | 2019-02-21 | Fix multi-class TN under-counting. New loss metric, ``swarmid`` classifier.  |
 | v0.0.9  | 2019-03-05 | Looks for expected primers, discards mismatches. Caches HMM files locally.   |
 | v0.0.10 | 2019-03-06 | Replace primer code allowing only 1bp differences with ``cutadapt``.         |
-| v0.0.11 | *Pending*  | Speed up FASTQ preparation by using ``flash`` instead of ``pear`` v0.9.6.    |
+| v0.0.11 | 2019-03-08 | Speed up FASTQ preparation by using ``flash`` instead of ``pear`` v0.9.6.    |
 
 
 # Development Notes

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ This should automatically find the installed copy of the Python code.
 | v0.0.8  | 2019-02-21 | Fix multi-class TN under-counting. New loss metric, ``swarmid`` classifier.  |
 | v0.0.9  | 2019-03-05 | Looks for expected primers, discards mismatches. Caches HMM files locally.   |
 | v0.0.10 | 2019-03-06 | Replace primer code allowing only 1bp differences with ``cutadapt``.         |
+| v0.0.11 | *Pending*  | Speed up FASTQ preparation by using ``flash`` instead of ``pear`` v0.9.6.    |
 
 
 # Development Notes

--- a/requirements-ext.txt
+++ b/requirements-ext.txt
@@ -5,8 +5,8 @@
 
 blast
 cutadapt
+flash
 hmmer
-pear=0.9.6
 swarm
 trimmomatic
 unzip

--- a/tests/test_prepare-reads.sh
+++ b/tests/test_prepare-reads.sh
@@ -12,11 +12,11 @@ set -o pipefail
 # Try a real example
 rm -rf $TMP/DNAMIX_S95_L001.fasta
 thapbi_pict prepare-reads -o $TMP tests/reads/DNAMIX_S95_L001_*.fastq.gz -a 0
-if [ `grep -c "^>" $TMP/DNAMIX_S95_L001.fasta` -ne "929" ]; then echo "Wrong FASTA output count"; false; fi
+if [ `grep -c "^>" $TMP/DNAMIX_S95_L001.fasta` -ne "643" ]; then echo "Wrong FASTA output count"; false; fi
 
 rm -rf $TMP/DNAMIX_S95_L001.fasta
 thapbi_pict prepare-reads -o $TMP tests/reads/DNAMIX_S95_L001_*.fastq.gz -a 5
-if [ `grep -c "^>" $TMP/DNAMIX_S95_L001.fasta` -ne "24" ]; then echo "Wrong FASTA output count"; false; fi
+if [ `grep -c "^>" $TMP/DNAMIX_S95_L001.fasta` -ne "23" ]; then echo "Wrong FASTA output count"; false; fi
 
 echo "Generating mock control file"
 # Using just 50 real reads (50 * 4 = 200 lines)

--- a/tests/test_prepare-reads.sh
+++ b/tests/test_prepare-reads.sh
@@ -12,11 +12,11 @@ set -o pipefail
 # Try a real example
 rm -rf $TMP/DNAMIX_S95_L001.fasta
 thapbi_pict prepare-reads -o $TMP tests/reads/DNAMIX_S95_L001_*.fastq.gz -a 0
-if [ `grep -c "^>" $TMP/DNAMIX_S95_L001.fasta` -ne "643" ]; then echo "Wrong FASTA output count"; false; fi
+if [ `grep -c "^>" $TMP/DNAMIX_S95_L001.fasta` -ne "780" ]; then echo "Wrong FASTA output count"; false; fi
 
 rm -rf $TMP/DNAMIX_S95_L001.fasta
 thapbi_pict prepare-reads -o $TMP tests/reads/DNAMIX_S95_L001_*.fastq.gz -a 5
-if [ `grep -c "^>" $TMP/DNAMIX_S95_L001.fasta` -ne "23" ]; then echo "Wrong FASTA output count"; false; fi
+if [ `grep -c "^>" $TMP/DNAMIX_S95_L001.fasta` -ne "24" ]; then echo "Wrong FASTA output count"; false; fi
 
 echo "Generating mock control file"
 # Using just 50 real reads (50 * 4 = 200 lines)

--- a/thapbi_pict/__init__.py
+++ b/thapbi_pict/__init__.py
@@ -17,4 +17,4 @@ You would typically use THAPBI PICT via the command line tool it defines::
 
 """
 
-__version__ = "0.0.10"
+__version__ = "0.0.11"

--- a/thapbi_pict/prepare.py
+++ b/thapbi_pict/prepare.py
@@ -158,11 +158,14 @@ def run_cutadapt(
     return run(cmd, debug=debug)
 
 
-def run_pear(trimmed_R1, trimmed_R2, output_prefix, debug=False, cpu=0):
+def run_flash(trimmed_R1, trimmed_R2, output_dir, output_prefix, debug=False, cpu=0):
     """Run pear on a pair of trimmed FASTQ files."""
-    cmd = ["pear", "-f", trimmed_R1, "-r", trimmed_R2, "-o", output_prefix]
+    cmd = ["flash", "-M", "300"]  # Note our reads tend to overlap a lot!
     if cpu:
         cmd += ["--threads", str(cpu)]
+    else:
+        cmd += ["-t", "1"]  # Default is all CPUs
+    cmd += ["-d", output_dir, "-o", output_prefix, trimmed_R1, trimmed_R2]
     return run(cmd, debug=debug)
 
 
@@ -319,12 +322,11 @@ def prepare_sample(
         if not os.path.isfile(_):
             sys.exit("ERROR: Expected file %r from trimmomatic\n" % _)
 
-    # pear
-    pear_prefix = os.path.join(tmp, "pear")
-    merged_fastq = os.path.join(tmp, "pear.assembled.fastq")
-    run_pear(trim_R1, trim_R2, pear_prefix, debug=debug, cpu=cpu)
+    # flash
+    merged_fastq = os.path.join(tmp, "flash.extendedFrags.fastq")
+    run_flash(trim_R1, trim_R2, tmp, "flash", debug=debug, cpu=cpu)
     if not os.path.isfile(merged_fastq):
-        sys.exit("ERROR: Expected file %r from pear\n" % merged_fastq)
+        sys.exit("ERROR: Expected file %r from flash\n" % merged_fastq)
 
     # trim
     trimmed_fasta = os.path.join(tmp, "cutadapt.fasta")

--- a/thapbi_pict/prepare.py
+++ b/thapbi_pict/prepare.py
@@ -160,7 +160,9 @@ def run_cutadapt(
 
 def run_flash(trimmed_R1, trimmed_R2, output_dir, output_prefix, debug=False, cpu=0):
     """Run pear on a pair of trimmed FASTQ files."""
-    cmd = ["flash", "-M", "300"]  # Note our reads tend to overlap a lot!
+    # Note our reads tend to overlap a lot, thus increase max overlap with -M
+    # Also, some of our samples are mostly 'outies' rather than 'innies', so -O
+    cmd = ["flash", "-O", "-M", "300"]
     if cpu:
         cmd += ["--threads", str(cpu)]
     else:


### PR DESCRIPTION
Using flash takes about 10 minutes per plate to run ``thapbi_pict prepare-reads``, compared to several hours with pear (both using 4 threads). This would close #41.

For our control plate (with known single isolate samples), this makes no difference to the prepared reads (once the negative control based minimum abundance threshold is applied).

Over 10 plates, using a minimum abundance of 250 (on top of the plate specific minimums which default to 100 but can be about 1000), see only 7 unique sequence changes. There are substantially more changes below this threshold (also seen with recent primer changes, see e.g. #83, #85), suggesting that perhaps our current default minimum abundance of 100 is on the low side?