### PR TITLE
Fix sequences in DB without taxonomy

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ This should automatically find the installed copy of the Python code.
 | v0.0.11 | 2019-03-08 | Speed up FASTQ preparation by using ``flash`` instead of ``pear`` v0.9.6.    |
 | v0.0.12 | 2019-03-11 | Fixed bug in ``swarmid`` classifier.                                         |
 | v0.0.13 | 2019-03-22 | Remove conserved 32bp when primer trim. Assess at sample level by default.   |
-| v0.0.14 | *Pending*  | MD5 in dump output.                                                          |
+| v0.0.14 | *Pending*  | MD5 in dump output. Fixed importing sequences failing taxonomic validation.  |
 
 
 # Development Notes

--- a/tests/test_legacy-import.sh
+++ b/tests/test_legacy-import.sh
@@ -51,12 +51,12 @@ thapbi_pict legacy-import -d $DB database/legacy/Phytophthora_ITS_database_v0.00
 if [ `sqlite3 $DB "SELECT COUNT(DISTINCT species) FROM taxonomy;"` -ne "251" ]; then echo "Wrong species count"; false; fi
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM data_source;"` -ne "1" ]; then echo "Wrong data_source count"; false; fi
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM its1_source;"` -ne "175" ]; then echo "Wrong its1_source count"; false; fi
-if [ `sqlite3 $DB "SELECT COUNT(id) FROM its1_sequence;"` -ne "172" ]; then echo "Wrong its1_sequence count"; false; fi
+if [ `sqlite3 $DB "SELECT COUNT(id) FROM its1_sequence;"` -ne "159" ]; then echo "Wrong its1_sequence count"; false; fi
 thapbi_pict legacy-import -d $DB database/legacy/Phytophthora_ITS_database_v0.004.fasta -n "Legacy DB v0.004"
 if [ `sqlite3 $DB "SELECT COUNT(DISTINCT species) FROM taxonomy;"` -ne "251" ]; then echo "Wrong species count"; false; fi
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM data_source;"` -ne "2" ]; then echo "Wrong data_source count"; false; fi
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM its1_source;"` -ne "348" ]; then echo "Wrong its1_source count"; false; fi
-if [ `sqlite3 $DB "SELECT COUNT(id) FROM its1_sequence;"` -ne "172" ]; then echo "Wrong its1_sequence count"; false; fi
+if [ `sqlite3 $DB "SELECT COUNT(id) FROM its1_sequence;"` -ne "159" ]; then echo "Wrong its1_sequence count"; false; fi
 if [ `thapbi_pict dump -d $DB -f fasta | grep -c "^>"` -ne "348" ]; then echo "Wrong FASTA record count"; false; fi
 
 #thapbi_pict dump 2>&1 | grep "the following arguments are required"

--- a/tests/test_ncbi-import.sh
+++ b/tests/test_ncbi-import.sh
@@ -20,7 +20,7 @@ rm -rf $DB
 thapbi_pict ncbi-import -x -d $DB tests/ncbi-import/20th_Century_ITS1.fasta
 
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM data_source;"` -ne "1" ]; then echo "Wrong data_source count"; false; fi
-if [ `sqlite3 $DB "SELECT COUNT(id) FROM its1_sequence;"` -ne "96" ]; then echo "Wrong its1_sequence count"; false; fi
+if [ `sqlite3 $DB "SELECT COUNT(id) FROM its1_sequence;"` -ne "90" ]; then echo "Wrong its1_sequence count"; false; fi
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM taxonomy;"` -ne "42" ]; then echo "Wrong taxonomy count"; false; fi
 # Other values subject to change
 
@@ -37,7 +37,7 @@ if [ `sqlite3 $DB "SELECT COUNT(DISTINCT species) FROM taxonomy;"` -ne "251" ]; 
 thapbi_pict ncbi-import -d $DB tests/ncbi-import/20th_Century_ITS1.fasta
 if [ `sqlite3 $DB "SELECT COUNT(DISTINCT species) FROM taxonomy;"` -ne "251" ]; then echo "Wrong species count"; false; fi
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM data_source;"` -ne "1" ]; then echo "Wrong data_source count"; false; fi
-if [ `sqlite3 $DB "SELECT COUNT(id) FROM its1_sequence;"` -ne "96" ]; then echo "Wrong its1_sequence count"; false; fi
+if [ `sqlite3 $DB "SELECT COUNT(id) FROM its1_sequence;"` -ne "87" ]; then echo "Wrong its1_sequence count"; false; fi
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM taxonomy;"` -ne "251" ]; then echo "Wrong taxonomy count"; false; fi
 # Other values subject to change
 

--- a/thapbi_pict/__init__.py
+++ b/thapbi_pict/__init__.py
@@ -17,4 +17,4 @@ You would typically use THAPBI PICT via the command line tool it defines::
 
 """
 
-__version__ = "0.0.13"
+__version__ = "0.0.14"

--- a/thapbi_pict/db_import.py
+++ b/thapbi_pict/db_import.py
@@ -325,13 +325,20 @@ def import_fasta_file(
                 its1 = ITS1(md5=its1_md5, sequence=its1_seq)
                 session.add(its1)
             good_seq_count += 1
+
         for entry, clade, genus, species, taxid, taxonomy in accepted_entries:
             if taxonomy is None:
                 assert not validate_species
-                taxonomy = Taxonomy(
-                    clade=clade, genus=genus, species=species, ncbi_taxid=taxid
-                )
-                session.add(taxonomy)
+                # A previous entry in this match could have had same sp,
+                assert not taxid
+                taxonomy = lookup_taxonomy(session, clade, genus, species)
+                if taxonomy is None:
+                    taxonomy = Taxonomy(
+                        clade=clade, genus=genus, species=species, ncbi_taxid=taxid
+                    )
+                    session.add(taxonomy)
+
+            assert taxonomy is not None
             # Note we use the original FASTA identifier for traceablity
             # but means the multi-entries get the same source accession
             record_entry = SequenceSource(


### PR DESCRIPTION
This fixes #103, and adds run-time checks to the classify code.

Can look for historic cases with grep on the classifier output, ``"No taxonomy entries"``

Does not affect our control plate (so can't assess the impact directly), but can see this changes the best BLAST hit results for:
- ``11685e5efd7cd8d8cf36b861900125c5`` to just has no hits.
- ``3ed0b33c5a491ea78a430e2e8ff21885`` to a multi-species tie (2 BLAST hits), 
- ``3f95e50b73ba20cd2d7c9969b4122e58`` to a multi-species tie (2 BLAST hits), 
- ``6f8d878e5956f93fc6801f98f58e58e2`` to a two species tie (2 BLAST hits)
- ``6fb11a824339126bdb46fd4d961eaffe`` now simply has no hits.
- ``9f0520fae750e705aa80e4c2f77d8ce5`` to *Phytophthora inundata*, 
- ``b36eeb7857c53d57ed0fc4c95f3da5a5`` to *Phytophthora chlamydospora*, 
- ``bb54f484b64f543464dc6f8020d9592c`` to two species (1 BLAST hit)
- ``ff93aa547e8e3c627c33f560fd1601c0``  to a multi-species tie (7 BLAST hits), 

i.e. We might have more TP and FP now with BLAST.

Regarding the other classifiers, no change noticed.