### PR TITLE
Use Sphinx apidoc & autodoc to include API docstrings

### DIFF
--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -1,0 +1,27 @@
+Python API
+==========
+
+.. automodule:: thapbi_pict
+   :members:
+      :undoc-members:
+         :show-inheritance:
+
+.. toctree::
+   :maxdepth: 1
+
+   thapbi_pict.assess
+   thapbi_pict.classify
+   thapbi_pict.db_import
+   thapbi_pict.db_orm
+   thapbi_pict.dump
+   thapbi_pict.edit_graph
+   thapbi_pict.hmm
+   thapbi_pict.legacy
+   thapbi_pict.ncbi
+   thapbi_pict.prepare
+   thapbi_pict.read_summary
+   thapbi_pict.sample_summary
+   thapbi_pict.seq_import
+   thapbi_pict.taxdump
+   thapbi_pict.utils
+   thapbi_pict.versions

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,7 @@
 """Configuration file for the Sphinx documentation builder."""
 
+import os
+
 import thapbi_pict
 
 # This file only contains a selection of the most common options. For a full
@@ -35,13 +37,16 @@ master_doc = "index"
 
 # -- General configuration ---------------------------------------------------
 
+# autodoc options require Sphinx 1.8.0b1 or later:
+needs_sphinx = "1.8"
+
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 #
 # We are using SVG images which work fine in the HTML output, but need
 # 'sphinx.ext.imgconverter' for it to work in the PDF output on RTD.
-extensions = ["sphinx.ext.imgconverter"]
+extensions = ["sphinx.ext.imgconverter", "sphinx.ext.autodoc", "sphinx.ext.autosummary"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
@@ -50,6 +55,19 @@ templates_path = ["_templates"]
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+
+# -- Options for autodoc --------------------------------------------------
+
+# This requires Sphinx 1.8.0b1 or later:
+autodoc_default_values = {
+    "members": None,
+    "undoc-members": None,
+    "special-members": None,
+    "show-inheritance": None,
+    "member-order": "bysource",
+    "exclude-members": "__dict__,__weakref__,__module__",
+}
 
 
 # -- Options for HTML output -------------------------------------------------
@@ -68,3 +86,25 @@ html_theme_options = {"prev_next_buttons_location": "both"}
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
+
+# -- Options for numpydoc -------------------------------------------------
+
+numpydoc_class_members_toctree = False
+
+# -- Magic to run sphinx-apidoc automatically -----------------------------
+
+# See https://github.com/rtfd/readthedocs.org/issues/1139
+# on which this is based.
+
+
+def run_apidoc(_):
+    """Call sphinx-apidoc on Bio and BioSQL modules."""
+    from sphinx.ext.apidoc import main as apidoc_main
+
+    apidoc_main(["-M", "-e", "-F", "-o", "api/", "../thapbi_pict"])
+    os.remove("api/thapbi_pict.rst")  # replaced with index.rst
+
+
+def setup(app):
+    """Over-ride Sphinx setup to trigger sphinx-apidoc."""
+    app.connect("builder-inited", run_apidoc)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,6 +43,7 @@ Key links:
    quick_start
    worked_example/index
    commands
+   api/index
    release_history
    development_notes
 

--- a/thapbi_pict/__init__.py
+++ b/thapbi_pict/__init__.py
@@ -6,31 +6,23 @@
 
 """THAPBI *Phytophthora* ITS1 Classifier Tool (PICT).
 
-*Phytophthora* (from Greek meaning plant-destroyer) species are economically
-important plant pathogens, important in both agriculture and forestry. ITS1 is
-short for Internal Transcribed Spacer one, which is a region of eukaryotes
-genomes between the 18S and 5.8S rRNA genes. This is commonly used for
-molecular barcoding, where sequencing this short region can identify species.
-
-This Python package provides ITS1-based diagnostic/profiling tools for the
-Tree Health and Plant Biosecurity Initiative (THAPBI) Phyto-Threats project,
-which is supported by a grant funded jointly by the Biotechnology and
-Biological Sciences Research Council (BBSRC), the Department for Environment,
-Food and Rural affairs (DEFRA), the Economic and Social Research Council
-(ESRC), the Forestry Commission, and the Natural Environment Research Council
-(NERC) and the Scottish Government, under the Tree Health and Plant
-Biosecurity Initiative (THAPBI).
-
-The `tool documentation <https://thapbi-pict.readthedocs.io/>`_ is
-hosted by `Read The Docs <https://readthedocs.org/>`_, generated
-automatically from the ``docs/`` folder of the `software repository
-<https://github.com/peterjc/thapbi-pict/>`_.
-
 You would typically use THAPBI PICT via the command line tool it defines::
 
     $ thapbi_pict --help
     ...
 
+However, it is also possible to call functions etc from within Python. The
+top level package currently only defines the tool version:
+
+    >>> from thapbi_pict import __version__
+    >>> print(__version__)
+    ...
+
+The `tool documentation <https://thapbi-pict.readthedocs.io/>`_ is
+hosted by `Read The Docs <https://readthedocs.org/>`_, generated
+automatically from the ``docs/`` folder of the `software repository
+<https://github.com/peterjc/thapbi-pict/>`_ and the *"docstrings"*
+within the source code which document the Python API.
 """
 
 __version__ = "0.3.6"


### PR DESCRIPTION
Took a bit of fiddling to get something which looked good locally.

Will still need work to fix the source links to point at the Python code rather than the (transient) RST files.