### PR TITLE
Set metadata column to use for group coloring at command line

### DIFF
--- a/thapbi_pict/__init__.py
+++ b/thapbi_pict/__init__.py
@@ -17,4 +17,4 @@ You would typically use THAPBI PICT via the command line tool it defines::
 
 """
 
-__version__ = "0.1.11"
+__version__ = "0.1.12"

--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -221,6 +221,7 @@ def read_summary(args=None):
         min_abundance=args.abundance,
         metadata_file=args.metadata,
         metadata_cols=args.metacols,
+        metadata_groups=args.metagroups,
         metadata_fieldnames=args.metafields,
         metadata_index=args.metaindex,
         debug=args.verbose,
@@ -243,6 +244,7 @@ def sample_summary(args=None):
         min_abundance=args.abundance,
         metadata_file=args.metadata,
         metadata_cols=args.metacols,
+        # metadata_groups=args.metagroups,
         metadata_fieldnames=args.metafields,
         metadata_index=args.metaindex,
         debug=args.verbose,
@@ -321,6 +323,7 @@ def pipeline(args=None):
         min_abundance=args.abundance,
         metadata_file=args.metadata,
         metadata_cols=args.metacols,
+        # metadata_groups=args.metagroups
         metadata_fieldnames=args.metafields,
         metadata_index=args.metaindex,
         debug=args.verbose,
@@ -337,6 +340,7 @@ def pipeline(args=None):
         min_abundance=args.abundance,
         metadata_file=args.metadata,
         metadata_cols=args.metacols,
+        metadata_groups=args.metagroups,
         metadata_fieldnames=args.metafields,
         metadata_index=args.metaindex,
         debug=args.verbose,
@@ -493,6 +497,19 @@ ARG_METAINDEX = dict(  # noqa: C408
     "could be sequenced multiple times with technical replicates.",
 )
 
+# "-g", "--metagroups",
+ARG_METAGROUPS = dict(  # noqa: C408
+    type=int,
+    default="0",
+    metavar="COL",
+    help="If using metadata, which column values should be used for applying "
+    "background color bands.  All samples with the same metadata value must "
+    "be grouped together after sorting, as the colors are reused. "
+    "Default is the first column requested as metadata output (which would "
+    "also be the primary sorting key, and thus ensures all members of the "
+    "same group will be together).",
+)
+
 # "-f", "--metafields",
 ARG_METAFIELDS = dict(  # noqa: C408
     type=int,
@@ -582,6 +599,7 @@ def main(args=None):
     parser_pipeline.add_argument("-t", "--metadata", **ARG_METADATA)
     parser_pipeline.add_argument("-c", "--metacols", **ARG_METACOLS)
     parser_pipeline.add_argument("-x", "--metaindex", **ARG_METAINDEX)
+    parser_pipeline.add_argument("-g", "--metagroups", **ARG_METAGROUPS)
     parser_pipeline.add_argument("-f", "--metafields", **ARG_METAFIELDS)
     # Can't use -t for --temp as already using for --metadata:
     parser_pipeline.add_argument("--temp", **ARG_TEMPDIR)
@@ -976,6 +994,7 @@ def main(args=None):
     parser_read_summary.add_argument("-t", "--metadata", **ARG_METADATA)
     parser_read_summary.add_argument("-c", "--metacols", **ARG_METACOLS)
     parser_read_summary.add_argument("-x", "--metaindex", **ARG_METAINDEX)
+    parser_read_summary.add_argument("-g", "--metagroups", **ARG_METAGROUPS)
     parser_read_summary.add_argument("-f", "--metafields", **ARG_METAFIELDS)
     parser_read_summary.add_argument("-v", "--verbose", **ARG_VERBOSE)
     parser_read_summary.set_defaults(func=read_summary)

--- a/thapbi_pict/read_summary.py
+++ b/thapbi_pict/read_summary.py
@@ -142,14 +142,14 @@ def main(
         metadata_fieldnames,
         metadata_index,
         sequenced_samples=samples,
+        metadata_sort=True,
         debug=debug,
     )
-    # Turn row-centric metadata into a dictionary keyed on sequenced sample name,
-    # and use for sorting order
+    # Turn row-centric metadata into a dictionary keyed on sequenced sample name
     metadata = {}
     new = []
-    # Note we sort rows on the metadata values, discarding the order in the table
-    for row, r_samples in sorted(zip(metadata_rows, metadata_samples)):
+    # Already sorted rows of the metadata values, discarded the order in the table
+    for row, r_samples in zip(metadata_rows, metadata_samples):
         for sample in r_samples:
             if sample in samples:
                 # print(sample, row)

--- a/thapbi_pict/sample_summary.py
+++ b/thapbi_pict/sample_summary.py
@@ -82,6 +82,7 @@ def main(
         metadata_fieldnames,
         metadata_index,
         sequenced_samples=samples,
+        metadata_sort=True,
         debug=debug,
     )
 
@@ -113,8 +114,8 @@ def main(
             "marker.\n\n"
         )
 
-    # Note we sort rows on the metadata values, discarding the order in the table
-    batches = sorted(zip(metadata_rows, metadata_samples))
+    # Note already sorted on metadata values, discarded the order in the table
+    batches = list(zip(metadata_rows, metadata_samples))
     if missing_meta:
         batches.append([meta_default, missing_meta])
     for metadata, sample_batch in batches:

--- a/thapbi_pict/sample_summary.py
+++ b/thapbi_pict/sample_summary.py
@@ -69,9 +69,11 @@ def main(
     if debug:
         sys.stderr.write("Loaded predictions for %i samples\n" % len(samples))
 
+    metadata_groups = None  # currently not requested at command line
     samples = sample_sort(samples)
     (
         metadata_rows,
+        meta_groups,
         metadata_samples,
         meta_names,
         meta_default,
@@ -79,12 +81,14 @@ def main(
     ) = load_metadata(
         metadata_file,
         metadata_cols,
+        metadata_groups,
         metadata_fieldnames,
         metadata_index,
         sequenced_samples=samples,
         metadata_sort=True,
         debug=debug,
     )
+    del meta_groups, metadata_groups
 
     if output == "-":
         if debug:

--- a/thapbi_pict/utils.py
+++ b/thapbi_pict/utils.py
@@ -461,6 +461,7 @@ def load_metadata(
     metadata_index=0,
     metadata_index_sep=";",
     sequenced_samples=None,
+    metadata_sort=True,
     debug=False,
 ):
     """Load specified metadata as several lists.
@@ -477,6 +478,9 @@ def load_metadata(
     This one-to-many mapping reflecting that a single field sample could
     be sequenced more than once (e.g. technical replicates). These sample
     names are matched against the file name stems, see function find_metadata.
+
+    if metadata_sort=True, then the table rows are sorted based on the
+    requested metadata - otherwise the table row order is preserved.
 
     Returns:
      - list of field sample metadata values (each a list of N values)
@@ -573,6 +577,10 @@ def load_metadata(
     # Remove blanks
     meta_plus_idx = [_ for _ in meta_plus_idx if any(_)]
     del lines
+
+    # Sort on metadata if requested
+    if metadata_sort:
+        meta_plus_idx.sort()
 
     # Select desired columns,
     meta = [_[:-1] for _ in meta_plus_idx]


### PR DESCRIPTION
Specify coloring group as a column via the command line, less heuristics = easy to document and test too.

TODO: Include group name in our own metadata table, and then can remove the code which tries taking the first word of the field specified (which works well with our structured sample names).