### PR TITLE
Use metadata to show sample batches

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ This should automatically find the installed copy of the Python code.
 | v0.1.2  | 2019-04-17 | Keep searching if ``onebp`` classifier perfect match is at genus-level only. |
 | v0.1.3  | 2019-04-24 | Can optionally display sample metadata from TSV file in summary reports.     |
 | v0.1.4  | 2019-04-25 | Sort samples using the optional metadata fields requested in reports.        |
+| v0.1.5  | 2019-04-29 | Reworked optional metadata integration and its display in summary reports.   |
 
 
 # Development Notes

--- a/tests/sample-summary/assess-meta.identity.tsv
+++ b/tests/sample-summary/assess-meta.identity.tsv
@@ -1,7 +1,7 @@
 #Sample	TaxID	Species	Unambiguous	Seq-count
+unclassified	0		True	1000
 fp	4784	Phytophthora capsici	False	1000
 fp	132615	Phytophthora glovera	False	1000
-unclassified	0		True	1000
 ex4	4784	Phytophthora capsici	False	1000
 ex4	4787	Phytophthora infestans	False	1000
 ex3	0		True	1000

--- a/tests/sample-summary/assess-meta.identity.txt
+++ b/tests/sample-summary/assess-meta.identity.txt
@@ -1,15 +1,15 @@
 NOTE: Species listed with (uncertain/ambiguous) in brackets are where sequences matched multiple species equally well. For example, Phytophthora andina, P. infestans, and P. ipomoeae, share an identical marker.
 
+unclassified
+Description: Negative
+
+ - Unknown
+
 fp
 Description: Negative
 
  - Phytophthora capsici (uncertain/ambiguous)
  - Phytophthora glovera (uncertain/ambiguous)
-
-unclassified
-Description: Negative
-
- - Unknown
 
 ex4
 Description: Phytophthora capsici/glovera

--- a/tests/sample-summary/assess-meta.identity.txt
+++ b/tests/sample-summary/assess-meta.identity.txt
@@ -1,43 +1,56 @@
 NOTE: Species listed with (uncertain/ambiguous) in brackets are where sequences matched multiple species equally well. For example, Phytophthora andina, P. infestans, and P. ipomoeae, share an identical marker.
 
-unclassified
+------------------------------------------------------------
+
 Description: Negative
+
+Sequencing sample: unclassified
 
  - Unknown
 
-fp
-Description: Negative
+Sequencing sample: fp
 
  - Phytophthora capsici (uncertain/ambiguous)
  - Phytophthora glovera (uncertain/ambiguous)
 
-ex4
+------------------------------------------------------------
+
 Description: Phytophthora capsici/glovera
+
+Sequencing sample: ex4
 
  - Phytophthora capsici (uncertain/ambiguous)
  - Phytophthora infestans (uncertain/ambiguous)
 
-ex3
+------------------------------------------------------------
+
 Description: Phytophthora europaea/flexuosa
+
+Sequencing sample: ex3
 
  - Unknown
 
-ex2
+------------------------------------------------------------
+
 Description: Phytophthora fallax
+
+Sequencing sample: ex2
 
  - Unknown
  - Phytophthora capsici (uncertain/ambiguous)
  - Phytophthora glovera (uncertain/ambiguous)
 
-ex1
+------------------------------------------------------------
+
 Description: Phytophthora megasperma
+
+Sequencing sample: ex1
 
  - Unknown
  - Phytophthora crassamura
  - Phytophthora megasperma
 
-ex1a
-Description: Phytophthora megasperma
+Sequencing sample: ex1a
 
  - Phytophthora megasperma
 

--- a/tests/sample-summary/classify-meta.blast.txt
+++ b/tests/sample-summary/classify-meta.blast.txt
@@ -1,10 +1,13 @@
 NOTE: Species listed with (uncertain/ambiguous) in brackets are where sequences matched multiple species equally well. For example, Phytophthora andina, P. infestans, and P. ipomoeae, share an identical marker.
 
-P-infestans-T30-4
+------------------------------------------------------------
+
 TaxID: 4787
 Species: Phytophthora infestans
 Description: Single isolate positive control
 Date: 2018
+
+Sequencing sample: P-infestans-T30-4
 
  - Phytophthora andina (uncertain/ambiguous)
  - Phytophthora infestans (uncertain/ambiguous)

--- a/tests/sample-summary/classify-meta.identity.txt
+++ b/tests/sample-summary/classify-meta.identity.txt
@@ -1,10 +1,13 @@
 NOTE: Species listed with (uncertain/ambiguous) in brackets are where sequences matched multiple species equally well. For example, Phytophthora andina, P. infestans, and P. ipomoeae, share an identical marker.
 
-P-infestans-T30-4
+------------------------------------------------------------
+
 TaxID: 4787
 Species: Phytophthora infestans
 Description: Single isolate positive control
 Date: 2018
+
+Sequencing sample: P-infestans-T30-4
 
  - Unknown
  - Phytophthora andina (uncertain/ambiguous)

--- a/tests/sample-summary/classify-meta.onebp.txt
+++ b/tests/sample-summary/classify-meta.onebp.txt
@@ -1,10 +1,13 @@
 NOTE: Species listed with (uncertain/ambiguous) in brackets are where sequences matched multiple species equally well. For example, Phytophthora andina, P. infestans, and P. ipomoeae, share an identical marker.
 
-P-infestans-T30-4
+------------------------------------------------------------
+
 TaxID: 4787
 Species: Phytophthora infestans
 Description: Single isolate positive control
 Date: 2018
+
+Sequencing sample: P-infestans-T30-4
 
  - Unknown
  - Phytophthora andina (uncertain/ambiguous)

--- a/tests/sample-summary/classify-meta.swarm.txt
+++ b/tests/sample-summary/classify-meta.swarm.txt
@@ -1,10 +1,13 @@
 NOTE: Species listed with (uncertain/ambiguous) in brackets are where sequences matched multiple species equally well. For example, Phytophthora andina, P. infestans, and P. ipomoeae, share an identical marker.
 
-P-infestans-T30-4
+------------------------------------------------------------
+
 TaxID: 4787
 Species: Phytophthora infestans
 Description: Single isolate positive control
 Date: 2018
+
+Sequencing sample: P-infestans-T30-4
 
  - Phytophthora andina (uncertain/ambiguous)
  - Phytophthora infestans (uncertain/ambiguous)

--- a/tests/sample-summary/classify-meta.swarmid.txt
+++ b/tests/sample-summary/classify-meta.swarmid.txt
@@ -1,10 +1,13 @@
 NOTE: Species listed with (uncertain/ambiguous) in brackets are where sequences matched multiple species equally well. For example, Phytophthora andina, P. infestans, and P. ipomoeae, share an identical marker.
 
-P-infestans-T30-4
+------------------------------------------------------------
+
 TaxID: 4787
 Species: Phytophthora infestans
 Description: Single isolate positive control
 Date: 2018
+
+Sequencing sample: P-infestans-T30-4
 
  - Phytophthora andina (uncertain/ambiguous)
  - Phytophthora infestans (uncertain/ambiguous)

--- a/thapbi_pict/__init__.py
+++ b/thapbi_pict/__init__.py
@@ -17,4 +17,4 @@ You would typically use THAPBI PICT via the command line tool it defines::
 
 """
 
-__version__ = "0.1.4"
+__version__ = "0.1.5"

--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -810,8 +810,8 @@ comma.
         type=str,
         default="",
         metavar="FILENAME",
-        help="Optional tab separated table containing metadata indexed by (stem "
-        "of) sample name. Must also specify the columns with -c / --metacols, "
+        help="Optional tab separated table containing metadata indexed by "
+        "sample name. Must also specify the columns with -c / --metacols, "
         "and then this information will be included as extra header rows.",
     )
     parser_plate_summary.add_argument(
@@ -831,12 +831,11 @@ comma.
         type=int,
         default="0",
         metavar="COL",
-        help="If using metadata, which column contains the (stem of) the sample "
-        "filenames. Default is the first column requested as metadata output "
+        help="If using metadata, which column contains the sequenced sample "
+        "names. Default is the first column requested as metadata output "
         "with the -c / --metacols argument. This column can contain multiple "
-        "semi-colon separated name stems catering to the fact that a field "
-        "sample could be sequenced multiple times with technical replicates. "
-        "Filenames are matched by removing underscore separated suffixes.",
+        "semi-colon separated name catering to the fact that a field sample "
+        "could be sequenced multiple times with technical replicates.",
     )
     parser_plate_summary.add_argument(
         "-n",
@@ -913,8 +912,8 @@ comma.
         type=str,
         default="",
         metavar="FILENAME",
-        help="Optional tab separated table containing metadata indexed by (stem "
-        "of) sample name. Must also specify the columns with -c / --metacols, "
+        help="Optional tab separated table containing metadata indexed by "
+        "sample name. Must also specify the columns with -c / --metacols, "
         "and then this information will be included in the human readable "
         "report output.",
     )
@@ -935,12 +934,11 @@ comma.
         type=int,
         default="0",
         metavar="COL",
-        help="If using metadata, which column contains the (stem of) the sample "
-        "filenames. Default is the first column requested as metadata output "
+        help="If using metadata, which column contains the sequenced sample "
+        "names. Default is the first column requested as metadata output "
         "with the -c / --metacols argument. This column can contain multiple "
-        "semi-colon separated name stems catering to the fact that a field "
-        "sample could be sequenced multiple times with technical replicates. "
-        "Filenames are matched by removing underscore separated suffixes.",
+        "semi-colon separated name catering to the fact that a field sample "
+        "could be sequenced multiple times with technical replicates.",
     )
     parser_sample_summary.add_argument(
         "-n",

--- a/thapbi_pict/sample_summary.py
+++ b/thapbi_pict/sample_summary.py
@@ -9,7 +9,6 @@ import sys
 from collections import Counter
 
 from .utils import find_requested_files
-from .utils import find_metadata
 from .utils import load_metadata
 from .utils import parse_species_tsv
 from .utils import abundance_from_read_name
@@ -75,15 +74,12 @@ def main(
         sys.stderr.write("Loaded predictions for %i samples\n" % len(samples))
 
     samples = sample_sort(samples)
-    sample_metadata = {}
     if metadata:
         for sample in samples:
-            sample_metadata[sample] = find_metadata(
-                sample, metadata, meta_default, debug=debug
-            )
+            if sample not in metadata:
+                sys.stderr.write("WARNING: Missing metadata for %s\n" % sample)
         # Sort samples using metadata:
-        samples = sample_sort(samples, [sample_metadata[_] for _ in samples])
-    del metadata
+        samples = sample_sort(samples, [metadata.get(_, meta_default) for _ in samples])
 
     if output == "-":
         if debug:
@@ -141,8 +137,8 @@ def main(
         if human:
             try:
                 human.write("%s\n" % sample)
-                if sample_metadata:
-                    for name, value in zip(meta_names, sample_metadata[sample]):
+                if sample in metadata:
+                    for name, value in zip(meta_names, metadata[sample]):
                         if value:
                             human.write("%s: %s\n" % (name, value))
                 human.write("\n")

--- a/thapbi_pict/sample_summary.py
+++ b/thapbi_pict/sample_summary.py
@@ -37,9 +37,15 @@ def main(
     if not (output or human_output):
         sys.exit("ERROR: No output file specified.\n")
 
-    metadata, meta_names, meta_default = load_metadata(
+    metadata_rows, metadata_samples, meta_names, meta_default = load_metadata(
         metadata_file, metadata_cols, metadata_name, metadata_index, debug=debug
     )
+    # Turn row-centric metadata into a dictionary keyed on sequenced sample name:
+    metadata = {}
+    for row, samples in zip(metadata_rows, metadata_samples):
+        for sample in samples:
+            metadata[sample] = row
+    del metadata_rows, metadata_samples
 
     samples = set()
     counts = Counter()

--- a/thapbi_pict/summary.py
+++ b/thapbi_pict/summary.py
@@ -38,9 +38,15 @@ def main(
     if not output:
         sys.exit("ERROR: No output file specified.\n")
 
-    metadata, meta_names, meta_default = load_metadata(
+    metadata_rows, metadata_samples, meta_names, meta_default = load_metadata(
         metadata_file, metadata_cols, metadata_name, metadata_index, debug=debug
     )
+    # Turn row-centric metadata into a dictionary keyed on sequenced sample name:
+    metadata = {}
+    for row, samples in zip(metadata_rows, metadata_samples):
+        for sample in samples:
+            metadata[sample] = row
+    del metadata_rows, metadata_samples
 
     samples = set()
     md5_abundance = Counter()

--- a/thapbi_pict/utils.py
+++ b/thapbi_pict/utils.py
@@ -589,29 +589,3 @@ def load_metadata(
     if debug:
         sys.stderr.write("DEBUG: Loaded metadata for %i samples\n" % len(meta))
     return meta, names, default
-
-
-def find_metadata(sample, metadata, default=None, sep="_", debug=False):
-    """Lookup sample in metadata dictionary, trying stem as key.
-
-    Will match sample name of N01_160517_101_R_A12 to a metadata
-    entry N01_160517_101 (removing words using the given separator).
-    In this example A12 was a well number on a 96-well plate.
-
-    If fails to find a match, and a default is set, prints a warning
-    to stderr and returns the default value -- otherwise raises a
-    KeyError exception.
-    """
-    key = sample
-    if key in metadata:
-        return metadata[key]
-    while sep in key:
-        # Remove next chunk of name
-        key = key.rsplit(sep, 1)[0]
-        if key in metadata:
-            return metadata[key]
-    if default:
-        sys.stderr.write("WARNING: Missing metadata for %s\n" % sample)
-        return default
-    else:
-        raise KeyError(sample)

--- a/thapbi_pict/utils.py
+++ b/thapbi_pict/utils.py
@@ -487,8 +487,8 @@ def load_metadata(
 
     Optional argument sequenced_samples should be a set or list of
     sample names which will be cross-checked against the metadata_index
-    column. Samples not in the metadata file will be included in a
-    dummy final row (with a warning). The other way round gives a
+    column. Samples not in the metadata file are one of the return values
+    and will generate warning message. The other way round gives a
     missing file warning too (but they are left in the returned data).
 
     """

--- a/thapbi_pict/utils.py
+++ b/thapbi_pict/utils.py
@@ -563,12 +563,17 @@ def load_metadata(
     # Break up line into fields
     lines = [_.rstrip("\n").split("\t") for _ in lines]
 
-    # Select desired columns,
-    meta = [[_[i].strip() for i in value_cols] for _ in lines]
-    # Pull out the index column too:
-    index = [_[sample_col].strip() for _ in lines]
-    index = [[s.strip() for s in _.split(";") if s.strip()] for _ in index]
+    # Select columns of interest
+    meta_plus_idx = [[_[i].strip() for i in value_cols + [sample_col]] for _ in lines]
+
+    # Remove blanks
+    meta_plus_idx = [_ for _ in meta_plus_idx if any(_)]
     del lines
+
+    # Select desired columns,
+    meta = [_[:-1] for _ in meta_plus_idx]
+    index = [[s.strip() for s in _[-1].split(";") if s.strip()] for _ in meta_plus_idx]
+    del meta_plus_idx
 
     back = {}
     for i, samples in enumerate(index):

--- a/thapbi_pict/utils.py
+++ b/thapbi_pict/utils.py
@@ -10,12 +10,8 @@ from Bio.Data.IUPACData import ambiguous_dna_values
 from Bio.SeqIO.FastaIO import SimpleFastaParser
 
 
-def sample_sort(sample_names, metadata=None):
+def sample_sort(sample_names):
     """Sort sample names like a human.
-
-    If metadata is provided, that is used as the primary sort key, falling back
-    on the sample names themselves but treating underscores and spaces like minus
-    signs.
 
     Our samples have occasionally used underscores and minus signs inconsistently
     in sample names as field separators or space substitutions. Therefore simple
@@ -36,15 +32,6 @@ def sample_sort(sample_names, metadata=None):
     """
     # TODO: Clever sorting of e.g. A1, A2, ..., A10, A11, A99 or
     # e.g. "Sample 1", "Sample 2", ... "Sample 10", "Sample 11", ...
-    # as values, or part of values.
-    if metadata:
-        assert len(sample_names) == len(metadata)
-        # Sort on meta data, falling back on munged sample name
-        both = sorted(
-            zip(metadata, sample_names),
-            key=lambda _: (_[0], _[1].replace("_", "-").replace(" ", "-")),
-        )
-        return [name for meta, name in both]
     # Just sort on the munged sample name
     return sorted(sample_names, key=lambda _: _.replace("_", "-").replace(" ", "-"))
 


### PR DESCRIPTION
Main visible change is to the human readable report from ``thapbi_pict sample-summary`` which is now visually broken up into blocks (with horizontal lines) for each row in the metadata table.

If you have exactly one sample per metadata row, aside from the extra horizontal lines, the only difference is the metadata values are now above the sequenced sample name. If you have multiple samples per row, the order follows that in the index column.

If you have no metadata, output should be unchanged.