### PR TITLE
Sort samples in reports using the metadata columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ This should automatically find the installed copy of the Python code.
 | v0.1.1  | 2019-04-16 | Expand default taxonomy and database from Peronosporaceae to Peronosporales. |
 | v0.1.2  | 2019-04-17 | Keep searching if ``onebp`` classifier perfect match is at genus-level only. |
 | v0.1.3  | 2019-04-24 | Can optionally display sample metadata from TSV file in summary reports.     |
+| v0.1.4  | 2019-04-25 | Sort samples using the optional metadata fields requested in reports.        |
 
 
 # Development Notes

--- a/thapbi_pict/__init__.py
+++ b/thapbi_pict/__init__.py
@@ -17,4 +17,4 @@ You would typically use THAPBI PICT via the command line tool it defines::
 
 """
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"

--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -822,7 +822,8 @@ comma.
         metavar="COLUMNS",
         help="Comma separated list (e.g, '1,3,5') of columns from the metadata "
         "table specified with the -m / --metadata argument to be included in the "
-        "human readable report. Use in conjunction with -m / --metadata argument.",
+        "human readable report, and use to sort the samples. Use in conjunction "
+        "with -m / --metadata argument.",
     )
     parser_plate_summary.add_argument(
         "-x",
@@ -925,7 +926,8 @@ comma.
         metavar="COLUMNS",
         help="Comma separated list (e.g, '1,3,5') of columns from the metadata "
         "table specified with the -m / --metadata argument to be included in the "
-        "report header. Use in conjunction with -m / --metadata argument.",
+        "report header, and use to sort the samples. Use in conjunction with "
+        "-m / --metadata argument.",
     )
     parser_sample_summary.add_argument(
         "-x",

--- a/thapbi_pict/sample_summary.py
+++ b/thapbi_pict/sample_summary.py
@@ -74,6 +74,17 @@ def main(
     if debug:
         sys.stderr.write("Loaded predictions for %i samples\n" % len(samples))
 
+    samples = sample_sort(samples)
+    sample_metadata = {}
+    if metadata:
+        for sample in samples:
+            sample_metadata[sample] = find_metadata(
+                sample, metadata, meta_default, debug=debug
+            )
+        # Sort samples using metadata:
+        samples = sample_sort(samples, [sample_metadata[_] for _ in samples])
+    del metadata
+
     if output == "-":
         if debug:
             sys.stderr.write("DEBUG: Output to stdout...\n")
@@ -101,7 +112,7 @@ def main(
             "Phytophthora andina, P. infestans, and P. ipomoeae, share an identical "
             "marker.\n\n"
         )
-    for sample in sample_sort(samples):
+    for sample in samples:
         all_sp = set()
         unambig_sp = set()
         for sp in sp_to_taxid:
@@ -130,11 +141,8 @@ def main(
         if human:
             try:
                 human.write("%s\n" % sample)
-                if metadata:
-                    for name, value in zip(
-                        meta_names,
-                        find_metadata(sample, metadata, meta_default, debug=debug),
-                    ):
+                if sample_metadata:
+                    for name, value in zip(meta_names, sample_metadata[sample]):
                         if value:
                             human.write("%s: %s\n" % (name, value))
                 human.write("\n")

--- a/thapbi_pict/summary.py
+++ b/thapbi_pict/summary.py
@@ -67,6 +67,16 @@ def main(
                 md5_species[md5] = set()
     samples = sample_sort(samples)
 
+    sample_metadata = {}
+    if metadata:
+        for sample in samples:
+            sample_metadata[sample] = find_metadata(
+                sample, metadata, meta_default, debug=debug
+            )
+        # Sort samples using metadata:
+        samples = sample_sort(samples, [sample_metadata[_] for _ in samples])
+    del metadata
+
     methods = method.split(",")
     for method in methods:
         if debug:
@@ -99,13 +109,10 @@ def main(
     else:
         handle = open(output, "w")
 
-    if metadata:
+    if sample_metadata:
         # Insert extra header rows at start for sample meta-data
         # Make a single metadata call for each sample
-        meta = [
-            find_metadata(sample, metadata, meta_default, debug=debug)
-            for sample in samples
-        ]
+        meta = [sample_metadata[sample] for sample in samples]
         for i, name in enumerate(meta_names):
             handle.write("#\t\t\t\t%s\t%s\n" % (name, "\t".join(_[i] for _ in meta)))
     handle.write(

--- a/thapbi_pict/utils.py
+++ b/thapbi_pict/utils.py
@@ -10,8 +10,12 @@ from Bio.Data.IUPACData import ambiguous_dna_values
 from Bio.SeqIO.FastaIO import SimpleFastaParser
 
 
-def sample_sort(sample_names):
-    """Sort sample names treating underscores and spaces like minus signs.
+def sample_sort(sample_names, metadata=None):
+    """Sort sample names like a human.
+
+    If metadata is provided, that is used as the primary sort key, falling back
+    on the sample names themselves but treating underscores and spaces like minus
+    signs.
 
     Our samples have occasionally used underscores and minus signs inconsistently
     in sample names as field separators or space substitutions. Therefore simple
@@ -30,6 +34,18 @@ def sample_sort(sample_names):
         ['N01-a', 'N01_b', 'N01 c', 'N011-a']
 
     """
+    # TODO: Clever sorting of e.g. A1, A2, ..., A10, A11, A99 or
+    # e.g. "Sample 1", "Sample 2", ... "Sample 10", "Sample 11", ...
+    # as values, or part of values.
+    if metadata:
+        assert len(sample_names) == len(metadata)
+        # Sort on meta data, falling back on munged sample name
+        both = sorted(
+            zip(metadata, sample_names),
+            key=lambda _: (_[0], _[1].replace("_", "-").replace(" ", "-")),
+        )
+        return [name for meta, name in both]
+    # Just sort on the munged sample name
     return sorted(sample_names, key=lambda _: _.replace("_", "-").replace(" ", "-"))
 
 


### PR DESCRIPTION
Very simple approach, if metadata columns are available they are used (in the order requested) as the preferred sample sort key.

i.e. Pick a good (alphabetically sorting) field as the first requested column of sample metadata, like the original sample name (without any suffixes or typos adding during sequencing).

Something like "Sample 1", "Sample 2", ..., "Sample 10", is a bad idea - currently must use consistent leading zeros.

This works very nicely on our Nursery samples where the master metadata table uses 3 digit nursery numbers consistently followed by a year-month-day date - which sorts as desired alphabetically.