### PR TITLE
Implement edit-graph subcommand

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,8 +20,8 @@ jobs:
             source activate myenv
             python --version
             conda config --add channels defaults
-            conda config --add channels conda-forge
             conda config --add channels bioconda
+            conda config --add channels conda-forge
             conda info -a
       - run:
           name: Whitespace checks

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,8 +44,8 @@ jobs:
           name: Installation
           command: |
             conda install --file requirements-ext.txt
-            #Don't install the Python requirements here - pip should do it...
-            #conda install --file requirements.txt
+            # Also installing the Python requirements here - pip should do it, but not all with C code have wheels
+            conda install --file requirements.txt
             rm -rf dist/* thapbi_pict/ITS1_DB.sqlite
             sqlite3 thapbi_pict/ITS1_DB.sqlite < database/ITS1_DB.sql
             chmod a-w thapbi_pict/ITS1_DB.sqlite

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ addons:
      - ncbi-blast+
      # cutadapt
      # flash
+     - graphviz
      - hmmer
      - swarm
      - trimmomatic

--- a/requirements-ext.txt
+++ b/requirements-ext.txt
@@ -6,6 +6,7 @@
 blast
 cutadapt
 flash
+graphviz
 hmmer
 swarm
 trimmomatic

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@
 #
 
 biopython
+matplotlib
 networkx
 python-levenshtein
 sqlalchemy

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,6 @@
 
 biopython
 networkx
+python-levenshtein
 sqlalchemy
 xlsxwriter

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,6 @@
 #
 
 biopython
+networkx
 sqlalchemy
 xlsxwriter

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@
 biopython
 matplotlib
 networkx
+pydot
 python-levenshtein
 sqlalchemy
 xlsxwriter

--- a/setup.py
+++ b/setup.py
@@ -99,6 +99,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "biopython",
+        "matplotlib",
         "networkx",
         "python-levenshtein",
         "sqlalchemy",

--- a/setup.py
+++ b/setup.py
@@ -97,6 +97,12 @@ setup(
     entry_points={"console_scripts": ["thapbi_pict = thapbi_pict.__main__:main"]},
     packages=find_packages(),
     include_package_data=True,
-    install_requires=["biopython", "networkx", "sqlalchemy", "xlsxwriter"],
+    install_requires=[
+        "biopython",
+        "networkx",
+        "python-levenshtein",
+        "sqlalchemy",
+        "xlsxwriter",
+    ],
     python_requires=">=3.5",
 )

--- a/setup.py
+++ b/setup.py
@@ -101,6 +101,7 @@ setup(
         "biopython",
         "matplotlib",
         "networkx",
+        "pydot",
         "python-levenshtein",
         "sqlalchemy",
         "xlsxwriter",

--- a/setup.py
+++ b/setup.py
@@ -97,6 +97,6 @@ setup(
     entry_points={"console_scripts": ["thapbi_pict = thapbi_pict.__main__:main"]},
     packages=find_packages(),
     include_package_data=True,
-    install_requires=["biopython", "sqlalchemy", "xlsxwriter"],
+    install_requires=["biopython", "networkx", "sqlalchemy", "xlsxwriter"],
     python_requires=">=3.5",
 )

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -26,3 +26,4 @@ tests/test_seq-import.sh
 tests/test_assess.sh
 tests/test_sample-summary.sh
 tests/test_read-summary.sh
+tests/test_edit-graph.sh

--- a/tests/test_edit-graph.sh
+++ b/tests/test_edit-graph.sh
@@ -12,15 +12,19 @@ if [ `thapbi_pict edit-graph -d - -i tests/prepare-reads/DNAMIX_S95_L001.fasta -
 # Loaded 7 unique sequences from 1 FASTA files.
 # Minimum total abundance threshold 200 left 7 sequences from FASTA files.
 # Computed 42 Levenshtein edit distances between 7 sequences.
-# Max edit distance 3 gave 6 connected components (size 2 to 1).
-# Dropped 0 sequences with no siblings within maximum edit distance 3.
+# Will draw 2 nodes with at least one edge (5 are isolated sequences).
+# Including high abundance isolated sequences, will draw 7 nodes.
 # 1
-#
-# i.e. GraphXML is missing the single unconnected nodes, so just get
-# two nodes with one edge in this example
 
 
 # No database, generic FASTA file, have to use explicit abundance thresholds of 1:
-if [ `thapbi_pict edit-graph -d - -i database/legacy/Phytophthora_ITS_database_v0.005.fasta -a 1 -t 1 | grep -c "<node"` -ne 103 ]; then echo "Wrong node count"; false; fi
+if [ `thapbi_pict edit-graph -d - -i database/legacy/Phytophthora_ITS_database_v0.005.fasta -a 1 -t 1 | grep -c "<node"` -ne 176 ]; then echo "Wrong node count"; false; fi
+# WARNING: Sequence(s) in database/legacy/Phytophthora_ITS_database_v0.005.fasta not using MD5_abundance naming
+# Loaded 176 unique sequences from 1 FASTA files.
+# Minimum total abundance threshold 1 left 176 sequences from FASTA files.
+# Computed 30800 Levenshtein edit distances between 176 sequences.
+# Will draw 103 nodes with at least one edge (73 are isolated sequences).
+# Including high abundance isolated sequences, will draw 176 nodes.
+# 176
 
 echo "$0 - test_edit-graph.sh passed"

--- a/tests/test_edit-graph.sh
+++ b/tests/test_edit-graph.sh
@@ -8,7 +8,7 @@ thapbi_pict edit-graph -d - 2>&1 | grep "Require -d / --database and/or -i / --i
 set -o pipefail
 
 # No database, small FASTA file, have to use explciit total abundance threshold
-if [ `thapbi_pict edit-graph -d - -i tests/prepare-reads/DNAMIX_S95_L001.fasta -t 200 | grep -c "<edge"` -ne 1 ]; then echo echo "Wrong edge count"; false; fi
+if [ `thapbi_pict edit-graph -d - -i tests/prepare-reads/DNAMIX_S95_L001.fasta -t 200 | grep -c "<edge "` -ne 1 ]; then echo echo "Wrong edge count"; false; fi
 # Loaded 7 unique sequences from 1 FASTA files.
 # Minimum total abundance threshold 200 left 7 sequences from FASTA files.
 # Computed 42 Levenshtein edit distances between 7 sequences.
@@ -17,8 +17,8 @@ if [ `thapbi_pict edit-graph -d - -i tests/prepare-reads/DNAMIX_S95_L001.fasta -
 # 1
 
 # Same example as above with default xgmml output, but here different output formats:
-if [ `thapbi_pict edit-graph -d - -i tests/prepare-reads/DNAMIX_S95_L001.fasta -t 200 -f graphml | grep -c "<edge"` -ne 1 ]; then echo echo "Wrong edge count"; false; fi
-if [ `thapbi_pict edit-graph -d - -i tests/prepare-reads/DNAMIX_S95_L001.fasta -t 200 -f gexf | grep -c "<edge"` -ne 1 ]; then echo echo "Wrong edge count"; false; fi
+if [ `thapbi_pict edit-graph -d - -i tests/prepare-reads/DNAMIX_S95_L001.fasta -t 200 -f graphml | grep -c "<edge "` -ne 1 ]; then echo echo "Wrong edge count"; false; fi
+if [ `thapbi_pict edit-graph -d - -i tests/prepare-reads/DNAMIX_S95_L001.fasta -t 200 -f gexf | grep -c "<edge "` -ne 1 ]; then echo echo "Wrong edge count"; false; fi
 # gml fails, https://github.com/networkx/networkx/issues/3471
 
 # Same example, but PDF output (more dependencies):
@@ -27,7 +27,7 @@ thapbi_pict edit-graph -d - -i tests/prepare-reads/DNAMIX_S95_L001.fasta -t 200 
 hexdump -C $TMP/edit-graph.pdf | head -1 | grep "%PDF-1.4.%"
 
 # No database, generic FASTA file, have to use explicit abundance thresholds of 1:
-if [ `thapbi_pict edit-graph -d - -i database/legacy/Phytophthora_ITS_database_v0.005.fasta -a 1 -t 1 | grep -c "<node"` -ne 176 ]; then echo "Wrong node count"; false; fi
+if [ `thapbi_pict edit-graph -d - -i database/legacy/Phytophthora_ITS_database_v0.005.fasta -a 1 -t 1 | grep -c "<node "` -ne 176 ]; then echo "Wrong node count"; false; fi
 # WARNING: Sequence(s) in database/legacy/Phytophthora_ITS_database_v0.005.fasta not using MD5_abundance naming
 # Loaded 176 unique sequences from 1 FASTA files.
 # Minimum total abundance threshold 1 left 176 sequences from FASTA files.

--- a/tests/test_edit-graph.sh
+++ b/tests/test_edit-graph.sh
@@ -3,7 +3,8 @@ IFS=$'\n\t'
 set -eux
 # Note not using "set -o pipefail" until after check error message with grep
 
-# Note all tests here (initially) using default database:
+# Debug:
+thapbi_pict edit-graph -h
 
 echo "Checking edit-graph"
 thapbi_pict edit-graph -d - 2>&1 | grep "Require -d / --database and/or -i / --input argument"

--- a/tests/test_edit-graph.sh
+++ b/tests/test_edit-graph.sh
@@ -3,10 +3,6 @@ IFS=$'\n\t'
 set -eux
 # Note not using "set -o pipefail" until after check error message with grep
 
-# Debug:
-thapbi_pict edit-graph -h
-thapbi_pict edit-graph -d -
-
 echo "Checking edit-graph"
 thapbi_pict edit-graph -d - 2>&1 | grep "Require -d / --database and/or -i / --input argument"
 set -o pipefail

--- a/tests/test_edit-graph.sh
+++ b/tests/test_edit-graph.sh
@@ -5,6 +5,7 @@ set -eux
 
 # Debug:
 thapbi_pict edit-graph -h
+thapbi_pict edit-graph -d -
 
 echo "Checking edit-graph"
 thapbi_pict edit-graph -d - 2>&1 | grep "Require -d / --database and/or -i / --input argument"

--- a/tests/test_edit-graph.sh
+++ b/tests/test_edit-graph.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+IFS=$'\n\t'
+set -eux
+# Note not using "set -o pipefail" until after check error message with grep
+
+# Note all tests here (initially) using default database:
+
+echo "Checking edit-graph"
+thapbi_pict edit-graph -d - 2>&1 | grep "Require -d / --database and/or -i / --input argument"
+set -o pipefail
+
+# No database, small FASTA file, have to use explciit total abundance threshold
+if [ `thapbi_pict edit-graph -d - -i tests/prepare-reads/DNAMIX_S95_L001.fasta -t 200 | grep -c "<edge"` -ne 1 ]; then echo echo "Wrong edge count"; false; fi
+# Loaded 7 unique sequences from 1 FASTA files.
+# Minimum total abundance threshold 200 left 7 sequences from FASTA files.
+# Computed 42 Levenshtein edit distances between 7 sequences.
+# Max edit distance 3 gave 6 connected components (size 2 to 1).
+# Dropped 0 sequences with no siblings within maximum edit distance 3.
+# 1
+#
+# i.e. GraphXML is missing the single unconnected nodes, so just get
+# two nodes with one edge in this example
+
+
+# No database, generic FASTA file, have to use explicit abundance thresholds of 1:
+if [ `thapbi_pict edit-graph -d - -i database/legacy/Phytophthora_ITS_database_v0.005.fasta -a 1 -t 1 | grep -c "<node"` -ne 103 ]; then echo "Wrong node count"; false; fi
+
+echo "$0 - test_edit-graph.sh passed"

--- a/tests/test_edit-graph.sh
+++ b/tests/test_edit-graph.sh
@@ -16,6 +16,15 @@ if [ `thapbi_pict edit-graph -d - -i tests/prepare-reads/DNAMIX_S95_L001.fasta -
 # Including high abundance isolated sequences, will draw 7 nodes.
 # 1
 
+# Same example as above with default xgmml output, but here different output formats:
+if [ `thapbi_pict edit-graph -d - -i tests/prepare-reads/DNAMIX_S95_L001.fasta -t 200 -f graphml | grep -c "<edge"` -ne 1 ]; then echo echo "Wrong edge count"; false; fi
+if [ `thapbi_pict edit-graph -d - -i tests/prepare-reads/DNAMIX_S95_L001.fasta -t 200 -f gexf | grep -c "<edge"` -ne 1 ]; then echo echo "Wrong edge count"; false; fi
+# gml fails, https://github.com/networkx/networkx/issues/3471
+
+# Same example, but PDF output (more dependencies):
+rm -rf $TMP/edit-graph.pdf
+thapbi_pict edit-graph -d - -i tests/prepare-reads/DNAMIX_S95_L001.fasta -t 200 -f pdf -o $TMP/edit-graph.pdf
+hexdump -C $TMP/edit-graph.pdf | head -1 | grep "%PDF-1.4.%"
 
 # No database, generic FASTA file, have to use explicit abundance thresholds of 1:
 if [ `thapbi_pict edit-graph -d - -i database/legacy/Phytophthora_ITS_database_v0.005.fasta -a 1 -t 1 | grep -c "<node"` -ne 176 ]; then echo "Wrong node count"; false; fi

--- a/tests/test_edit-graph.sh
+++ b/tests/test_edit-graph.sh
@@ -24,9 +24,8 @@ if [ `thapbi_pict edit-graph -d - -i tests/prepare-reads/DNAMIX_S95_L001.fasta -
 # gml fails, https://github.com/networkx/networkx/issues/3471
 
 # Same example, but PDF output (more dependencies):
-rm -rf $TMP/edit-graph.pdf
-thapbi_pict edit-graph -d - -i tests/prepare-reads/DNAMIX_S95_L001.fasta -t 200 -f pdf -o $TMP/edit-graph.pdf
-hexdump -C $TMP/edit-graph.pdf | head -1 | grep "%PDF-1.4.%"
+thapbi_pict edit-graph -d - -i tests/prepare-reads/DNAMIX_S95_L001.fasta -t 200 -f pdf | grep "%PDF-1.4"
+
 
 # No database, generic FASTA file, have to use explicit abundance thresholds of 1:
 if [ `thapbi_pict edit-graph -d - -i database/legacy/Phytophthora_ITS_database_v0.005.fasta -a 1 -t 1 | grep -c "<node "` -ne 176 ]; then echo "Wrong node count"; false; fi

--- a/tests/test_edit-graph.sh
+++ b/tests/test_edit-graph.sh
@@ -3,6 +3,8 @@ IFS=$'\n\t'
 set -eux
 # Note not using "set -o pipefail" until after check error message with grep
 
+export TMP=${TMP:-/tmp}
+
 echo "Checking edit-graph"
 thapbi_pict edit-graph -d - 2>&1 | grep "Require -d / --database and/or -i / --input argument"
 set -o pipefail

--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -1131,7 +1131,7 @@ def main(args=None):
         "--format",
         type=str,
         default="graphml",
-        choices=["graphml", "gexf", "gml", "pdf"],
+        choices=["graphml", "gexf", "gml", "xgmml", "pdf"],
         help="Format to write out (default 'graphml').",
     )
     parser_edit_graph.add_argument(

--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -263,6 +263,7 @@ def edit_graph(args=None):
 
     return main(
         graph_output=args.output,
+        graph_format=args.format,
         db_url=db,
         inputs=args.input,
         min_abundance=args.abundance,
@@ -1080,10 +1081,10 @@ def main(args=None):
         "edit-graph",
         description="Draw network graph of sequences using edit distance.",
         epilog="Takes an ITS1 database and/or prepared FASTA files as input. "
-        "The output is a network graph (in PDF format) with unique sequences "
-        "as nodes (labelled by the database taxonomy, colored by genus, size "
-        "set by total abundance in the FASTA files), and short edit "
-        "distances as edges between nodes.",
+        "The output is a network graph (in GraphML or PDF format) with unique "
+        "sequences as nodes (in the PDF labelled by the database taxonomy, "
+        "colored by genus, size set by total abundance in the FASTA files), "
+        "and short edit distances as edges between nodes.",
     )
     arg = parser_edit_graph.add_argument("-d", "--database", **ARG_DB_INPUT)
     arg.help += " Use '-' to mean no database."
@@ -1123,7 +1124,15 @@ def main(args=None):
         type=str,
         default="-",
         metavar="FILENAME",
-        help="Write PDF graph here. Default is '-' meaning stdout.",
+        help="Write graph here. Default is '-' meaning stdout.",
+    )
+    parser_edit_graph.add_argument(
+        "-f",
+        "--format",
+        type=str,
+        default="graphml",
+        choices=["graphml", "pdf"],
+        help="Format to write out (default 'graphml').",
     )
     parser_edit_graph.add_argument(
         "-v", "--verbose", action="store_true", help="Verbose logging"

--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -1084,7 +1084,11 @@ def main(args=None):
         "The output is a network graph (in a choice of format) with unique "
         "sequences as nodes (in the PDF labelled by the database taxonomy, "
         "colored by genus, size set by total abundance in the FASTA files), "
-        "and short edit distances as edges between nodes.",
+        "and short edit distances as edges between nodes. For Cytoscape "
+        "we recommend generating XGMML output here, the start Cytoscape, "
+        "menu 'File', 'Import', 'Import from file', and then run a layout. "
+        "Both 'Perfuse Force Directed' and 'Edge-weighted Spring Embedded' "
+        "work well.",
     )
     arg = parser_edit_graph.add_argument("-d", "--database", **ARG_DB_INPUT)
     arg.help += " Use '-' to mean no database."

--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -258,9 +258,7 @@ def edit_graph(args=None):
     return main(
         graph_output=args.output,
         db_url=expand_database_argument(args.database, exist=True, blank_default=True),
-        # inputs=args.inputs,
-        # graph_output=args.output,
-        # method=args.method,
+        inputs=args.input,
         # min_abundance=args.abundance,
         # total_min_abundance=args.total,
         max_edit_dist=args.editdist,
@@ -1081,23 +1079,10 @@ def main(args=None):
         "distances as edges between nodes.",
     )
     parser_edit_graph.add_argument("-d", "--database", **ARG_DB_INPUT)
-    # parser_edit_graph.add_argument(
-    #    "inputs",
-    #    type=str,
-    #    nargs="+",
-    #    help="One or more prepared read files (*.fasta), prediction "
-    #    "files (*.method.tsv) or folder names. If passing folder names, "
-    #    "it expects to find paired files using these extensions. "
-    #    "The classifier method extension can be set via -m / --method.",
-    # )
-    # parser_edit_graph.add_argument(
-    #    "-m",
-    #    "--method",
-    #    type=str,
-    #    default="identity",
-    #    help="Method(s) to report, comma separaed list (used to infer "
-    #    "filenames), default is identity (only).",
-    # )
+    # Currently ARG_INPUT_FASTA uses required=True, but we need to change thant:
+    arg = parser_edit_graph.add_argument("-i", "--input", **ARG_INPUT_FASTA)
+    arg.required = False
+    del arg
     # parser_edit_graph.add_argument(
     #    "-a",
     #    "--abundance",

--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -1081,7 +1081,7 @@ def main(args=None):
         "edit-graph",
         description="Draw network graph of sequences using edit distance.",
         epilog="Takes an ITS1 database and/or prepared FASTA files as input. "
-        "The output is a network graph (in GraphML or PDF format) with unique "
+        "The output is a network graph (in a choice of format) with unique "
         "sequences as nodes (in the PDF labelled by the database taxonomy, "
         "colored by genus, size set by total abundance in the FASTA files), "
         "and short edit distances as edges between nodes.",
@@ -1131,7 +1131,7 @@ def main(args=None):
         "--format",
         type=str,
         default="graphml",
-        choices=["graphml", "pdf"],
+        choices=["graphml", "gexf", "gml", "pdf"],
         help="Format to write out (default 'graphml').",
     )
     parser_edit_graph.add_argument(

--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -1105,9 +1105,8 @@ def main(args=None):
         "--editdist",
         type=int,
         default="3",
-        help="Maximum edit distance. Recommend at most 3 (default) for plate "
-        "level graphs, could try putting this higher for smaller datasets like "
-        "single samples, or if combined with hard minimum abundance settings.",
+        choices=[1, 2, 3],
+        help="Maximum edit distance to draw. Default and maximum 3.",
     )
     parser_edit_graph.add_argument(
         "-o",

--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -1130,9 +1130,9 @@ def main(args=None):
         "-f",
         "--format",
         type=str,
-        default="graphml",
+        default="xgmml",
         choices=["graphml", "gexf", "gml", "xgmml", "pdf"],
-        help="Format to write out (default 'graphml').",
+        help="Format to write out (default 'xgmml' for use with Cytoscape).",
     )
     parser_edit_graph.add_argument(
         "-v", "--verbose", action="store_true", help="Verbose logging"

--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -255,9 +255,15 @@ def edit_graph(args=None):
     """Subcommand to create sequence-level edit-distance graph."""
     from .edit_graph import main
 
+    db = (
+        None
+        if args.database == "-"
+        else expand_database_argument(args.database, exist=True, blank_default=True)
+    )
+
     return main(
         graph_output=args.output,
-        db_url=expand_database_argument(args.database, exist=True, blank_default=True),
+        db_url=db,
         inputs=args.input,
         min_abundance=args.abundance,
         total_min_abundance=args.total,
@@ -370,7 +376,7 @@ def pipeline(args=None):
 
 # "-d", "--database",
 ARG_DB_INPUT = dict(  # noqa: C408
-    type=str, default="", help="ITS1 database to use, default is bundled database."
+    type=str, default="", help="ITS1 database to use, default '' is bundled database."
 )
 
 # "-i", "--input",
@@ -1073,12 +1079,15 @@ def main(args=None):
     parser_edit_graph = subparsers.add_parser(
         "edit-graph",
         description="Draw network graph of sequences using edit distance.",
-        epilog="Currently takes an ITS1 database as input. "
+        epilog="Takes an ITS1 database and/or prepared FASTA files as input. "
         "The output is a network graph (in PDF format) with unique sequences "
-        "as nodes (labelled by the database taxonomy), and short edit "
+        "as nodes (labelled by the database taxonomy, colored by genus, size "
+        "set by total abundance in the FASTA files), and short edit "
         "distances as edges between nodes.",
     )
-    parser_edit_graph.add_argument("-d", "--database", **ARG_DB_INPUT)
+    arg = parser_edit_graph.add_argument("-d", "--database", **ARG_DB_INPUT)
+    arg.help += " Use '-' to mean no database."
+    del arg
     # Currently ARG_INPUT_FASTA uses required=True, but we need to change thant:
     arg = parser_edit_graph.add_argument("-i", "--input", **ARG_INPUT_FASTA)
     arg.required = False

--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -251,6 +251,23 @@ def sample_summary(args=None):
     )
 
 
+def edit_graph(args=None):
+    """Subcommand to create sequence-level edit-distance graph."""
+    from .edit_graph import main
+
+    return main(
+        graph_output=args.output,
+        db_url=expand_database_argument(args.database, exist=True, blank_default=True),
+        # inputs=args.inputs,
+        # graph_output=args.output,
+        # method=args.method,
+        # min_abundance=args.abundance,
+        # total_min_abundance=args.total,
+        max_edit_dist=args.editdist,
+        debug=args.verbose,
+    )
+
+
 def pipeline(args=None):
     """Subcommand to run the default classification pipeline."""
     from .prepare import main as prepare
@@ -1053,6 +1070,76 @@ def main(args=None):
     parser_sample_summary.add_argument("-v", "--verbose", **ARG_VERBOSE)
     parser_sample_summary.set_defaults(func=sample_summary)
     del parser_sample_summary  # To prevent acidentally adding more
+
+    # edit-graph
+    parser_edit_graph = subparsers.add_parser(
+        "edit-graph",
+        description="Draw network graph of sequences using edit distance.",
+        epilog="Currently takes an ITS1 database as input. "
+        "The output is a network graph (in PDF format) with unique sequences "
+        "as nodes (labelled by the database taxonomy), and short edit "
+        "distances as edges between nodes.",
+    )
+    parser_edit_graph.add_argument("-d", "--database", **ARG_DB_INPUT)
+    # parser_edit_graph.add_argument(
+    #    "inputs",
+    #    type=str,
+    #    nargs="+",
+    #    help="One or more prepared read files (*.fasta), prediction "
+    #    "files (*.method.tsv) or folder names. If passing folder names, "
+    #    "it expects to find paired files using these extensions. "
+    #    "The classifier method extension can be set via -m / --method.",
+    # )
+    # parser_edit_graph.add_argument(
+    #    "-m",
+    #    "--method",
+    #    type=str,
+    #    default="identity",
+    #    help="Method(s) to report, comma separaed list (used to infer "
+    #    "filenames), default is identity (only).",
+    # )
+    # parser_edit_graph.add_argument(
+    #    "-a",
+    #    "--abundance",
+    #    type=int,
+    #    default="100",
+    #    help="Mininum sample level abundance to require for the report. "
+    #    "Default 100 reflects default in prepare-reads. Rather than re-running "
+    #    "the prepare or classifier steps with a stricter minimum abundance you "
+    #    "can apply it here. Use zero or one look at everything (but beware that "
+    #    "negative control samples will include low abundance entries).",
+    # )
+    # parser_edit_graph.add_argument(
+    #    "-t",
+    #    "--total",
+    #    type=int,
+    #    default="1000",
+    #    help="Mininum total abundance to require for the report. This is applied "
+    #    "after the per-sample level minimum (-a / --abundance), and is mainly "
+    #    "offered as a way to simplify the final graph.",
+    # )
+    parser_edit_graph.add_argument(
+        "-e",
+        "--editdist",
+        type=int,
+        default="3",
+        help="Maximum edit distance. Recommend at most 3 (default) for plate "
+        "level graphs, could try putting this higher for smaller datasets like "
+        "single samples, or if combined with hard minimum abundance settings.",
+    )
+    parser_edit_graph.add_argument(
+        "-o",
+        "--output",
+        type=str,
+        default="-",
+        metavar="FILENAME",
+        help="Write PDF graph here. Default is '-' meaning stdout.",
+    )
+    parser_edit_graph.add_argument(
+        "-v", "--verbose", action="store_true", help="Verbose logging"
+    )
+    parser_edit_graph.set_defaults(func=edit_graph)
+    del parser_edit_graph  # To prevent accidentally adding more
 
     # What have we been asked to do?
     options = parser.parse_args(args)

--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -259,8 +259,8 @@ def edit_graph(args=None):
         graph_output=args.output,
         db_url=expand_database_argument(args.database, exist=True, blank_default=True),
         inputs=args.input,
-        # min_abundance=args.abundance,
-        # total_min_abundance=args.total,
+        min_abundance=args.abundance,
+        total_min_abundance=args.total,
         max_edit_dist=args.editdist,
         debug=args.verbose,
     )
@@ -1083,26 +1083,23 @@ def main(args=None):
     arg = parser_edit_graph.add_argument("-i", "--input", **ARG_INPUT_FASTA)
     arg.required = False
     del arg
-    # parser_edit_graph.add_argument(
-    #    "-a",
-    #    "--abundance",
-    #    type=int,
-    #    default="100",
-    #    help="Mininum sample level abundance to require for the report. "
-    #    "Default 100 reflects default in prepare-reads. Rather than re-running "
-    #    "the prepare or classifier steps with a stricter minimum abundance you "
-    #    "can apply it here. Use zero or one look at everything (but beware that "
-    #    "negative control samples will include low abundance entries).",
-    # )
-    # parser_edit_graph.add_argument(
-    #    "-t",
-    #    "--total",
-    #    type=int,
-    #    default="1000",
-    #    help="Mininum total abundance to require for the report. This is applied "
-    #    "after the per-sample level minimum (-a / --abundance), and is mainly "
-    #    "offered as a way to simplify the final graph.",
-    # )
+    parser_edit_graph.add_argument(
+        "-a",
+        "--abundance",
+        type=int,
+        default="100",
+        help="Mininum sample level abundance for FASTA sequences. "
+        "Default 100 reflects default in prepare-reads.",
+    )
+    parser_edit_graph.add_argument(
+        "-t",
+        "--total",
+        type=int,
+        default="1000",
+        help="Mininum total abundance for FASTA sequences. "
+        "Applied after per-sample level minimum (-a / --abundance). "
+        "Offered as a way to simplify the final graph.",
+    )
     parser_edit_graph.add_argument(
         "-e",
         "--editdist",

--- a/thapbi_pict/edit_graph.py
+++ b/thapbi_pict/edit_graph.py
@@ -107,6 +107,7 @@ assert connected_components(
 
 def main(
     graph_output,
+    graph_format,
     db_url,
     inputs,
     min_abundance=100,
@@ -449,25 +450,34 @@ def main(
             "DEBUG: Dropped %i redundant 2-bp or 3-bp edges.\n" % redundant
         )
 
-    # TODO: Try "sfdp" but need GraphViz built with triangulation library
-    placement = nx.drawing.nx_pydot.graphviz_layout(graph, "fdp")
-    nx.draw_networkx_nodes(
-        graph,
-        placement,
-        node_color=node_colors,
-        # node_labels=node_labels,
-        node_size=node_sizes,
-    )
-    nx.draw_networkx_edges(
-        graph,
-        placement,
-        style=edge_style,
-        width=edge_width,
-        edge_color=edge_color,
-        alpha=0.5,
-    )
-    nx.draw_networkx_labels(graph, placement, node_labels, font_size=4)
-    plt.axis("off")
-    plt.savefig(graph_output)
+    if graph_format == "pdf":
+        # TODO: Try "sfdp" but need GraphViz built with triangulation library
+        placement = nx.drawing.nx_pydot.graphviz_layout(graph, "fdp")
+        nx.draw_networkx_nodes(
+            graph,
+            placement,
+            node_color=node_colors,
+            # node_labels=node_labels,
+            node_size=node_sizes,
+        )
+        nx.draw_networkx_edges(
+            graph,
+            placement,
+            style=edge_style,
+            width=edge_width,
+            edge_color=edge_color,
+            alpha=0.5,
+        )
+        nx.draw_networkx_labels(graph, placement, node_labels, font_size=4)
+        plt.axis("off")
+        plt.savefig(graph_output)
+    elif graph_format == "graphml":
+        with open(graph_output, "w") as handle:
+            for line in nx.generate_graphml(graph):
+                # Seems not to bother including the new line...
+                handle.write(line.rstrip() + "\n")
+    else:
+        # Typically this would be caught in __main__.py
+        sys.exit("ERROR: Unexpected graph output format: %s" % graph_format)
 
     return 0

--- a/thapbi_pict/edit_graph.py
+++ b/thapbi_pict/edit_graph.py
@@ -178,8 +178,10 @@ def main(
                 # dist = levenshtein(seq1, seq2)
                 dist = distances[i, j]
                 if dist <= max_edit_dist:
-                    # Some graph layout algorithms can use weight attr
-                    graph.add_edge(check1, check2, weight=1.0 / dist)
+                    # Some graph layout algorithms can use weight attr; some want int
+                    # Larger weight makes it closer to the requested length.
+                    # fdp default length is 0.3, neato is 1.0
+                    graph.add_edge(check1, check2, len=0.3 * dist / max_edit_dist)
                     edge_count += 1
                     if dist <= 1:
                         edge_style.append("solid")

--- a/thapbi_pict/edit_graph.py
+++ b/thapbi_pict/edit_graph.py
@@ -1,0 +1,157 @@
+"""Generate edit-distance network graph from FASTA files.
+
+This implementes the ``thapbi_pict edit-graph ...`` command.
+"""
+
+import sys
+
+import matplotlib.pyplot as plt
+import networkx as nx
+
+from Levenshtein import distance as levenshtein
+
+from sqlalchemy.orm import aliased, contains_eager
+
+from .db_orm import ITS1, SequenceSource, Taxonomy, connect_to_db
+
+from .utils import genus_species_name
+
+
+def main(
+    graph_output,
+    db_url,
+    # inputs,
+    # graph_output,
+    # method="identity",
+    # min_abundance=100,
+    # total_min_abundance=1000,
+    max_edit_dist=3,
+    debug=False,
+):
+    """Run the edit-graph command with arguments from the command line.
+
+    Plan is to show sequences from a database (possibly with species/genus
+    limits) and/or selected FASTA files (possibly with predictions or other
+    metadata, and minimum abundance limits).
+    """
+    md5_to_seq = {}
+    md5_species = {}
+
+    # Connect to the DB,
+    Session = connect_to_db(db_url, echo=debug)
+    session = Session()
+
+    # Doing a join to pull in the ITS1 and Taxonomy tables too:
+    cur_tax = aliased(Taxonomy)
+    its1_seq = aliased(ITS1)
+    view = (
+        session.query(SequenceSource)
+        .join(its1_seq, SequenceSource.its1)
+        .join(cur_tax, SequenceSource.current_taxonomy)
+        .options(contains_eager(SequenceSource.its1, alias=its1_seq))
+        .options(contains_eager(SequenceSource.current_taxonomy, alias=cur_tax))
+    )
+    # Sorting for reproducibility
+    view = view.order_by(SequenceSource.id)
+    # TODO - Copy genus/species filtering behvaiour from dump command?
+
+    for seq_source in view:
+        md5 = seq_source.its1.md5
+        md5_to_seq[md5] = seq_source.its1.sequence
+        genus_species = genus_species_name(
+            seq_source.current_taxonomy.genus, seq_source.current_taxonomy.species
+        )
+        try:
+            md5_species[md5].add(genus_species)
+        except KeyError:
+            md5_species[md5] = {genus_species}
+
+    # SIZE = 100 / (total_max_abundance - total_min_abundance)  # scaling factor
+    graph = nx.Graph()
+    node_colors = []
+    node_labels = {}
+    node_sizes = []
+    for check1 in md5_to_seq:
+        graph.add_node(check1)
+        if md5_species[check1]:
+            node_colors.append("#ff0000")
+            node_labels[check1] = "\n".join(sorted(md5_species[check1])).replace(
+                "Phytophthora", "P."
+            )
+        else:
+            node_colors.append("#808080")
+        # node_sizes.append(SIZE * (md5_abundance[check1] - total_min_abundance))
+        node_sizes.append(1)
+    if debug:
+        sys.stderr.write(
+            "Node sizes %0.2f to %0.2f\n" % (min(node_sizes), max(node_sizes))
+        )
+
+    # for check1 in md5_abundance:
+    #    if check1 in node_labels:
+    #        if debug:
+    #            node_labels[check1] += "\n" + check1[:6]
+    #    else:
+    #        node_labels[check1] = check1[:6]
+
+    if debug:
+        sys.stderr.write(
+            "DEBUG: About to compute edit distances between %i unique sequences\n"
+            % len(md5_to_seq)
+        )
+    edge_count = 0
+    edge_style = []
+    edge_width = []
+    edge_color = []
+    for i, check1 in enumerate(md5_to_seq):
+        seq1 = md5_to_seq[check1]
+        for j, check2 in enumerate(md5_to_seq):
+            if i < j:
+                seq2 = md5_to_seq[check2]
+                dist = levenshtein(seq1, seq2)
+                if dist <= max_edit_dist:
+                    # Some graph layout algorithms can use weight attr
+                    graph.add_edge(check1, check2, weight=1.0 / dist)
+                    edge_count += 1
+                    if dist <= 1:
+                        edge_style.append("solid")
+                        edge_width.append(1.0)
+                        edge_color.append("#404040")
+                    elif dist <= 2:
+                        edge_style.append("dashed")
+                        edge_width.append(0.33)
+                        edge_color.append("#707070")
+                    else:
+                        edge_style.append("dotted")
+                        edge_width.append(0.25)
+                        edge_color.append("#808080")
+                    # if debug:
+                    #    sys.stderr.write("%s\t%s\t%i\n" % (check1, check2, dist))
+
+    if debug:
+        sys.stderr.write(
+            "DEBUG: %i edges up to maximum edit distance %i\n"
+            % (edge_count, max_edit_dist)
+        )
+
+    placement = nx.drawing.nx_pydot.graphviz_layout(graph, "fdp")
+    nx.draw_networkx_nodes(
+        graph,
+        placement,
+        node_color=node_colors,
+        # node_labels=node_labels,
+        node_size=node_sizes,
+    )
+    nx.draw_networkx_edges(
+        graph,
+        placement,
+        style=edge_style,
+        width=edge_width,
+        edge_color=edge_color,
+        alpha=0.5,
+    )
+    nx.draw_networkx_labels(graph, placement, node_labels, font_size=4)
+    plt.axis("off")
+    plt.savefig(graph_output)
+
+    return 0

--- a/thapbi_pict/edit_graph.py
+++ b/thapbi_pict/edit_graph.py
@@ -341,6 +341,7 @@ def main(
             % (redundant2, redundant3)
         )
 
+    # TODO: Try "sfdp" but need GraphViz built with triangulation library
     placement = nx.drawing.nx_pydot.graphviz_layout(graph, "fdp")
     nx.draw_networkx_nodes(
         graph,

--- a/thapbi_pict/edit_graph.py
+++ b/thapbi_pict/edit_graph.py
@@ -476,23 +476,11 @@ def main(
         # PDF to stdout?
         plt.savefig(graph_output)
     elif graph_format == "graphml":
-        if graph_output == "-":
-            for line in nx.generate_graphml(graph):
-                # Seems not to bother including the new line...
-                sys.stdout.write(line.rstrip() + "\n")
-        else:
-            with open(graph_output, "w") as handle:
-                for line in nx.generate_graphml(graph):
-                    # Seems not to bother including the new line...
-                    handle.write(line.rstrip() + "\n")
+        nx.write_graphml(graph, "/dev/stdout" if graph_output == "-" else graph_output)
     elif graph_format == "gexf":
-        nx.readwrite.gexf.write_gexf(
-            graph, "/dev/stdout" if graph_output == "-" else graph_output
-        )
+        nx.write_gexf(graph, "/dev/stdout" if graph_output == "-" else graph_output)
     elif graph_format == "gml":
-        nx.readwrite.gml.write_gml(
-            graph, "/dev/stdout" if graph_output == "-" else graph_output
-        )
+        nx.write_gml(graph, "/dev/stdout" if graph_output == "-" else graph_output)
     else:
         # Typically this would be caught in __main__.py
         sys.exit("ERROR: Unexpected graph output format: %s" % graph_format)

--- a/thapbi_pict/edit_graph.py
+++ b/thapbi_pict/edit_graph.py
@@ -56,6 +56,8 @@ def main(
     # TODO - Copy genus/species filtering behvaiour from dump command?
 
     for seq_source in view:
+        # if debug and len(md5_to_seq) > 1000:
+        #    break
         md5 = seq_source.its1.md5
         md5_to_seq[md5] = seq_source.its1.sequence
         genus_species = genus_species_name(
@@ -65,6 +67,13 @@ def main(
             md5_species[md5].add(genus_species)
         except KeyError:
             md5_species[md5] = {genus_species}
+
+    for md5 in md5_species:
+        for genus_species in [_ for _ in md5_species[md5] if species_level(_)]:
+            genus = genus_species.split(None, 1)[0]
+            if genus in md5_species[md5]:
+                # If have species level, discard genus level only
+                md5_species[md5].remove(genus)
 
     # SIZE = 100 / (total_max_abundance - total_min_abundance)  # scaling factor
     graph = nx.Graph()
@@ -76,7 +85,7 @@ def main(
         sp = md5_species[check1]
         if not sp:
             node_colors.append("#808080")
-        elif species_level(sp):
+        elif any(species_level(_) for _ in sp):
             node_colors.append("#ff0000")
             node_labels[check1] = "\n".join(sorted(sp)).replace("Phytophthora", "P.")
         else:

--- a/thapbi_pict/edit_graph.py
+++ b/thapbi_pict/edit_graph.py
@@ -351,9 +351,9 @@ def main(
     else:
         # Happens with DB only graph,
         SIZE = 100
-    graph = nx.Graph()
-    graph.graph["node_default"] = {"color": "#8B0000", "size": 1.0}
-    graph.graph["edge_default"] = {"color": "#808080", "weight": 1.0}
+    G = nx.Graph()
+    G.graph["node_default"] = {"color": "#8B0000", "size": 1.0}
+    G.graph["edge_default"] = {"color": "#808080", "weight": 1.0}
     for clump in clumps:
         if len(clump) < MIN_CLUMP:
             continue
@@ -380,7 +380,7 @@ def main(
             node_size = max(
                 1, SIZE * (md5_abundance.get(check1, 0) - total_min_abundance)
             )
-            graph.add_node(check1, color=node_color, size=node_size, label=node_label)
+            G.add_node(check1, color=node_color, size=node_size, label=node_label)
 
     edge_count = 0
     edge_count1 = edge_count2 = edge_count3 = 0
@@ -412,7 +412,7 @@ def main(
                     # Redundant edge, if dist=2, two 1bp edges exist
                     # Or, if dist=3, three 1bp edges exist, or 1bp+2bp
                     redundant += 1
-                    graph.add_edge(
+                    G.add_edge(
                         check1,
                         check2,
                         len=edge_length,
@@ -429,7 +429,7 @@ def main(
                     # Some graph layout algorithms can use weight attr; some want int
                     # Larger weight makes it closer to the requested length.
                     # fdp default length is 0.3, neato is 1.0
-                    graph.add_edge(
+                    G.add_edge(
                         check1,
                         check2,
                         len=edge_length,
@@ -481,6 +481,6 @@ def main(
         # Typically this would be caught in __main__.py
         sys.exit("ERROR: Unexpected graph output format: %s" % graph_format)
 
-    write_fn(graph, "/dev/stdout" if graph_output == "-" else graph_output)
+    write_fn(G, "/dev/stdout" if graph_output == "-" else graph_output)
 
     return 0

--- a/thapbi_pict/edit_graph.py
+++ b/thapbi_pict/edit_graph.py
@@ -271,6 +271,7 @@ def main(
     #        node_labels[check1] = check1[:6]
 
     edge_count = 0
+    edge_count1 = edge_count2 = edge_count3 = 0
     edge_style = []
     edge_width = []
     edge_color = []
@@ -301,19 +302,24 @@ def main(
                 graph.add_edge(
                     check1,
                     check2,
+                    # i.e. edit distance 1, 2, 3 becomes distance 0.1, 0.2 and 0.3
                     len=0.3 * dist / max_edit_dist,
+                    # i.e. edit distance 1, 2, 3 get weights 3, 2, 1
                     weight=max_edit_dist - dist + 1,
                 )
                 edge_count += 1
                 if dist <= 1:
+                    edge_count1 += 1
                     edge_style.append("solid")
                     edge_width.append(1.0)
                     edge_color.append("#404040")
                 elif dist <= 2:
+                    edge_count2 += 1
                     edge_style.append("dashed")
                     edge_width.append(0.33)
                     edge_color.append("#707070")
                 else:
+                    edge_count3 += 1
                     edge_style.append("dotted")
                     edge_width.append(0.25)
                     edge_color.append("#808080")
@@ -325,6 +331,11 @@ def main(
             "DEBUG: %i edges up to maximum edit distance %i\n"
             % (edge_count, max_edit_dist)
         )
+        sys.stderr.write(
+            "DEBUG: %i one-bp edges; %i two-bp edges; %i three-bp edges.\n"
+            % (edge_count1, edge_count2, edge_count3)
+        )
+        assert edge_count == edge_count1 + edge_count2 + edge_count3
         sys.stderr.write(
             "DEBUG: Dropped %i redundant 2-bp edges, and %i redundant 3-bp edges\n"
             % (redundant2, redundant3)

--- a/thapbi_pict/edit_graph.py
+++ b/thapbi_pict/edit_graph.py
@@ -86,8 +86,14 @@ def write_pdf(G, filename):
 
 
 def write_xgmml(G, filename, name="THAPBI PICT edit-graph"):
-    """Call networkxxgmml to save graph in XGML format."""
+    """Call networkxgmml to save graph in XGML format."""
     from networkxgmml import XGMMLWriter
+
+    # Hack for bug in networkxgmml
+    # https://github.com/informationsea/networkxxgmml/issues/14
+    for e in G.edges():
+        del G.edges[e]["style"]
+        del G.edges[e]["color"]
 
     with open(filename, "w") as handle:
         XGMMLWriter(handle, G, name, directed=False)

--- a/thapbi_pict/edit_graph.py
+++ b/thapbi_pict/edit_graph.py
@@ -349,8 +349,9 @@ def main(
                     # ValueError: Unrecognized linestyle: invis
                     edge_style = "dotted"
                     edge_width = 0.1
-                    edge_color = "#0000FF9F"  # blue for debug
+                    edge_color = "#0000FF9F"  # transparent blue for debug
                     # edge_color = "#000000FF"  # fully transparent
+                    continue
                 else:
                     # Some graph layout algorithms can use weight attr; some want int
                     # Larger weight makes it closer to the requested length.

--- a/thapbi_pict/edit_graph.py
+++ b/thapbi_pict/edit_graph.py
@@ -470,12 +470,18 @@ def main(
         )
         nx.draw_networkx_labels(graph, placement, node_labels, font_size=4)
         plt.axis("off")
+        # PDF to stdout?
         plt.savefig(graph_output)
     elif graph_format == "graphml":
-        with open(graph_output, "w") as handle:
+        if graph_output == "-":
             for line in nx.generate_graphml(graph):
                 # Seems not to bother including the new line...
-                handle.write(line.rstrip() + "\n")
+                sys.stdout.write(line.rstrip() + "\n")
+        else:
+            with open(graph_output, "w") as handle:
+                for line in nx.generate_graphml(graph):
+                    # Seems not to bother including the new line...
+                    handle.write(line.rstrip() + "\n")
     else:
         # Typically this would be caught in __main__.py
         sys.exit("ERROR: Unexpected graph output format: %s" % graph_format)

--- a/thapbi_pict/edit_graph.py
+++ b/thapbi_pict/edit_graph.py
@@ -14,7 +14,7 @@ from sqlalchemy.orm import aliased, contains_eager
 
 from .db_orm import ITS1, SequenceSource, Taxonomy, connect_to_db
 
-from .utils import genus_species_name
+from .utils import genus_species_name, species_level
 
 
 def main(
@@ -73,13 +73,15 @@ def main(
     node_sizes = []
     for check1 in md5_to_seq:
         graph.add_node(check1)
-        if md5_species[check1]:
-            node_colors.append("#ff0000")
-            node_labels[check1] = "\n".join(sorted(md5_species[check1])).replace(
-                "Phytophthora", "P."
-            )
-        else:
+        sp = md5_species[check1]
+        if not sp:
             node_colors.append("#808080")
+        elif species_level(sp):
+            node_colors.append("#ff0000")
+            node_labels[check1] = "\n".join(sorted(sp)).replace("Phytophthora", "P.")
+        else:
+            # Genus only, dark red
+            node_colors.append("#600000")
         # node_sizes.append(SIZE * (md5_abundance[check1] - total_min_abundance))
         node_sizes.append(1)
     if debug:

--- a/thapbi_pict/edit_graph.py
+++ b/thapbi_pict/edit_graph.py
@@ -263,7 +263,12 @@ def main(
                     # Some graph layout algorithms can use weight attr; some want int
                     # Larger weight makes it closer to the requested length.
                     # fdp default length is 0.3, neato is 1.0
-                    graph.add_edge(check1, check2, len=0.3 * dist / max_edit_dist)
+                    graph.add_edge(
+                        check1,
+                        check2,
+                        len=0.3 * dist / max_edit_dist,
+                        weight=max_edit_dist - dist + 1,
+                    )
                     edge_count += 1
                     if dist <= 1:
                         edge_style.append("solid")

--- a/thapbi_pict/edit_graph.py
+++ b/thapbi_pict/edit_graph.py
@@ -105,13 +105,13 @@ def write_xgmml(G, filename, name="THAPBI PICT edit-graph"):
             except KeyError:
                 label = None
             if not label:
-                # Cytoscape does not like blank labels:
-                label = n
-            handle.write('  <node label="%s" id="%s">\n' % (label, n))
+                label = n[:6]  # start of MD5
+            handle.write('  <node id="%s" label="%s">\n' % (n, label))
             color = node["color"]
-            size = node["size"]
+            # Size 1 to 100 works find in PDF output, not in Cytoscape!
+            size = (node["size"] * 0.95) + 5.0
             handle.write(
-                '    <graphics type="CIRCLE" fill="%s" width="0" outline="#000000" '
+                '    <graphics type="CIRCLE" fill="%s" outline="#000000" '
                 'h="%0.2f" w="%0.2f"/>\n' % (color, size, size)
             )
             handle.write("  </node>\n")

--- a/thapbi_pict/edit_graph.py
+++ b/thapbi_pict/edit_graph.py
@@ -89,6 +89,11 @@ def write_xgmml(G, filename, name="THAPBI PICT edit-graph"):
     """Call networkxgmml to save graph in XGML format."""
     from networkxgmml import XGMMLWriter
 
+    for n in G:
+        if "label" in G.nodes[n] and not G.nodes[n]["label"]:
+            # Cytoscape does not like blank labels:
+            G.nodes[n]["label"] = n
+
     # Hack for bug in networkxgmml
     # https://github.com/informationsea/networkxxgmml/issues/14
     for e in G.edges():

--- a/thapbi_pict/edit_graph.py
+++ b/thapbi_pict/edit_graph.py
@@ -17,6 +17,25 @@ from .db_orm import ITS1, SequenceSource, Taxonomy, connect_to_db
 from .utils import genus_species_name, species_level
 
 
+genus_color = {
+    # From the VGA colors, in order of DB abundance,
+    "Phytophthora": "#FF0000",  # Red
+    "Peronospora": "#00FF00",  # Lime
+    "Hyaloperonospora": "#0000FF",  # Blue
+    "Bremia": "#FFFF00",  # Yellow
+    "Pseudoperonospora": "#00FFFF",  # Cyan
+    "Plasmopara": "#FF00FF",  # Magenta
+    "Nothophytophthora": "#800000",  # Maroon
+    "Peronosclerospora": "#808000",  # Olive
+    "Perofascia": "#008000",  # Green
+    "Paraperonospora": "#800080",  # Purple
+    "Protobremia": "#008080",  # Teal
+    # Basidiophora
+    # Calycofera
+    # Plasmoverna
+}
+
+
 def main(
     graph_output,
     db_url,
@@ -83,14 +102,20 @@ def main(
     for check1 in md5_to_seq:
         graph.add_node(check1)
         sp = md5_species[check1]
-        if not sp:
-            node_colors.append("#808080")
-        elif any(species_level(_) for _ in sp):
-            node_colors.append("#ff0000")
+        genus = sorted({_.split(None, 1)[0] for _ in sp})
+        if not genus:
+            node_colors.append("#808080")  # grey
+        elif len(genus) > 1:
+            node_colors.append("#FF8C00")  # dark orange
+        elif genus[0] in genus_color:
+            node_colors.append(genus_color[genus[0]])
+        else:
+            node_colors.append("#8B0000")  # dark red
+        if any(species_level(_) for _ in sp):
             node_labels[check1] = "\n".join(sorted(sp)).replace("Phytophthora", "P.")
         else:
-            # Genus only, dark red
-            node_colors.append("#600000")
+            # Genus only
+            pass
         # node_sizes.append(SIZE * (md5_abundance[check1] - total_min_abundance))
         node_sizes.append(1)
     if debug:

--- a/thapbi_pict/edit_graph.py
+++ b/thapbi_pict/edit_graph.py
@@ -101,11 +101,11 @@ def write_xgmml(G, filename, name="THAPBI PICT edit-graph"):
         for n in G:
             node = G.nodes[n]
             try:
-                label = node["label"]
+                label = node["label"].replace("\n", ";")  # Undo newline for Graphviz
             except KeyError:
                 label = None
             if not label:
-                label = n[:6]  # start of MD5
+                label = "{%s}" % n[:6]  # start of MD5, prefixed for sorting
             # weight = node["weight"]
             handle.write('  <node id="%s" label="%s">\n' % (n, label))
             color = node["color"]

--- a/thapbi_pict/edit_graph.py
+++ b/thapbi_pict/edit_graph.py
@@ -224,7 +224,13 @@ def main(
         % (len(dropped), max_edit_dist)
     )
 
-    SIZE = 100 / (max(md5_abundance.values()) - total_min_abundance)  # scaling factor
+    if md5_abundance:
+        SIZE = 100 / (
+            max(md5_abundance.values()) - total_min_abundance
+        )  # scaling factor
+    else:
+        # Happens with DB only graph,
+        SIZE = 100
     graph = nx.Graph()
     node_colors = []
     node_labels = {}

--- a/thapbi_pict/edit_graph.py
+++ b/thapbi_pict/edit_graph.py
@@ -46,65 +46,6 @@ genus_color = {
 }
 
 
-def connected_components(boolean_edge_matrix):
-    """Given an N x N boolean symetric edge matrix, return a partition of the N nodes.
-
-    For example, this 3 x 3 matrix breaks down into two connected components,
-    node 0 and 2, and node 1 on its own:
-
-    >>> import numpy as np
-    >>> connected_components(np.array([[0, 0, 1], [0, 0, 0], [1, 0, 0]], np.bool))
-    [(0, 2), (1, )]
-
-    The partition is sorted by size (largest component first)
-    """
-    # Could have built a NetworkX object, and used their code...
-    n = boolean_edge_matrix.shape[0]
-    if boolean_edge_matrix.shape != (n, n):
-        raise ValueError("Expected a square adjacency matrix")
-    partition = [{_} for _ in range(n)]
-    for i in range(n):
-        # So, what is node i connected to?
-        for j in range(n):
-            if boolean_edge_matrix[i, j] != boolean_edge_matrix[j, i]:
-                raise ValueError("Expected a symmetric adjacency matrix")
-            if i < j:
-                continue
-            if boolean_edge_matrix[i, j]:
-                # Need to merge the partitions containing i and j
-                i_old = [_ for _ in partition if i in _]
-                assert len(i_old) == 1
-                i_old = i_old[0]
-                j_old = [_ for _ in partition if j in _]
-                assert len(j_old) == 1, (
-                    "%i found in %i members of the partitioning %r"
-                    % (j, len(j_old), partition)
-                )
-                j_old = j_old[0]
-                if i_old == j_old:
-                    # Already in same partition
-                    continue
-                # Need to merge the partitions containing i and j
-                partition = [_ for _ in partition if i not in _ and j not in _]
-                partition.append(i_old.union(j_old))
-    return [tuple(sorted(_)) for _ in sorted(partition, key=len, reverse=True)]
-
-
-assert connected_components(np.array([[0, 0, 1], [0, 0, 0], [1, 0, 0]], np.bool)) == [
-    (0, 2),
-    (1,),
-]
-assert connected_components(
-    np.array([[0, 0, 1, 1], [0, 0, 0, 1], [1, 0, 0, 1], [1, 1, 1, 0]], np.bool)
-) == [(0, 1, 2, 3)]
-assert connected_components(
-    np.array([[0, 0, 1, 0], [0, 0, 0, 1], [1, 0, 0, 1], [0, 1, 1, 0]], np.bool)
-) == [(0, 1, 2, 3)]
-assert connected_components(
-    np.array([[0, 0, 1, 0], [0, 0, 0, 1], [1, 0, 0, 0], [0, 1, 0, 0]], np.bool)
-) == [(0, 2), (1, 3)]
-
-
 def write_pdf(G, filename):
     """Render NetworkX graph to PDF using GraphViz fdp."""
     # TODO: Try "sfdp" but need GraphViz built with triangulation library
@@ -157,8 +98,6 @@ def main(
     if inputs is None:
         inputs = []
     assert isinstance(inputs, list)
-
-    MIN_CLUMP = 150  # command line option?
 
     if 3 < max_edit_dist:
         sys.exit("ERROR: Maximum supported edit distance is 3bp.")
@@ -303,12 +242,6 @@ def main(
         % (n * (n - 1), n)
     )
 
-    clumps = connected_components(distances <= max_edit_dist)
-    sys.stderr.write(
-        "Max edit distance %i gave %i connected components (size %i to %i).\n"
-        % (max_edit_dist, len(clumps), len(clumps[0]), len(clumps[-1]))
-    )
-
     # Matrix computation of multi-step paths vs edit distances, e.g.
     # will use fact A-B is 1bp and B-C is 2bp to skip drawing A-C of 3bp.
     one_bp = distances == 1  # boolean
@@ -321,24 +254,19 @@ def main(
 
     md5_list = list(md5_to_seq)
     dropped = set()
-    for clump in clumps:
-        if MIN_CLUMP <= len(clump):
-            # Keep them all
+    for md5 in md5_list:
+        if total_min_abundance <= md5_abundance.get(md5, 0):
+            # High abundance, include it (not applied to DB sequences)
             continue
-        for index in clump:
-            md5 = md5_list[index]
-            if total_min_abundance <= md5_abundance.get(md5, 0):
-                # High abundance, include it (not applied to DB sequences)
-                continue
-            # # Ignore self-vs-self which will be zero distance
-            # if i > 1 and min(distances[i, 0 : i - 1]) <= max_edit_dist:
-            #    # Good, will draw this
-            #    continue
-            # elif i + 1 < n and min(distances[i, i + 1 :]) <= max_edit_dist:
-            #    # Good, will draw this
-            #    continue
-            # No reason to draw this:
-            dropped.add(md5)
+        # Ignore self-vs-self which will be zero distance
+        if i > 1 and min(distances[i, 0 : i - 1]) <= max_edit_dist:
+            # Good, will draw this
+            continue
+        elif i + 1 < n and min(distances[i, i + 1 :]) <= max_edit_dist:
+            # Good, will draw this
+            continue
+        # No reason to draw this:
+        dropped.add(md5)
     sys.stderr.write(
         "Dropped %i sequences with no siblings within maximum edit distance %i.\n"
         % (len(dropped), max_edit_dist)
@@ -354,31 +282,27 @@ def main(
     G = nx.Graph()
     G.graph["node_default"] = {"color": "#8B0000", "size": 1.0}
     G.graph["edge_default"] = {"color": "#808080", "weight": 1.0}
-    for clump in clumps:
-        if len(clump) < MIN_CLUMP:
+    for md5 in md5_list:
+        if md5 in dropped:
             continue
-        for index in clump:
-            md5 = md5_list[index]
-            if md5 in dropped:
-                continue
-            sp = md5_species.get(md5, [])
-            genus = sorted({_.split(None, 1)[0] for _ in sp})
-            if not genus:
-                node_color = "#808080"  # grey
-            elif len(genus) > 1:
-                node_color = "#FF8C00"  # dark orange
-            elif genus[0] in genus_color:
-                node_color = genus_color[genus[0]]
-            else:
-                node_color = "#8B0000"  # dark red
-            if any(species_level(_) for _ in sp):
-                node_label = "\n".join(sorted(sp)).replace("Phytophthora", "P.")
-            else:
-                # Genus only
-                node_label = ""
-            # DB only entries get size one, FASTA entries can be up to 100.
-            node_size = max(1, SIZE * (md5_abundance.get(md5, 0) - total_min_abundance))
-            G.add_node(md5, color=node_color, size=node_size, label=node_label)
+        sp = md5_species.get(md5, [])
+        genus = sorted({_.split(None, 1)[0] for _ in sp})
+        if not genus:
+            node_color = "#808080"  # grey
+        elif len(genus) > 1:
+            node_color = "#FF8C00"  # dark orange
+        elif genus[0] in genus_color:
+            node_color = genus_color[genus[0]]
+        else:
+            node_color = "#8B0000"  # dark red
+        if any(species_level(_) for _ in sp):
+            node_label = "\n".join(sorted(sp)).replace("Phytophthora", "P.")
+        else:
+            # Genus only
+            node_label = ""
+        # DB only entries get size one, FASTA entries can be up to 100.
+        node_size = max(1, SIZE * (md5_abundance.get(md5, 0) - total_min_abundance))
+        G.add_node(md5, color=node_color, size=node_size, label=node_label)
 
     edge_count = 0
     edge_count1 = edge_count2 = edge_count3 = 0

--- a/thapbi_pict/edit_graph.py
+++ b/thapbi_pict/edit_graph.py
@@ -60,6 +60,8 @@ def main(
     limits) and/or selected FASTA files (possibly with predictions or other
     metadata, and minimum abundance limits).
     """
+    if inputs is None:
+        inputs = []
     assert isinstance(inputs, list)
 
     if 3 < max_edit_dist:

--- a/thapbi_pict/edit_graph.py
+++ b/thapbi_pict/edit_graph.py
@@ -358,10 +358,10 @@ def main(
         if len(clump) < MIN_CLUMP:
             continue
         for index in clump:
-            check1 = md5_list[index]
-            if check1 in dropped:
+            md5 = md5_list[index]
+            if md5 in dropped:
                 continue
-            sp = md5_species.get(check1, [])
+            sp = md5_species.get(md5, [])
             genus = sorted({_.split(None, 1)[0] for _ in sp})
             if not genus:
                 node_color = "#808080"  # grey
@@ -377,10 +377,8 @@ def main(
                 # Genus only
                 node_label = ""
             # DB only entries get size one, FASTA entries can be up to 100.
-            node_size = max(
-                1, SIZE * (md5_abundance.get(check1, 0) - total_min_abundance)
-            )
-            G.add_node(check1, color=node_color, size=node_size, label=node_label)
+            node_size = max(1, SIZE * (md5_abundance.get(md5, 0) - total_min_abundance))
+            G.add_node(md5, color=node_color, size=node_size, label=node_label)
 
     edge_count = 0
     edge_count1 = edge_count2 = edge_count3 = 0
@@ -388,13 +386,13 @@ def main(
     edge_width = []
     edge_color = []
     redundant = 0
-    for i, check1 in enumerate(md5_to_seq):
+    for i, check1 in enumerate(md5_list):
         if check1 in dropped:
             continue
-        seq1 = md5_to_seq[check1]
-        for j, check2 in enumerate(md5_to_seq):
+        # seq1 = md5_to_seq[check1]
+        for j, check2 in enumerate(md5_list):
             if i < j and check2 not in dropped:
-                seq2 = md5_to_seq[check2]
+                # seq2 = md5_to_seq[check2]
                 # dist = levenshtein(seq1, seq2)
                 dist = distances[i, j]
                 # Some graph layout algorithms can use weight attr; some want int

--- a/thapbi_pict/edit_graph.py
+++ b/thapbi_pict/edit_graph.py
@@ -105,36 +105,37 @@ assert connected_components(
 ) == [(0, 2), (1, 3)]
 
 
-def write_pdf(graph, filename):
+def write_pdf(G, filename):
     """Render NetworkX graph to PDF using GraphViz fdp."""
     # TODO: Try "sfdp" but need GraphViz built with triangulation library
-    default = graph["node_default"]["color"]
-    node_colors = [graph.node[_].get("color", default) for _ in graph]
+    default = G.graph["node_default"]["color"]
+    node_colors = [G.node[_].get("color", default) for _ in G]
 
     default = 1.0
-    node_sizes = [graph.node[_].get("size", default) for _ in graph]
+    node_sizes = [G.node[_].get("size", default) for _ in G]
 
     default = ""
-    node_labels = [graph.node[_].get("label", default) for _ in graph]
+    node_labels = {_: G.node[_].get("label", default) for _ in G}
 
-    default = graph["edge_default"]["color"]
-    edge_colors = [graph.edge[_].get("color", default) for _ in graph.edges]
+    default = G.graph["edge_default"]["color"]
+    # edge_colors = [G.edges[_].get("color", default) for _ in G.edges]
 
-    placement = nx.drawing.nx_pydot.graphviz_layout(graph, "fdp")
-    nx.draw_networkx_nodes(
-        graph, placement, node_color=node_colors, node_size=node_sizes
-    )
+    placement = nx.drawing.nx_pydot.graphviz_layout(G, "fdp")
+    nx.draw_networkx_nodes(G, placement, node_color=node_colors, node_size=node_sizes)
     nx.draw_networkx_edges(
-        graph,
+        G,
         placement,
         # style=edge_styles,
         # width=edge_widths,
-        edge_color=edge_colors,
+        # edge_color=edge_colors,
         alpha=0.5,
     )
-    nx.draw_networkx_labels(graph, placement, node_labels, font_size=4)
+    nx.draw_networkx_labels(G, placement, node_labels, font_size=4)
     plt.axis("off")
-    plt.savefig(filename)
+    if filename in ["-", "/dev/stdout"]:
+        plt.savefig(sys.stdout.buffer, format="pdf")
+    else:
+        plt.savefig(filename, format="pdf")
 
 
 def main(

--- a/thapbi_pict/edit_graph.py
+++ b/thapbi_pict/edit_graph.py
@@ -58,17 +58,23 @@ def write_pdf(G, filename):
     default = ""
     node_labels = {_: G.node[_].get("label", default) for _ in G}
 
+    default = G.graph["edge_default"]["style"]
+    edge_styles = [G.edges[_].get("style", default) for _ in G.edges()]
+
     default = G.graph["edge_default"]["color"]
-    # edge_colors = [G.edges[_].get("color", default) for _ in G.edges]
+    edge_colors = [G.edges[_].get("color", default) for _ in G.edges()]
+
+    default = G.graph["edge_default"]["width"]
+    edge_widths = [G.edges[_].get("width", default) for _ in G.edges()]
 
     placement = nx.drawing.nx_pydot.graphviz_layout(G, "fdp")
     nx.draw_networkx_nodes(G, placement, node_color=node_colors, node_size=node_sizes)
     nx.draw_networkx_edges(
         G,
         placement,
-        # style=edge_styles,
-        # width=edge_widths,
-        # edge_color=edge_colors,
+        style=edge_styles,
+        width=edge_widths,
+        edge_color=edge_colors,
         alpha=0.5,
     )
     nx.draw_networkx_labels(G, placement, node_labels, font_size=4)
@@ -281,7 +287,12 @@ def main(
         SIZE = 100
     G = nx.Graph()
     G.graph["node_default"] = {"color": "#8B0000", "size": 1.0}
-    G.graph["edge_default"] = {"color": "#808080", "weight": 1.0}
+    G.graph["edge_default"] = {
+        "color": "#FF0000",
+        "weight": 1.0,
+        "width": 1.0,
+        "style": "solid",
+    }
     for md5 in md5_list:
         if md5 in dropped:
             continue
@@ -334,48 +345,42 @@ def main(
                     # Redundant edge, if dist=2, two 1bp edges exist
                     # Or, if dist=3, three 1bp edges exist, or 1bp+2bp
                     redundant += 1
-                    G.add_edge(
-                        check1,
-                        check2,
-                        len=edge_length,
-                        K=edge_length,
-                        weight=edge_weight,
-                    )
-                    # edge_style.append("invis")
+                    # edge_style = "invis"
                     # ValueError: Unrecognized linestyle: invis
-                    edge_style.append("dotted")
-                    edge_width.append(0.1)
-                    edge_color.append("#0000FF9F")  # blue for debug
-                    # edge_color.append("#000000FF")  # fully transparent
+                    edge_style = "dotted"
+                    edge_width = 0.1
+                    edge_color = "#0000FF9F"  # blue for debug
+                    # edge_color = "#000000FF"  # fully transparent
                 else:
                     # Some graph layout algorithms can use weight attr; some want int
                     # Larger weight makes it closer to the requested length.
                     # fdp default length is 0.3, neato is 1.0
-                    G.add_edge(
-                        check1,
-                        check2,
-                        len=edge_length,
-                        K=edge_length,
-                        weight=edge_weight,
-                    )
                     edge_count += 1
                     if dist <= 1:
                         edge_count1 += 1
-                        edge_style.append("solid")
-                        edge_width.append(1.0)
-                        edge_color.append("#404040")
+                        edge_style = "solid"
+                        edge_width = 1.0
+                        edge_color = "#404040"
                     elif dist <= 2:
                         edge_count2 += 1
-                        edge_style.append("dashed")
-                        edge_width.append(0.33)
-                        edge_color.append("#707070")
+                        edge_style = "dashed"
+                        edge_width = 0.33
+                        edge_color = "#707070"
                     else:
                         edge_count3 += 1
-                        edge_style.append("dotted")
-                        edge_width.append(0.25)
-                        edge_color.append("#808080")
-                    # if debug:
-                    #    sys.stderr.write("%s\t%s\t%i\n" % (check1, check2, dist))
+                        edge_style = "dotted"
+                        edge_width = 0.25
+                        edge_color = "#808080"
+                G.add_edge(
+                    check1,
+                    check2,
+                    len=edge_length,
+                    K=edge_length,
+                    weight=edge_weight,
+                    style=edge_style,
+                    width=edge_width,
+                    color=edge_color,
+                )
 
     if debug:
         sys.stderr.write(

--- a/thapbi_pict/edit_graph.py
+++ b/thapbi_pict/edit_graph.py
@@ -329,17 +329,17 @@ def main(
             check1 = md5_list[index]
             if check1 in dropped:
                 continue
-            graph.add_node(check1)
             sp = md5_species.get(check1, [])
             genus = sorted({_.split(None, 1)[0] for _ in sp})
             if not genus:
-                node_colors.append("#808080")  # grey
+                c = "#808080"  # grey
             elif len(genus) > 1:
-                node_colors.append("#FF8C00")  # dark orange
+                c = "#FF8C00"  # dark orange
             elif genus[0] in genus_color:
-                node_colors.append(genus_color[genus[0]])
+                c = genus_color[genus[0]]
             else:
-                node_colors.append("#8B0000")  # dark red
+                c = "#8B0000"  # dark red
+            node_colors.append(c)
             if any(species_level(_) for _ in sp):
                 node_labels[check1] = "\n".join(sorted(sp)).replace(
                     "Phytophthora", "P."
@@ -351,7 +351,10 @@ def main(
             node_sizes.append(
                 max(1, SIZE * (md5_abundance.get(check1, 0) - total_min_abundance))
             )
-    if debug:
+            # TODO - record color, label, size, etc on the node itself
+            graph.add_node(check1)
+    assert len(node_colors) == len(node_labels) == len(node_sizes)
+    if debug and node_sizes:
         sys.stderr.write(
             "Node sizes %0.2f to %0.2f\n" % (min(node_sizes), max(node_sizes))
         )
@@ -482,6 +485,14 @@ def main(
                 for line in nx.generate_graphml(graph):
                     # Seems not to bother including the new line...
                     handle.write(line.rstrip() + "\n")
+    elif graph_format == "gexf":
+        nx.readwrite.gexf.write_gexf(
+            graph, "/dev/stdout" if graph_output == "-" else graph_output
+        )
+    elif graph_format == "gml":
+        nx.readwrite.gml.write_gml(
+            graph, "/dev/stdout" if graph_output == "-" else graph_output
+        )
     else:
         # Typically this would be caught in __main__.py
         sys.exit("ERROR: Unexpected graph output format: %s" % graph_format)

--- a/thapbi_pict/edit_graph.py
+++ b/thapbi_pict/edit_graph.py
@@ -208,7 +208,7 @@ def main(
         % (len(dropped), max_edit_dist)
     )
 
-    # SIZE = 100 / (total_max_abundance - total_min_abundance)  # scaling factor
+    SIZE = 100 / (max(md5_abundance.values()) - total_min_abundance)  # scaling factor
     graph = nx.Graph()
     node_colors = []
     node_labels = {}
@@ -232,8 +232,10 @@ def main(
         else:
             # Genus only
             pass
-        # node_sizes.append(SIZE * (md5_abundance[check1] - total_min_abundance))
-        node_sizes.append(1)
+        # DB only entries get size one, FASTA entries can be up to 100.
+        node_sizes.append(
+            max(1, SIZE * (md5_abundance.get(check1, 0) - total_min_abundance))
+        )
     if debug:
         sys.stderr.write(
             "Node sizes %0.2f to %0.2f\n" % (min(node_sizes), max(node_sizes))

--- a/thapbi_pict/edit_graph.py
+++ b/thapbi_pict/edit_graph.py
@@ -117,7 +117,10 @@ def write_xgmml(G, filename, name="THAPBI PICT edit-graph"):
             handle.write("  </node>\n")
         for n1, n2 in G.edges():
             edge = G.edges[n1, n2]
-            handle.write('  <edge source="%s" target="%s">\n' % (n1, n2))
+            weight = edge["weight"]
+            handle.write(
+                '  <edge source="%s" target="%s" weight="%0.2f">\n' % (n1, n2, weight)
+            )
             # style = edge["style"]  # Not in XGMML?
             color = edge["color"]
             width = edge["width"]

--- a/thapbi_pict/edit_graph.py
+++ b/thapbi_pict/edit_graph.py
@@ -85,6 +85,14 @@ def write_pdf(G, filename):
         plt.savefig(filename, format="pdf")
 
 
+def write_xgmml(G, filename, name="THAPBI PICT edit-graph"):
+    """Call networkxxgmml to save graph in XGML format."""
+    from networkxgmml import XGMMLWriter
+
+    with open(filename, "w") as handle:
+        XGMMLWriter(handle, G, name, directed=False)
+
+
 def main(
     graph_output,
     graph_format,
@@ -401,6 +409,7 @@ def main(
         "gexf": nx.write_gexf,
         "gml": nx.write_gml,
         "graphml": nx.write_graphml,
+        "xgmml": write_xgmml,
         "pdf": write_pdf,
     }
     try:


### PR DESCRIPTION
Would partly help with #137, as can draw an edit-graph of the DB sequences.

Adds some new dependencies:

* ``python-levenshtein`` for calculating edit distances, does not have wheels but in conda

and:

* ``networkx`` for graphs (depending on desired output formats, not essential)
* ``matplotlib`` for PDF via ``networkx``
* ``graphviz`` for PDF layout via ``networkx``

Currently supports multiple graph output formats, static PDF, XGMML (XML suitable for Cytoscape, assigns colours and visual edge weights automatically) and a handful of other graph formats which are more painful to use in Cytoscape.

If we just focus on XGMML output, could slash the extra dependencies. But if we keep NetworkX etc, we could try doing the layout for XGMML output (currently leave this to the user to do in Cytoscape)?