### PR TITLE
Include edit-graph in pipeline; --total default off

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -22,4 +22,4 @@ include database/legacy/Phytophthora_ITS_database_v0.005.fasta
 
 # The following is better than a blanket include wildcard * but
 # this still risks unwanted includes of any working files:
-recursive-include tests *.sh *.txt *.tsv *.fasta *.fastq.gz
+recursive-include tests *.sh *.txt *.tsv *.fasta *.fastq.gz *.xgmml

--- a/tests/pipeline/thapbi-pict.edit-graph.xgmml
+++ b/tests/pipeline/thapbi-pict.edit-graph.xgmml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<graph directed="0"  xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://www.cs.rpi.edu/XGMML">
+  <node id="9e8f051c64c2b9cc3b6fcb27559418ca" label="P. plurivora">
+    <graphics type="CIRCLE" fill="#FF0000" outline="#000000" h="50.00" w="50.00"/>
+    <att type="string" name="MD5" value="9e8f051c64c2b9cc3b6fcb27559418ca"/>
+    <att type="integer" name="Total-abundance" value="985"/>
+    <att type="integer" name="Sample-count" value="1"/>
+    <att type="string" name="Genus" value="Phytophthora"/>
+    <att type="string" name="Taxonomy" value="Phytophthora plurivora"/>
+  </node>
+  <node id="2ba87367bdbb87cc37521bed773ffa37" label="P. rubi">
+    <graphics type="CIRCLE" fill="#FF0000" outline="#000000" h="50.00" w="50.00"/>
+    <att type="string" name="MD5" value="2ba87367bdbb87cc37521bed773ffa37"/>
+    <att type="integer" name="Total-abundance" value="829"/>
+    <att type="integer" name="Sample-count" value="1"/>
+    <att type="string" name="Genus" value="Phytophthora"/>
+    <att type="string" name="Taxonomy" value="Phytophthora rubi"/>
+  </node>
+  <node id="0368431c779b6d3b2555f68f90d047c5" label="{036843}">
+    <graphics type="CIRCLE" fill="#FF0000" outline="#000000" h="50.00" w="50.00"/>
+    <att type="string" name="MD5" value="0368431c779b6d3b2555f68f90d047c5"/>
+    <att type="integer" name="Total-abundance" value="395"/>
+    <att type="integer" name="Sample-count" value="1"/>
+    <att type="string" name="Genus" value="Phytophthora"/>
+    <att type="string" name="Taxonomy" value="Phytophthora"/>
+  </node>
+  <node id="5122dde24762f8e3d6a54e3f79077254" label="P. agathidicida;P. castaneae">
+    <graphics type="CIRCLE" fill="#FF0000" outline="#000000" h="50.00" w="50.00"/>
+    <att type="string" name="MD5" value="5122dde24762f8e3d6a54e3f79077254"/>
+    <att type="integer" name="Total-abundance" value="304"/>
+    <att type="integer" name="Sample-count" value="1"/>
+    <att type="string" name="Genus" value="Phytophthora"/>
+    <att type="string" name="Taxonomy" value="Phytophthora agathidicida;Phytophthora castaneae"/>
+  </node>
+  <node id="2b8e7a64e493e5c191e92f21596b4256" label="P. pseudocryptogea">
+    <graphics type="CIRCLE" fill="#FF0000" outline="#000000" h="50.00" w="50.00"/>
+    <att type="string" name="MD5" value="2b8e7a64e493e5c191e92f21596b4256"/>
+    <att type="integer" name="Total-abundance" value="301"/>
+    <att type="integer" name="Sample-count" value="1"/>
+    <att type="string" name="Genus" value="Phytophthora"/>
+    <att type="string" name="Taxonomy" value="Phytophthora pseudocryptogea"/>
+  </node>
+  <node id="6803c088eb1e53bb2e44bffecbaa0fdd" label="P. capsici;P. glovera">
+    <graphics type="CIRCLE" fill="#FF0000" outline="#000000" h="50.00" w="50.00"/>
+    <att type="string" name="MD5" value="6803c088eb1e53bb2e44bffecbaa0fdd"/>
+    <att type="integer" name="Total-abundance" value="297"/>
+    <att type="integer" name="Sample-count" value="1"/>
+    <att type="string" name="Genus" value="Phytophthora"/>
+    <att type="string" name="Taxonomy" value="Phytophthora capsici;Phytophthora glovera"/>
+  </node>
+  <node id="9577aa1a6c2da294ebbfa5c84cff65aa" label="P. crassamura;P. megasperma">
+    <graphics type="CIRCLE" fill="#FF0000" outline="#000000" h="50.00" w="50.00"/>
+    <att type="string" name="MD5" value="9577aa1a6c2da294ebbfa5c84cff65aa"/>
+    <att type="integer" name="Total-abundance" value="267"/>
+    <att type="integer" name="Sample-count" value="1"/>
+    <att type="string" name="Genus" value="Phytophthora"/>
+    <att type="string" name="Taxonomy" value="Phytophthora crassamura;Phytophthora megasperma"/>
+  </node>
+  <edge source="0368431c779b6d3b2555f68f90d047c5" target="2b8e7a64e493e5c191e92f21596b4256" weight="3.00">
+    <graphics fill="#404040" width="1.0"/>
+    <att type="integer" name="Edit-distance" value="1"/>
+    <att type="integer" name="Edit-distance-weight" value="3"/>
+  </edge>
+</graph>

--- a/tests/test_pipeline.sh
+++ b/tests/test_pipeline.sh
@@ -16,6 +16,7 @@ diff $TMP/intermediate/DNAMIX_S95_L001.fasta tests/prepare-reads/DNAMIX_S95_L001
 diff $TMP/output/thapbi-pict.samples.txt tests/pipeline/thapbi-pict.samples.onebp.txt
 diff $TMP/output/thapbi-pict.samples.tsv tests/pipeline/thapbi-pict.samples.onebp.tsv
 diff $TMP/output/thapbi-pict.reads.tsv tests/pipeline/thapbi-pict.reads.onebp.tsv
+diff $TMP/output/thapbi-pict.edit-graph.xgmml tests/pipeline/thapbi-pict.edit-graph.xgmml
 
 # Leaving the intermediate files in place... plus some stray files:
 touch $TMP/intermediate/unwanted.fasta
@@ -30,5 +31,6 @@ diff $TMP/intermediate/DNAMIX_S95_L001.fasta tests/prepare-reads/DNAMIX_S95_L001
 diff $TMP/output/thapbi-pict.samples.txt tests/pipeline/thapbi-pict.samples.onebp.txt
 diff $TMP/output/thapbi-pict.samples.tsv tests/pipeline/thapbi-pict.samples.onebp.tsv
 diff $TMP/output/thapbi-pict.reads.tsv tests/pipeline/thapbi-pict.reads.onebp.tsv
+diff $TMP/output/thapbi-pict.edit-graph.xgmml tests/pipeline/thapbi-pict.edit-graph.xgmml
 
 echo "$0 - test_pipeline.sh passed"

--- a/tests/test_pipeline.sh
+++ b/tests/test_pipeline.sh
@@ -26,11 +26,11 @@ touch $TMP/intermediate/distraction.fasta
 touch $TMP/intermediate/ignore-me.onebp.tsv
 # Run again with some explicit options set (shouldn't change output)
 rm -rf $TMP/output/*
-thapbi_pict pipeline -i tests/reads/ -s $TMP/intermediate -o $TMP/output -m onebp -a 250 -r thapbi-pict
+thapbi_pict pipeline -i tests/reads/ -s $TMP/intermediate -o $TMP/output -m onebp -a 250 -r report
 diff $TMP/intermediate/DNAMIX_S95_L001.fasta tests/prepare-reads/DNAMIX_S95_L001.fasta
-diff $TMP/output/thapbi-pict.samples.txt tests/pipeline/thapbi-pict.samples.onebp.txt
-diff $TMP/output/thapbi-pict.samples.tsv tests/pipeline/thapbi-pict.samples.onebp.tsv
-diff $TMP/output/thapbi-pict.reads.tsv tests/pipeline/thapbi-pict.reads.onebp.tsv
-diff $TMP/output/thapbi-pict.edit-graph.xgmml tests/pipeline/thapbi-pict.edit-graph.xgmml
+diff $TMP/output/report.samples.txt tests/pipeline/thapbi-pict.samples.onebp.txt
+diff $TMP/output/report.samples.tsv tests/pipeline/thapbi-pict.samples.onebp.tsv
+diff $TMP/output/report.reads.tsv tests/pipeline/thapbi-pict.reads.onebp.tsv
+diff $TMP/output/report.edit-graph.xgmml tests/pipeline/thapbi-pict.edit-graph.xgmml
 
 echo "$0 - test_pipeline.sh passed"

--- a/thapbi_pict/edit_graph.py
+++ b/thapbi_pict/edit_graph.py
@@ -169,7 +169,7 @@ def main(
     inputs,
     min_abundance=100,
     always_show_db=False,
-    total_min_abundance=1000,
+    total_min_abundance=0,
     max_edit_dist=3,
     debug=False,
 ):
@@ -240,15 +240,17 @@ def main(
             % (len(md5_in_fasta), len(samples))
         )
         # Drop low total abundance FASTA sequences now (before compute distances)
-        for md5, total in md5_abundance.items():
-            if total < total_min_abundance:
-                # Remove it!
-                md5_in_fasta.remove(md5)
-                del md5_to_seq[md5]
-        sys.stderr.write(
-            "Minimum total abundance threshold %i left %i sequences from FASTA files.\n"
-            % (total_min_abundance, len(md5_in_fasta))
-        )
+        if total_min_abundance:
+            for md5, total in md5_abundance.items():
+                if total < total_min_abundance:
+                    # Remove it!
+                    md5_in_fasta.remove(md5)
+                    del md5_to_seq[md5]
+            sys.stderr.write(
+                "Minimum total abundance threshold %i "
+                "left %i sequences from FASTA files.\n"
+                % (total_min_abundance, len(md5_in_fasta))
+            )
 
     if db_url:
         if debug:


### PR DESCRIPTION
Added XGMML edit-graph to the pipeline output, closes #149 

As part of this I have changed the edit-graph default minimum total abundance to zero (off). For the test case, the original default of 1000 would not work in the pipeline (no sequences to draw an edit-graph of), and I don't want to add it as a pipeline argument.