### PR TITLE
Include sample metadata in reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ This should automatically find the installed copy of the Python code.
 | v0.1.0  | 2019-04-04 | Include a bundled ITS1 database.                                             |
 | v0.1.1  | 2019-04-16 | Expand default taxonomy and database from Peronosporaceae to Peronosporales. |
 | v0.1.2  | 2019-04-17 | Keep searching if ``onebp`` classifier perfect match is at genus-level only. |
+| v0.1.3  | 2019-04-17 | Can optionally display sample metadata from TSV file in summary reports.     |
 
 
 # Development Notes

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ This should automatically find the installed copy of the Python code.
 | v0.1.0  | 2019-04-04 | Include a bundled ITS1 database.                                             |
 | v0.1.1  | 2019-04-16 | Expand default taxonomy and database from Peronosporaceae to Peronosporales. |
 | v0.1.2  | 2019-04-17 | Keep searching if ``onebp`` classifier perfect match is at genus-level only. |
-| v0.1.3  | 2019-04-17 | Can optionally display sample metadata from TSV file in summary reports.     |
+| v0.1.3  | 2019-04-24 | Can optionally display sample metadata from TSV file in summary reports.     |
 
 
 # Development Notes

--- a/thapbi_pict/__init__.py
+++ b/thapbi_pict/__init__.py
@@ -17,4 +17,4 @@ You would typically use THAPBI PICT via the command line tool it defines::
 
 """
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"

--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -188,6 +188,7 @@ def plate_summary(args=None):
         min_abundance=args.abundance,
         metadata_file=args.metadata,
         metadata_cols=args.metacols,
+        metadata_name=args.metaname,
         debug=args.verbose,
     )
 
@@ -208,6 +209,7 @@ def sample_summary(args=None):
         min_abundance=args.abundance,
         metadata_file=args.metadata,
         metadata_cols=args.metacols,
+        metadata_name=args.metaname,
         debug=args.verbose,
     )
 
@@ -823,6 +825,16 @@ comma.
         "Use in conjunction with -m / --metadata argument.",
     )
     parser_plate_summary.add_argument(
+        "-n",
+        "--metaname",
+        type=int,
+        default="1",
+        metavar="ROW",
+        help="If using metadata, which row should be used as the field names? "
+        "Default 1, use 0 for no labels. "
+        "Use in conjunction with -m / --metadata argument.",
+    )
+    parser_plate_summary.add_argument(
         "-v", "--verbose", action="store_true", help="Verbose logging"
     )
     parser_plate_summary.set_defaults(func=plate_summary)
@@ -902,6 +914,16 @@ comma.
         "human reable report (e.g, 1,3,5), and the column containing the sample "
         "name as used in the filename stems (e.g. 2) expressed as '2:1,3,5' "
         "(index column, colon, comma separated list of columns to output). "
+        "Use in conjunction with -m / --metadata argument.",
+    )
+    parser_sample_summary.add_argument(
+        "-n",
+        "--metaname",
+        type=int,
+        default="1",
+        metavar="ROW",
+        help="If using metadata, which row should be used as the field names? "
+        "Default 1, use 0 for no labels. "
         "Use in conjunction with -m / --metadata argument.",
     )
     parser_sample_summary.add_argument(

--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -189,6 +189,7 @@ def plate_summary(args=None):
         metadata_file=args.metadata,
         metadata_cols=args.metacols,
         metadata_name=args.metaname,
+        metadata_index=args.metaindex,
         debug=args.verbose,
     )
 
@@ -210,6 +211,7 @@ def sample_summary(args=None):
         metadata_file=args.metadata,
         metadata_cols=args.metacols,
         metadata_name=args.metaname,
+        metadata_index=args.metaindex,
         debug=args.verbose,
     )
 
@@ -818,11 +820,22 @@ comma.
         type=str,
         default="",
         metavar="COLUMNS",
-        help="Optional description of the metadata columns to include in the "
-        "human reable report (e.g, 1,3,5), and index column containing semi-colon "
-        "separated sample name stem(s) as used in the sample filenames (e.g. 2) "
-        "expressed as '2:1,3,5' (index column, colon, comma separated list of "
-        "columns to output). Use in conjunction with -m / --metadata argument.",
+        help="Comma separated list (e.g, '1,3,5') of columns from the metadata "
+        "table specified with the -m / --metadata argument to be included in the "
+        "human readable report. Use in conjunction with -m / --metadata argument.",
+    )
+    parser_plate_summary.add_argument(
+        "-x",
+        "--metaindex",
+        type=int,
+        default="0",
+        metavar="COL",
+        help="If using metadata, which column contains the (stem of) the sample "
+        "filenames. Default is the first column requested as metadata output "
+        "with the -c / --metacols argument. This column can contain multiple "
+        "semi-colon separated name stems catering to the fact that a field "
+        "sample could be sequenced multiple times with technical replicates. "
+        "Filenames are matched by removing underscore separated suffixes.",
     )
     parser_plate_summary.add_argument(
         "-n",
@@ -910,11 +923,22 @@ comma.
         type=str,
         default="",
         metavar="COLUMNS",
-        help="Optional description of the metadata columns to include in the "
-        "human reable report (e.g, 1,3,5), and index column containing semi-colon "
-        "separated sample name stem(s) as used in the sample filenames (e.g. 2) "
-        "expressed as '2:1,3,5' (index column, colon, comma separated list of "
-        "columns to output). Use in conjunction with -m / --metadata argument.",
+        help="Comma separated list (e.g, '1,3,5') of columns from the metadata "
+        "table specified with the -m / --metadata argument to be included in the "
+        "report header. Use in conjunction with -m / --metadata argument.",
+    )
+    parser_sample_summary.add_argument(
+        "-x",
+        "--metaindex",
+        type=int,
+        default="0",
+        metavar="COL",
+        help="If using metadata, which column contains the (stem of) the sample "
+        "filenames. Default is the first column requested as metadata output "
+        "with the -c / --metacols argument. This column can contain multiple "
+        "semi-colon separated name stems catering to the fact that a field "
+        "sample could be sequenced multiple times with technical replicates. "
+        "Filenames are matched by removing underscore separated suffixes.",
     )
     parser_sample_summary.add_argument(
         "-n",

--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -13,6 +13,12 @@ from . import __version__
 from .classify import method_classifier
 
 
+def check_input_file(filename):
+    """Command line validation of an input filename."""
+    if not os.path.isfile(filename):
+        sys.exit("ERROR: Could not find input file: %s" % filename)
+
+
 def check_output_directory(out_dir):
     """Command line validation of output directory value."""
     if out_dir == "-" or os.path.isdir(out_dir):
@@ -171,11 +177,17 @@ def plate_summary(args=None):
     """Subcommand to run per-output-folder summary at sequence level."""
     from .summary import main
 
+    if args.metadata:
+        check_input_file(args.metadata)
+        if not args.metacols:
+            sys.exit("ERROR: Must also supply -c / --metacols argument.")
     return main(
         inputs=args.inputs,
         output=args.output,
         method=args.method,
         min_abundance=args.abundance,
+        metadata_file=args.metadata,
+        metadata_cols=args.metacols,
         debug=args.verbose,
     )
 
@@ -184,12 +196,18 @@ def sample_summary(args=None):
     """Subcommand to run multiple-output-folder summary at sample level."""
     from .sample_summary import main
 
+    if args.metadata:
+        check_input_file(args.metadata)
+        if not args.metacols:
+            sys.exit("ERROR: Must also supply -c / --metacols argument.")
     return main(
         inputs=args.inputs,
         output=args.output,
         human_output=args.human,
         method=args.method,
         min_abundance=args.abundance,
+        metadata_file=args.metadata,
+        metadata_cols=args.metacols,
         debug=args.verbose,
     )
 
@@ -783,6 +801,28 @@ comma.
         "Default is '-' meaning to stdout.",
     )
     parser_plate_summary.add_argument(
+        "-t",
+        "--metadata",
+        type=str,
+        default="",
+        metavar="FILENAME",
+        help="Optional tab separated table containing metadata indexed by "
+        "sample name. Must also specify the columns with -c / --metacols, "
+        "and then this information will be included as extra header rows.",
+    )
+    parser_plate_summary.add_argument(
+        "-c",
+        "--metacols",
+        type=str,
+        default="",
+        metavar="COLUMNS",
+        help="Optional description of the metadata columns to include in the "
+        "output (e.g, 1,3,5), and the column containing the sample name as "
+        "used in the filename stems (e.g. 2) expressed as '2:1,3,5' "
+        "(index column, colon, comma separated list of columns to output). "
+        "Use in conjunction with -m / --metadata argument.",
+    )
+    parser_plate_summary.add_argument(
         "-v", "--verbose", action="store_true", help="Verbose logging"
     )
     parser_plate_summary.set_defaults(func=plate_summary)
@@ -840,6 +880,29 @@ comma.
         metavar="FILENAME",
         help="File to write human readable smaple level species predictions to. "
         "Can use '-' meaning to stdout. Default is not to write this file.",
+    )
+    parser_sample_summary.add_argument(
+        "-t",
+        "--metadata",
+        type=str,
+        default="",
+        metavar="FILENAME",
+        help="Optional tab separated table containing metadata indexed by "
+        "sample name. Must also specify the columns with -c / --metacols, "
+        "and then this information will be included in the human readable "
+        "report output.",
+    )
+    parser_sample_summary.add_argument(
+        "-c",
+        "--metacols",
+        type=str,
+        default="",
+        metavar="COLUMNS",
+        help="Optional description of the metadata columns to include in the "
+        "human reable report (e.g, 1,3,5), and the column containing the sample "
+        "name as used in the filename stems (e.g. 2) expressed as '2:1,3,5' "
+        "(index column, colon, comma separated list of columns to output). "
+        "Use in conjunction with -m / --metadata argument.",
     )
     parser_sample_summary.add_argument(
         "-v", "--verbose", action="store_true", help="Verbose logging"

--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -808,8 +808,8 @@ comma.
         type=str,
         default="",
         metavar="FILENAME",
-        help="Optional tab separated table containing metadata indexed by "
-        "sample name. Must also specify the columns with -c / --metacols, "
+        help="Optional tab separated table containing metadata indexed by (stem "
+        "of) sample name. Must also specify the columns with -c / --metacols, "
         "and then this information will be included as extra header rows.",
     )
     parser_plate_summary.add_argument(
@@ -819,10 +819,10 @@ comma.
         default="",
         metavar="COLUMNS",
         help="Optional description of the metadata columns to include in the "
-        "output (e.g, 1,3,5), and the column containing the sample name as "
-        "used in the filename stems (e.g. 2) expressed as '2:1,3,5' "
-        "(index column, colon, comma separated list of columns to output). "
-        "Use in conjunction with -m / --metadata argument.",
+        "human reable report (e.g, 1,3,5), and index column containing semi-colon "
+        "separated sample name stem(s) as used in the sample filenames (e.g. 2) "
+        "expressed as '2:1,3,5' (index column, colon, comma separated list of "
+        "columns to output). Use in conjunction with -m / --metadata argument.",
     )
     parser_plate_summary.add_argument(
         "-n",
@@ -899,8 +899,8 @@ comma.
         type=str,
         default="",
         metavar="FILENAME",
-        help="Optional tab separated table containing metadata indexed by "
-        "sample name. Must also specify the columns with -c / --metacols, "
+        help="Optional tab separated table containing metadata indexed by (stem "
+        "of) sample name. Must also specify the columns with -c / --metacols, "
         "and then this information will be included in the human readable "
         "report output.",
     )
@@ -911,10 +911,10 @@ comma.
         default="",
         metavar="COLUMNS",
         help="Optional description of the metadata columns to include in the "
-        "human reable report (e.g, 1,3,5), and the column containing the sample "
-        "name as used in the filename stems (e.g. 2) expressed as '2:1,3,5' "
-        "(index column, colon, comma separated list of columns to output). "
-        "Use in conjunction with -m / --metadata argument.",
+        "human reable report (e.g, 1,3,5), and index column containing semi-colon "
+        "separated sample name stem(s) as used in the sample filenames (e.g. 2) "
+        "expressed as '2:1,3,5' (index column, colon, comma separated list of "
+        "columns to output). Use in conjunction with -m / --metadata argument.",
     )
     parser_sample_summary.add_argument(
         "-n",

--- a/thapbi_pict/sample_summary.py
+++ b/thapbi_pict/sample_summary.py
@@ -25,6 +25,7 @@ def main(
     metadata_file=None,
     metadata_cols=None,
     metadata_name=None,
+    metadata_index=None,
     debug=False,
 ):
     """Implement the thapbi_pict sample-summary command.
@@ -38,7 +39,7 @@ def main(
         sys.exit("ERROR: No output file specified.\n")
 
     metadata, meta_names, meta_default = load_metadata(
-        metadata_file, metadata_cols, metadata_name, debug=debug
+        metadata_file, metadata_cols, metadata_name, metadata_index, debug=debug
     )
 
     samples = set()

--- a/thapbi_pict/sample_summary.py
+++ b/thapbi_pict/sample_summary.py
@@ -24,6 +24,7 @@ def main(
     min_abundance=1,
     metadata_file=None,
     metadata_cols=None,
+    metadata_name=None,
     debug=False,
 ):
     """Implement the thapbi_pict sample-summary command.
@@ -36,7 +37,9 @@ def main(
     if not (output or human_output):
         sys.exit("ERROR: No output file specified.\n")
 
-    metadata, meta_default = load_metadata(metadata_file, metadata_cols)
+    metadata, meta_names, meta_default = load_metadata(
+        metadata_file, metadata_cols, metadata_name, debug=debug
+    )
 
     samples = set()
     counts = Counter()
@@ -127,10 +130,11 @@ def main(
             try:
                 human.write("%s\n" % sample)
                 if metadata:
-                    for value in find_metadata(sample, metadata, meta_default):
-                        # Don't currently have names of the meta-data fields
+                    for name, value in zip(
+                        meta_names, find_metadata(sample, metadata, meta_default)
+                    ):
                         if value:
-                            human.write("%s\n" % value)
+                            human.write("%s: %s\n" % (name, value))
                 human.write("\n")
                 for sp in sorted(all_sp):
                     if sp not in unambig_sp:

--- a/thapbi_pict/sample_summary.py
+++ b/thapbi_pict/sample_summary.py
@@ -131,7 +131,8 @@ def main(
                 human.write("%s\n" % sample)
                 if metadata:
                     for name, value in zip(
-                        meta_names, find_metadata(sample, metadata, meta_default)
+                        meta_names,
+                        find_metadata(sample, metadata, meta_default, debug=debug),
                     ):
                         if value:
                             human.write("%s: %s\n" % (name, value))

--- a/thapbi_pict/summary.py
+++ b/thapbi_pict/summary.py
@@ -26,6 +26,7 @@ def main(
     metadata_file=None,
     metadata_cols=None,
     metadata_name=None,
+    metadata_index=None,
     debug=False,
 ):
     """Implement the thapbi_pict plate-summary command.
@@ -39,7 +40,7 @@ def main(
         sys.exit("ERROR: No output file specified.\n")
 
     metadata, meta_names, meta_default = load_metadata(
-        metadata_file, metadata_cols, metadata_name, debug=debug
+        metadata_file, metadata_cols, metadata_name, metadata_index, debug=debug
     )
 
     samples = set()

--- a/thapbi_pict/summary.py
+++ b/thapbi_pict/summary.py
@@ -25,6 +25,7 @@ def main(
     min_abundance=1,
     metadata_file=None,
     metadata_cols=None,
+    metadata_name=None,
     debug=False,
 ):
     """Implement the thapbi_pict plate-summary command.
@@ -37,7 +38,9 @@ def main(
     if not output:
         sys.exit("ERROR: No output file specified.\n")
 
-    metadata, meta_default = load_metadata(metadata_file, metadata_cols)
+    metadata, meta_names, meta_default = load_metadata(
+        metadata_file, metadata_cols, metadata_name, debug=debug
+    )
 
     samples = set()
     md5_abundance = Counter()
@@ -98,12 +101,15 @@ def main(
     if metadata:
         # Insert extra header rows at start for sample meta-data
         # Note currently we don't have the meta-data field names
-        for i in range(len(meta_default)):
+        for i, name in enumerate(meta_names):
             handle.write(
-                "#\t\t\t\t\t%s\n"
-                % "\t".join(
-                    find_metadata(sample, metadata, meta_default)[i]
-                    for sample in samples
+                "#\t\t\t\t%s\t%s\n"
+                % (
+                    name,
+                    "\t".join(
+                        find_metadata(sample, metadata, meta_default)[i]
+                        for sample in samples
+                    ),
                 )
             )
     handle.write(

--- a/thapbi_pict/summary.py
+++ b/thapbi_pict/summary.py
@@ -100,18 +100,13 @@ def main(
 
     if metadata:
         # Insert extra header rows at start for sample meta-data
-        # Note currently we don't have the meta-data field names
+        # Make a single metadata call for each sample
+        meta = [
+            find_metadata(sample, metadata, meta_default, debug=debug)
+            for sample in samples
+        ]
         for i, name in enumerate(meta_names):
-            handle.write(
-                "#\t\t\t\t%s\t%s\n"
-                % (
-                    name,
-                    "\t".join(
-                        find_metadata(sample, metadata, meta_default, debug=debug)[i]
-                        for sample in samples
-                    ),
-                )
-            )
+            handle.write("#\t\t\t\t%s\t%s\n" % (name, "\t".join(_[i] for _ in meta)))
     handle.write(
         "#ITS1-MD5\t%s-predictions\tSequence\tSample-count\tTotal-abundance\t%s\n"
         % (",".join(methods), "\t".join(samples))

--- a/thapbi_pict/summary.py
+++ b/thapbi_pict/summary.py
@@ -107,7 +107,7 @@ def main(
                 % (
                     name,
                     "\t".join(
-                        find_metadata(sample, metadata, meta_default)[i]
+                        find_metadata(sample, metadata, meta_default, debug=debug)[i]
                         for sample in samples
                     ),
                 )

--- a/thapbi_pict/utils.py
+++ b/thapbi_pict/utils.py
@@ -505,10 +505,14 @@ def load_metadata(metadata_file, metadata_cols, metadata_name_row=1, debug=False
                     )
                     continue
                 else:
-                    sys.exit(
-                        "ERROR: Conflicting metadata for %s\nOld:%r\nNew:%r\n"
-                        % (parts[sample_col], meta[sample], values)
+                    sys.stderr.write(
+                        "WARNING: Dropping conflicting metadata for %s\n"
+                        "Old:%r\nNew:%r\n" % (parts[sample_col], meta[sample], values)
                     )
+                    values = [
+                        old if old == new else "ERROR"
+                        for (old, new) in zip(meta[sample], values)
+                    ]
             meta[sample] = values
     return meta, names, default
 

--- a/thapbi_pict/utils.py
+++ b/thapbi_pict/utils.py
@@ -474,7 +474,7 @@ def load_metadata(metadata_file, metadata_cols, metadata_name_row=1, debug=False
     if not metadata_file or not metadata_cols:
         if debug:
             sys.stderr.write("DEBUG: Not loading any metadata\n")
-        return {}, []
+        return {}, [], []
 
     sample_col = int(metadata_cols.split(":", 1)[0]) - 1
     value_cols = [int(_) - 1 for _ in metadata_cols.split(":", 1)[1].split(",")]

--- a/thapbi_pict/utils.py
+++ b/thapbi_pict/utils.py
@@ -458,9 +458,8 @@ def load_metadata(metadata_file, metadata_cols, metadata_name_row=1, debug=False
     sample name index column, colon, comma separated list of columns to
     output. The column numbers are assumed to be one based.
 
-    Returns a dictionary indexed by sample name (with underscores and
-    spaces mapped to minus signs; see find_metadata function), and a
-    default value (list of empty strings).
+    Returns a dictionary indexed by sample name, and a default value
+    (list of empty strings).
     """
     # TODO - Accept Excel style A, ..., Z, AA, ... column names?
 
@@ -504,7 +503,7 @@ def load_metadata(metadata_file, metadata_cols, metadata_name_row=1, debug=False
             parts = line.rstrip(b"\n").split(b"\t")
             # Only decode the fields we want
             try:
-                sample = parts[sample_col].decode().replace(" ", "-").replace("_", "-")
+                sample = parts[sample_col].decode()
             except UnicodeDecodeError:
                 sys.exit(
                     "ERROR: Sample column not using system default encoding: %r\n"
@@ -540,22 +539,18 @@ def load_metadata(metadata_file, metadata_cols, metadata_name_row=1, debug=False
     return meta, names, default
 
 
-def find_metadata(sample, metadata, default, debug=False):
+def find_metadata(sample, metadata, default, sep="_", debug=False):
     """Lookup sample in metadata dictionary, trying stem as key.
 
-    Maps any spaces or underscores in the sample name to minus signs,
-    and then breaks the name at minus signs removing one suffix at a
-    time until it finds a match.
-
-    e.g. Will match sample name of N01_160517_101_R_A12 to a metadata
-    entry N01_160517_101
+    Will match sample name of N01_160517_101_R_A12 to a metadata
+    entry N01_160517_101 (removing words using the given separator).
     """
-    key = sample.replace(" ", "-").replace("_", "-")
+    key = sample
     if key in metadata:
         return metadata[key]
-    while "-" in key:
+    while sep in key:
         # Remove next chunk of name
-        key = key.rsplit("-", 1)[0]
+        key = key.rsplit(sep, 1)[0]
         if key in metadata:
             return metadata[key]
     if debug:

--- a/thapbi_pict/utils.py
+++ b/thapbi_pict/utils.py
@@ -497,6 +497,18 @@ def load_metadata(metadata_file, metadata_cols, metadata_name_row=1, debug=False
             parts = line.rstrip("\n").split("\t")
             sample = parts[sample_col].replace(" ", "-").replace("_", "-")
             values = [parts[_] for _ in value_cols]
+            if sample in meta:
+                # Bad... note using the unedited sample name for the messages
+                if meta[sample] == values:
+                    sys.stderr.write(
+                        "WARNING: Duplicated metadata for %s\n" % parts[sample_col]
+                    )
+                    continue
+                else:
+                    sys.exit(
+                        "ERROR: Conflicting metadata for %s\nOld:%r\nNew:%r\n"
+                        % (parts[sample_col], meta[sample], values)
+                    )
             meta[sample] = values
     return meta, names, default
 

--- a/thapbi_pict/utils.py
+++ b/thapbi_pict/utils.py
@@ -517,6 +517,9 @@ def load_metadata(metadata_file, metadata_cols, metadata_name_row=1, debug=False
                     "ERROR: Metadata for sample %s not using system default encoding\n"
                     % sample
                 )
+            if not sample:
+                # Not all our field samples will have been sequenced yet
+                continue
             if sample in meta:
                 # Bad... note using the unedited sample name for the messages
                 if meta[sample] == values:
@@ -537,7 +540,7 @@ def load_metadata(metadata_file, metadata_cols, metadata_name_row=1, debug=False
     return meta, names, default
 
 
-def find_metadata(sample, metadata, default):
+def find_metadata(sample, metadata, default, debug=False):
     """Lookup sample in metadata dictionary, trying stem as key.
 
     Maps any spaces or underscores in the sample name to minus signs,
@@ -547,12 +550,14 @@ def find_metadata(sample, metadata, default):
     e.g. Will match sample name of N01_160517_101_R_A12 to a metadata
     entry N01_160517_101
     """
-    sample = sample.replace(" ", "-").replace("_", "-")
-    if sample in metadata:
-        return metadata[sample]
-    while "-" in sample:
+    key = sample.replace(" ", "-").replace("_", "-")
+    if key in metadata:
+        return metadata[key]
+    while "-" in key:
         # Remove next chunk of name
-        sample = sample.rsplit("-", 1)[0]
-        if sample in metadata:
-            return metadata[sample]
+        key = key.rsplit("-", 1)[0]
+        if key in metadata:
+            return metadata[key]
+    if debug:
+        sys.stderr.write("DEBUG: Missing metadata for %s\n" % sample)
     return default

--- a/thapbi_pict/utils.py
+++ b/thapbi_pict/utils.py
@@ -458,8 +458,9 @@ def load_metadata(metadata_file, metadata_cols, metadata_name_row=1, debug=False
     sample name index column, colon, comma separated list of columns to
     output. The column numbers are assumed to be one based.
 
-    Returns a dictionary indexed by sample name, and a default value
-    (list of empty strings).
+    Returns a dictionary indexed by sample name (with underscores and
+    spaces mapped to minus signs; see find_metadata function), and a
+    default value (list of empty strings).
     """
     # TODO - Accept Excel style A, ..., Z, AA, ... column names?
 
@@ -494,23 +495,28 @@ def load_metadata(metadata_file, metadata_cols, metadata_name_row=1, debug=False
             if line.startswith("#"):
                 continue
             parts = line.rstrip("\n").split("\t")
-            sample = parts[sample_col]
+            sample = parts[sample_col].replace(" ", "-").replace("_", "-")
             values = [parts[_] for _ in value_cols]
             meta[sample] = values
     return meta, names, default
 
 
-def find_metadata(sample, metadata, default, sep="_"):
+def find_metadata(sample, metadata, default):
     """Lookup sample in metadata dictionary, trying stem as key.
 
-    Will match sample name of N01_160517_101_R_A12 to a metadata
-    entry N01_160517_101 (removing words using the given separator).
+    Maps any spaces or underscores in the sample name to minus signs,
+    and then breaks the name at minus signs removing one suffix at a
+    time until it finds a match.
+
+    e.g. Will match sample name of N01_160517_101_R_A12 to a metadata
+    entry N01_160517_101
     """
+    sample = sample.replace(" ", "-").replace("_", "-")
     if sample in metadata:
         return metadata[sample]
-    while sep in sample:
+    while "-" in sample:
         # Remove next chunk of name
-        sample = sample.rsplit(sep, 1)[0]
+        sample = sample.rsplit("-", 1)[0]
         if sample in metadata:
             return metadata[sample]
     return default

--- a/thapbi_pict/utils.py
+++ b/thapbi_pict/utils.py
@@ -455,6 +455,7 @@ def load_metadata(
     metadata_file,
     metadata_cols,
     metadata_name_row=1,
+    metadata_index=0,
     metadata_index_sep=";",
     debug=False,
 ):
@@ -486,8 +487,28 @@ def load_metadata(
             sys.stderr.write("DEBUG: Not loading any metadata\n")
         return {}, [], []
 
-    sample_col = int(metadata_cols.split(":", 1)[0]) - 1
-    value_cols = [int(_) - 1 for _ in metadata_cols.split(":", 1)[1].split(",")]
+    try:
+        value_cols = [int(_) - 1 for _ in metadata_cols.split(",")]
+    except ValueError:
+        sys.exit(
+            "ERROR: Output metadata columns should be a comma separated list "
+            "of positive integers, not %r." % metadata_cols
+        )
+    if min(value_cols) < 0:
+        sys.exit("ERROR: Invalid metadata output column, should all be positive.")
+    if metadata_index:
+        sample_col = int(metadata_index) - 1
+        if sample_col < 0:
+            sys.exit(
+                "ERROR: Invalid metadata index column, should be positive, not %r."
+                % metadata_index
+            )
+    else:
+        sample_col = value_cols[0]  # Default is first output column
+    if debug:
+        sys.stderr.write(
+            "DEBUG: Matching sample names to metadata column %i\n" % (sample_col + 1)
+        )
     names = [""] * len(value_cols)  # default
     meta = {}
     default = [""] * len(value_cols)


### PR DESCRIPTION
Extends the ``thapbi_pict sample-summary ...`` (human readable output) and ``thapbi_pict plate-summary ...`` (big table) with sample metadata.

Requires a TSV version of a sample spreadsheet (with any encoding issue fixed, eg apostrophes).