### PR TITLE
TravisCI: install external dependencies with apt-get

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ before_install:
  - flake8 .
 
 install:
- # Thus far only using conda on CircleCI, can we used apt packages instead?
- # conda install --file requirements-test.txt
+ # Installing external dependencies with apt-get (using conda on CircleCI)
+ grep '^[^#]' requirements-ext.txt | xargs apt-get install
  # Deliberatly not installing Python dependencies here, pip should do it...
  # pip install -r requirements.txt
  # Make a tar-ball, and try installing from that


### PR DESCRIPTION
(1) Install dependencies.

Sadly apt-get does not accept a list of packages via a filename. Little bit of grep magic to pull out non-comment non-blank lines, and then call apt-get for each requirement via xargs.

(2) If that works, run the tests. Will probably move to a new run_tests.sh script for this to avoid duplication with CircleCI configuration.
