### PR TITLE
Continuous integration: make source tar-ball and wheel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,10 +57,10 @@ jobs:
             python -c "import thapbi_pict; print(thapbi_pict.__version__)"
             thapbi_pict -v
             python -m thapbi_pict -v
-            # Now unpack the tar-ball, and use that for the tests
-            tar -zxvf dist/thapbi_pict-*.tar.gz
+            # Now unpack the tests from the sdist tar-ball
+            tar --wildcards '*/tests/*' -zxvf dist/thapbi_pict-*.tar.gz
+            tar --wildcards '*/database/*' -zxvf dist/thapbi_pict-*.tar.gz
             cd thapbi_pict-*/
-            rm -rf thapbi-pict/
             # Run the tests (and confirm the tar-ball is complete)
             tests/test_load-tax.sh
             tests/test_legacy-import.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,7 @@ jobs:
             #conda install --file requirements.txt
             rm -rf dist/* thapbi_pict/ITS1_DB.sqlite
             sqlite3 thapbi_pict/ITS1_DB.sqlite < database/ITS1_DB.sql
+            chmod a-w thapbi_pict/ITS1_DB.sqlite
             python setup.py sdist --formats=gztar
             python setup.py bdist_wheel
             pip install dist/thapbi_pict-*.whl

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,11 @@ jobs:
             python -c "import thapbi_pict; print(thapbi_pict.__version__)"
             thapbi_pict -v
             python -m thapbi_pict -v
+            # Now unpack the tar-ball, and use that for the tests
+            tar -zxvf dist/thapbi_pict-*.tar.gz
+            cd thapbi_pict-*/
+            rm -rf thapbi-pict/
+            # Run the tests (and confirm the tar-ball is complete)
             tests/test_load-tax.sh
             tests/test_legacy-import.sh
             tests/test_ncbi-import.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,10 +45,11 @@ jobs:
           command: |
             conda install --file requirements-ext.txt
             conda install --file requirements.txt
-            rm -rf dist/*.tar.gz thapbi_pict/ITS1_DB.sqlite
+            rm -rf dist/* thapbi_pict/ITS1_DB.sqlite
             sqlite3 thapbi_pict/ITS1_DB.sqlite < database/ITS1_DB.sql
             python setup.py sdist --formats=gztar
-            pip install dist/thapbi_pict-*.tar.gz
+            python setup.py bdist_wheel
+            pip install dist/thapbi_pict-*.whl
       - run:
           name: Test
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,11 +45,10 @@ jobs:
           command: |
             conda install --file requirements-ext.txt
             conda install --file requirements.txt
-            rm -rf dist/*.tar.gz
+            rm -rf dist/*.tar.gz thapbi_pict/ITS1_DB.sqlite
+            sqlite3 thapbi_pict/ITS1_DB.sqlite < database/ITS1_DB.sql
             python setup.py sdist --formats=gztar
             pip install dist/thapbi_pict-*.tar.gz
-            # TODO Include ITS1_DB.sql in the automated install (and use in tests):
-            sqlite3 database/ITS1_DB.sqlite < database/ITS1_DB.sql
       - run:
           name: Test
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,8 @@ jobs:
           name: Installation
           command: |
             conda install --file requirements-ext.txt
-            conda install --file requirements.txt
+            #Don't install the Python requirements here - pip should do it...
+            #conda install --file requirements.txt
             rm -rf dist/* thapbi_pict/ITS1_DB.sqlite
             sqlite3 thapbi_pict/ITS1_DB.sqlite < database/ITS1_DB.sql
             python setup.py sdist --formats=gztar

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,10 @@ jobs:
           command: |
             conda install --file requirements-ext.txt
             conda install --file requirements.txt
-            pip install .
+            rm -rf dist/*.tar.gz
+            python setup.py sdist --formats=gztar
+            pip install dist/thapbi_pict-*.tar.gz
+            # TODO Include ITS1_DB.sql in the automated install (and use in tests):
             sqlite3 database/ITS1_DB.sqlite < database/ITS1_DB.sql
       - run:
           name: Test

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,8 @@ before_install:
 install:
  # Thus far only using conda on CircleCI, can we used apt packages instead?
  # conda install --file requirements-test.txt
- - pip install -r requirements.txt
- - python -c "import Bio; print(Bio.__version__)"
- - python -c "import sqlalchemy; print(sqlalchemy.__version__)"
+ # Deliberatly not installing Python dependencies here, pip should do it...
+ # pip install -r requirements.txt
  # Make a tar-ball, and try installing from that
  - rm -rf dist/* thapbi_pict/ITS1_DB.sqlite
  - sqlite3 thapbi_pict/ITS1_DB.sqlite < database/ITS1_DB.sql

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,11 @@ script:
  - python -c "import thapbi_pict; print(thapbi_pict.__version__)"
  - thapbi_pict -v
  - python -m thapbi_pict -v
+ # Now unpack the tar-ball, and use that for the tests
+ - tar -zxvf dist/thapbi_pict-*.tar.gz
+ - cd thapbi_pict-*/
+ - rm -rf thapbi-pict/
+ # Run the tests (and confirm the tar-ball is complete)
  - tests/test_load-tax.sh
  # Can't run tests/test_legacy-import.sh without hmmer
  # Can't run tests/test-ncbi_import.sh without hmmer

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,10 +29,11 @@ install:
  - python -c "import Bio; print(Bio.__version__)"
  - python -c "import sqlalchemy; print(sqlalchemy.__version__)"
  # Make a tar-ball, and try installing from that
- - rm -rf dist/*.tar.gz thapbi_pict/ITS1_DB.sqlite
+ - rm -rf dist/* thapbi_pict/ITS1_DB.sqlite
  - sqlite3 thapbi_pict/ITS1_DB.sqlite < database/ITS1_DB.sql
  - python setup.py sdist --formats=gztar
- - pip install dist/thapbi_pict-*.tar.gz
+ - python setup.py bdist_wheel
+ - pip install dist/thapbi_pict-*.whl
 
 script:
  - python -c "import thapbi_pict; print(thapbi_pict.__version__)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ install:
  # Make a tar-ball, and try installing from that
  - rm -rf dist/* thapbi_pict/ITS1_DB.sqlite
  - sqlite3 thapbi_pict/ITS1_DB.sqlite < database/ITS1_DB.sql
+ - chmod a-w thapbi_pict/ITS1_DB.sqlite
  - python setup.py sdist --formats=gztar
  - python setup.py bdist_wheel
  - pip install dist/thapbi_pict-*.whl

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,10 +38,10 @@ script:
  - python -c "import thapbi_pict; print(thapbi_pict.__version__)"
  - thapbi_pict -v
  - python -m thapbi_pict -v
- # Now unpack the tar-ball, and use that for the tests
- - tar -zxvf dist/thapbi_pict-*.tar.gz
+ # Now unpack tests from the sdist tar-ball
+ - tar --wildcards '*/tests/*' -zxvf dist/thapbi_pict-*.tar.gz
+ - tar --wildcards '*/database/*' -zxvf dist/thapbi_pict-*.tar.gz
  - cd thapbi_pict-*/
- - rm -rf thapbi-pict/
  # Run the tests (and confirm the tar-ball is complete)
  - tests/test_load-tax.sh
  # Can't run tests/test_legacy-import.sh without hmmer

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,11 @@ install:
  - pip install -r requirements.txt
  - python -c "import Bio; print(Bio.__version__)"
  - python -c "import sqlalchemy; print(sqlalchemy.__version__)"
- - pip install .
+ # Make a tar-ball, and try installing from that
+ - rm -rf dist/*.tar.gz
+ - python setup.py sdist --formats=gztar
+ - pip install dist/thapbi_pict-*.tar.gz
+ # TODO Include ITS1_DB.sql in the automated install (and use in tests):
  - sqlite3 database/ITS1_DB.sqlite < database/ITS1_DB.sql
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,11 +29,10 @@ install:
  - python -c "import Bio; print(Bio.__version__)"
  - python -c "import sqlalchemy; print(sqlalchemy.__version__)"
  # Make a tar-ball, and try installing from that
- - rm -rf dist/*.tar.gz
+ - rm -rf dist/*.tar.gz thapbi_pict/ITS1_DB.sqlite
+ - sqlite3 thapbi_pict/ITS1_DB.sqlite < database/ITS1_DB.sql
  - python setup.py sdist --formats=gztar
  - pip install dist/thapbi_pict-*.tar.gz
- # TODO Include ITS1_DB.sql in the automated install (and use in tests):
- - sqlite3 database/ITS1_DB.sqlite < database/ITS1_DB.sql
 
 script:
  - python -c "import thapbi_pict; print(thapbi_pict.__version__)"

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,12 +8,14 @@ include *.md
 recursive-include thapbi_pict *.py
 recursive-include thapbi_pict/hmm phytophthora_its1.*
 
-# Deliberately not bothering to include legacy/ subdirectory
-# and anything else which might be present locally like an
-# NCBI taxonomy or symlinks to control plate positive controls.
+# Deliberately not bothering to anything in database via wildcards.
+# e.g. NCBI taxonomy or symlinks to control plate positive controls.
 include database/README.md
 include database/ITS1_DB.sql
+include database/legacy/database.fasta
+include database/legacy/Phytophthora_ITS_database_v0.004.fasta
+include database/legacy/Phytophthora_ITS_database_v0.005.fasta
 
-# Well better than a blanket include *
-# this still risks false includes of any working files:
+# The following is better than a blanket include wildcard * but
+# this still risks unwanted includes of any working files:
 recursive-include tests *.sh *.txt *.tsv *.fasta *.fastq.gz

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,7 +6,11 @@ include MANIFEST.in
 include *.md
 
 recursive-include thapbi_pict *.py
+
+# Placing the HMM and DB binary files within the Python tree as
+# the simplest way to get them included in a wheel for install:
 recursive-include thapbi_pict/hmm phytophthora_its1.*
+include thapbi_pict/ITS1_DB.sqlite
 
 # Deliberately not bothering to anything in database via wildcards.
 # e.g. NCBI taxonomy or symlinks to control plate positive controls.

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ This should automatically find the installed copy of the Python code.
 | v0.1.3  | 2019-04-24 | Can optionally display sample metadata from TSV file in summary reports.     |
 | v0.1.4  | 2019-04-25 | Sort samples using the optional metadata fields requested in reports.        |
 | v0.1.5  | 2019-04-29 | Reworked optional metadata integration and its display in summary reports.   |
+| v0.1.6  | 2019-04-30 | Include ready to use binary ITS1 database in source tar-ball & wheel files.  |
 
 
 # Development Notes

--- a/database/README.md
+++ b/database/README.md
@@ -3,10 +3,12 @@ Database of ITS1 sequences for use as a molecular barcode.
 
 The most important file in this folder is the default ITS1 database
 stored under version control as ``ITS1_DB.sql`` (plain text SQL
-dump from sqlite3), from which we generate the binary DB using:
+dump from sqlite3), from which we generate the binary DB using
+the following commands as part of the release process:
 
 ```bash
-$ sqlite3 ITS1_DB.sqlite < ITS1_DB.sql
+$ sqlite3 thapbi_pict/ITS1_DB.sqlite < database/ITS1_DB.sql
+$ chmod a-w thapbi_pict/ITS1_DB.sqlite
 ```
 
 This database was created using the following three sets of

--- a/thapbi_pict/__init__.py
+++ b/thapbi_pict/__init__.py
@@ -17,4 +17,4 @@ You would typically use THAPBI PICT via the command line tool it defines::
 
 """
 
-__version__ = "0.1.5"
+__version__ = "0.1.6"


### PR DESCRIPTION
Builds the sdist tar-ball and wheel (both of which should include the compiled SQLite database and HMM files).

Installs the wheel (uses it for the tests).

Runs the tests extracted from the tar ball (confirming has all the test files included).

Should close #115  once uploaded to PyPI with twine.