### PR TITLE
v0.4.2 - Drop clade from taxonomy table

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Release History
 ======= ========== ============================================================================
 Version Date       Notes
 ======= ========== ============================================================================
+v0.4.2  2019-09-20 Dropped clade from the taxonomy table to simplify importing data.
 v0.4.1  2019-09-16 Include NCBI strains/variants/etc and their synonyms as species synonyms.
 v0.4.0  2019-09-12 NCBI taxonomy synonym support; taxonomy import defaults to all *Oomycetes*.
 v0.3.12 2019-09-12 New ``thapbi_pict dump`` option ``-m`` /  ``--minimal`` for DB comparison.

--- a/tests/test_dump.sh
+++ b/tests/test_dump.sh
@@ -32,10 +32,4 @@ if [ `thapbi_pict dump -f fasta -g Phytophthora -m | grep -c "^>"` -ne 2979 ]; t
 # With genus and species filter,
 if [ `thapbi_pict dump -f fasta -g Phytophthora -s "fallax, andina" | grep -c "^>"` -ne 7 ]; then echo "Wrong source for two species"; false; fi
 
-# With genus and clades
-if [ `thapbi_pict dump -f fasta -g Phytophthora -c 8a,8b | grep -c "^>"` -ne 17 ]; then echo "Wrong source for Phytophthora clade"; false; fi
-
-# With clades only (by DB construction will be Phytophthora only)
-if [ `thapbi_pict dump -c 8a,8b | grep -c -v "^#"` -ne 17 ]; then echo "Wrong source for clade"; false; fi
-
 echo "$0 - test_dump.sh passed"

--- a/tests/test_legacy-import.sh
+++ b/tests/test_legacy-import.sh
@@ -44,7 +44,7 @@ thapbi_pict legacy-import -x -d $DB -i database/legacy/Phytophthora_ITS_database
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM data_source;"` -ne "2" ]; then echo "Wrong data_source count"; false; fi
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM its1_source;"` -ne "382" ]; then echo "Wrong its1_source count"; false; fi
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM its1_sequence;"` -ne "176" ]; then echo "Wrong its1_sequence count"; false; fi
-if [ `sqlite3 $DB "SELECT COUNT(id) FROM taxonomy;"` -ne "165" ]; then echo "Wrong taxonomy count"; false; fi
+if [ `sqlite3 $DB "SELECT COUNT(id) FROM taxonomy;"` -ne "164" ]; then echo "Wrong taxonomy count"; false; fi
 if [ `thapbi_pict dump -d $DB -f fasta | grep -c "^>"` -ne "382" ]; then echo "Wrong FASTA record count"; false; fi
 if [ `thapbi_pict dump -d $DB | grep "synthetic" -c` -ne 4 ]; then echo "Missing four synthetic controls"; false; fi
 
@@ -73,10 +73,9 @@ if [ `thapbi_pict dump -d $DB -f fasta | grep -c "^>"` -ne "348" ]; then echo "W
 
 #thapbi_pict dump 2>&1 | grep "the following arguments are required"
 thapbi_pict dump -d database/legacy/Phytophthora_ITS_database_v0.005.sqlite -o /dev/null
-thapbi_pict dump -d "sqlite:///database/legacy/Phytophthora_ITS_database_v0.005.sqlite" -o /dev/null -c 8a,8b
+thapbi_pict dump -d "sqlite:///database/legacy/Phytophthora_ITS_database_v0.005.sqlite" -o /dev/null -g Phytophthora
 
 export DB=database/legacy/database_lax.sqlite
-thapbi_pict dump -d $DB -o /dev/null -c -
 thapbi_pict dump -d $DB -o /dev/null -g Phytophthora
 thapbi_pict dump -d $DB -o /dev/null -g Phytophthora -s "ilicis, sp. aff. meadii"
 
@@ -84,7 +83,6 @@ set +o pipefail
 thapbi_pict dump -d $DB -o /dev/null -s "ambiguous" 2>&1 | grep "requires a single genus"
 thapbi_pict dump -d $DB -o /dev/null -g "Phytophthora" -s "ambiguous" 2>&1 | grep "not in database"
 thapbi_pict dump -d $DB -o /dev/null -g "Phytopthora" 2>&1 | grep "not in database"
-thapbi_pict dump -d $DB -o /dev/null -c "123" 2>&1 | grep "not in database"
 set -o pipefail
 
 echo "$0 - test_legacy-import.sh passed"

--- a/thapbi_pict/__init__.py
+++ b/thapbi_pict/__init__.py
@@ -25,4 +25,4 @@ automatically from the ``docs/`` folder of the `software repository
 within the source code which document the Python API.
 """
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"

--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -142,7 +142,6 @@ def dump(args=None):
         output_filename=args.output,
         output_format=args.format,
         minimal=args.minimal,
-        clade=args.clade,
         genus=args.genus,
         species=args.species,
         debug=args.verbose,
@@ -806,7 +805,7 @@ def main(args=None):
     parser_dump = subparsers.add_parser(
         "dump",
         description="Export an ITS1 database to a text file.",
-        epilog="e.g. 'thapbi_pict dump -d ... -c 8a,8b -o clade_8a_8b.txt'",
+        epilog="e.g. 'thapbi_pict dump -d ... -g Peronospora -o Peronospora.txt'",
     )
     parser_dump.add_argument("-d", "--database", **ARG_DB_INPUT)
     parser_dump.add_argument(
@@ -830,15 +829,6 @@ def main(args=None):
         default="txt",
         choices=["txt", "fasta"],
         help="Format to write out (default 'txt' for debugging).",
-    )
-    parser_dump.add_argument(
-        "-c",
-        "--clade",
-        type=str,
-        default="",
-        help="Which clade(s) to export (comma separated list, "
-        "with '-' meaning no clade defined). "
-        "Default is not to filter by clade.",
     )
     parser_dump.add_argument(
         "-g",

--- a/thapbi_pict/db_orm.py
+++ b/thapbi_pict/db_orm.py
@@ -45,31 +45,19 @@ class Taxonomy(Base):
 
     __tablename__ = "taxonomy"
     __table_args__ = (
-        # Might have old entry with clade A, and new curated entry with clade B
-        # (but same genus, species and NCBI taxid)
-        Index(
-            "taxid_genus_species_clade",
-            "ncbi_taxid",
-            "genus",
-            "species",
-            "clade",
-            unique=True,
-        ),
         Index("taxid_genus_species", "ncbi_taxid", "genus", "species", unique=False),
         Index("genus_species", "genus", "species", unique=False),
     )
 
     id = Column(Integer, primary_key=True)
-    # Using empty string rather than Null (None) for clade, genus, species
-    clade = Column(String(10), nullable=False)  # TODO - Integer linked to table?
+    # Using empty string rather than Null (None) for genus, species
     ncbi_taxid = Column(Integer)
     genus = Column(String(100), nullable=False)
     species = Column(String(100), nullable=False)  # source may have variant/strain?
 
     def __repr__(self):
         """Represent a taxonomy database entry as a string."""
-        return "Taxonomy(clade=%r, ncbi_taxid=%r, genus=%r, species=%r)" % (
-            self.clade,
+        return "Taxonomy(ncbi_taxid=%r, genus=%r, species=%r)" % (
             self.ncbi_taxid,
             self.genus,
             self.species,

--- a/thapbi_pict/dump.py
+++ b/thapbi_pict/dump.py
@@ -33,7 +33,6 @@ def main(
     output_filename,
     output_format,
     minimal=False,
-    clade="",
     genus="",
     species="",
     debug=True,
@@ -62,16 +61,6 @@ def main(
     )
     # Sorting for reproducibility
     view = view.order_by(its1_seq.sequence, SequenceSource.id)
-
-    clade_list = []
-    if clade:
-        # Split on commas, convert "-" into "" meaning no entry
-        clade_list = ["" if _ == "-" else _ for _ in clade.split(",")]
-        for x in clade_list:
-            if not session.query(Taxonomy).filter_by(clade=x).count():
-                sys.stderr.write("WARNING: Clade %r not in database\n" % x)
-        view = view.filter(cur_tax.clade.in_(clade_list))
-    del clade
 
     genus_list = []
     if genus.strip():
@@ -112,7 +101,7 @@ def main(
         out_handle.write("#MD5\tSpecies\tSequence\n")
     else:
         out_handle.write(
-            "#Identifier\tClade\tGenus\tSpecies\tTaxID\tITS1-MD5\tITS1-seq\tSequence\n"
+            "#Identifier\tGenus\tSpecies\tTaxID\tITS1-MD5\tITS1-seq\tSequence\n"
         )
 
     if minimal:
@@ -160,10 +149,9 @@ def main(
                         seq_source.current_taxonomy.species,
                     )
                     out_handle.write(
-                        ">%s [clade=%s] [species=%s] [taxid=%s]\n%s\n"
+                        ">%s [species=%s] [taxid=%s]\n%s\n"
                         % (
                             seq_source.source_accession,
-                            none_str(seq_source.current_taxonomy.clade),
                             genus_species,
                             taxid,
                             seq_source.its1.sequence,
@@ -171,10 +159,9 @@ def main(
                     )
                 else:
                     out_handle.write(
-                        "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n"
+                        "%s\t%s\t%s\t%s\t%s\t%s\t%s\n"
                         % (
                             seq_source.source_accession,
-                            none_str(seq_source.current_taxonomy.clade),
                             none_str(seq_source.current_taxonomy.genus),
                             none_str(seq_source.current_taxonomy.species),
                             taxid,
@@ -190,10 +177,6 @@ def main(
                 sys.stderr.close()
                 sys.exit(1)
 
-            if clade_list:
-                assert (
-                    seq_source.current_taxonomy.clade in clade_list
-                ), seq_source.current_taxonomy
             if genus_list:
                 assert (
                     seq_source.current_taxonomy.genus in genus_list

--- a/thapbi_pict/legacy.py
+++ b/thapbi_pict/legacy.py
@@ -118,7 +118,7 @@ def parse_fasta_entry(text):
     Will also convert the underscores in the species name into spaces:
 
     >>> parse_fasta_entry('4_P._arenaria_HQ013219')
-    ('4', 'P. arenaria', '')
+    (0, 'P. arenaria', '')
 
     Note - this assumes function ``split_composite_entry`` has already
     been used to break up any multiple species composite entries.
@@ -127,17 +127,17 @@ def parse_fasta_entry(text):
     underscore between the clade and species:
 
     >>> parse_fasta_entry('1Phytophthora_aff_infestans_P13660')
-    ('1', 'Phytophthora aff infestans', '')
+    (0, 'Phytophthora aff infestans', '')
 
     And the old variant without any clade at the start, e.g.
 
     >>> parse_fasta_entry('P._amnicola_CBS131652')
-    ('', 'P. amnicola', '')
+    (0, 'P. amnicola', '')
 
     And the old variant with just an accession, e.g.
 
     >>> parse_fasta_entry('VHS17779')
-    ('', '', '')
+    (0, '', '')
 
     Dividing the species name into genus, species, strain etc
     is not handled here.
@@ -145,7 +145,7 @@ def parse_fasta_entry(text):
     Handles the special case of the synthetic controls as follows:
 
     >>> parse_fasta_entry("Control_05 C1")
-    (0, '', 'synthetic construct C1', '')
+    (0, 'synthetic construct C1', '')
     """
     taxid = 0
 
@@ -157,23 +157,13 @@ def parse_fasta_entry(text):
     if parts[0] == "Control":
         # txid32630 is "synthetic construct", seems best taxonomy match
         if " " in text:
-            return (
-                0,
-                "",
-                ("synthetic construct %s" % text.split(" ", 1)[1]).rstrip(),
-                "",
-            )
+            return (0, ("synthetic construct %s" % text.split(" ", 1)[1]).rstrip(), "")
         else:
-            return (
-                0,
-                "",
-                ("synthetic construct %s" % " ".join(parts[1:])).rstrip(),
-                "",
-            )
+            return (0, ("synthetic construct %s" % " ".join(parts[1:])).rstrip(), "")
 
     if len(parts) == 1:
         # Legacy variant with just an accession
-        return (taxid, "", "", "")
+        return (taxid, "", "")
 
     clade = parts[0]
 
@@ -220,53 +210,38 @@ def parse_fasta_entry(text):
 
     if clade and not clade_re.fullmatch(clade):
         raise ValueError("Clade %s not recognised from %r" % (clade, text))
-    return (taxid, clade, " ".join(name), "")
+    return (taxid, " ".join(name), "")
 
 
-assert parse_fasta_entry("Control_05 C1") == (0, "", "synthetic construct C1", "")
+assert parse_fasta_entry("Control_05 C1") == (0, "synthetic construct C1", "")
 assert parse_fasta_entry("7a_Phytophthora_alni_subsp._uniformis_AF139367") == (
     0,
-    "7a",
     "Phytophthora uniformis",
     "",
 )
 assert parse_fasta_entry("8d_Phytophthora_austrocedri_DQ995184") == (
     0,
-    "8d",
     "Phytophthora austrocedrae",
     "",
 )
 assert parse_fasta_entry("6_Phytophthora_taxon_cyperaceae_KJ372258") == (
     0,
-    "6",
     "Phytophthora balyanboodja",
     "",
 )
-assert parse_fasta_entry("4_P._arenaria_HQ013219") == (
-    0,
-    "4",
-    "Phytophthora arenaria",
-    "",
-)
+assert parse_fasta_entry("4_P._arenaria_HQ013219") == (0, "Phytophthora arenaria", "")
 assert parse_fasta_entry("1Phytophthora_aff_infestans_P13660") == (
     0,
-    "1",
     "Phytophthora aff infestans",
     "",
 )
-assert parse_fasta_entry("P._amnicola_CBS131652") == (
-    0,
-    "",
-    "Phytophthora amnicola",
-    "",
-)
+assert parse_fasta_entry("P._amnicola_CBS131652") == (0, "Phytophthora amnicola", "")
 assert parse_fasta_entry("10_Phytophthora_boehmeriae_Voucher_HQ643149") == (
     0,
-    "10",
     "Phytophthora boehmeriae",
     "",
 )
-assert parse_fasta_entry("ACC-ONLY") == (0, "", "", "")
+assert parse_fasta_entry("ACC-ONLY") == (0, "", "")
 
 
 def main(

--- a/thapbi_pict/ncbi.py
+++ b/thapbi_pict/ncbi.py
@@ -31,23 +31,18 @@ from .db_import import import_fasta_file
 def parse_fasta_entry(text):
     """Split an entry of Accession_Genus_Species_name_Description.
 
-    Returns a tuple: taxid (always zero), clade (always empty),
-    presumed genus-species (here taken as two words by default),
-    and spare text which might be more of the species (for use
-    with species name validation).
-
-    Note we can't infer the clade without looking up the species,
-    so for now this returns an empty clade.
+    Returns a tuple: taxid (always zero), presumed genus-species
+    (here taken as two words by default), and spare text which might
+    be more of the species (for use with species name validation).
 
     >>> parse_fasta_entry('LC159493.1 Phytophthora drechsleri genes ...')
-    ('', 'Phytophthora drechsleri', 'genes ...')
+    (0, 'Phytophthora drechsleri', 'genes ...')
 
     Dividing the species name into genus, species, strain etc
     is not handled here.
     """  # noqa: E501
     parts = text.rstrip().split()
     taxid = 0
-    clade = ""
     # acc = parts[0]
     name = parts[1:3]  # assumes "Genus species" only (2 words)
     rest = parts[3:]
@@ -73,12 +68,11 @@ def parse_fasta_entry(text):
         else:
             name.extend(rest[:2])
             rest = rest[2:]
-    return (taxid, clade, " ".join(name), " ".join(rest))
+    return (taxid, " ".join(name), " ".join(rest))
 
 
 assert parse_fasta_entry("LC159493.1 Phytophthora drechsleri genes ...") == (
     0,
-    "",
     "Phytophthora drechsleri",
     "genes ...",
 )
@@ -87,7 +81,6 @@ assert parse_fasta_entry(
     "MG707849.1 Phytophthora humicola x Phytophthora inundata isolate SCVWD597 internal transcribed spacer 1, ..."  # noqa: E501
 ) == (
     0,
-    "",
     "Phytophthora humicola x inundata",
     "isolate SCVWD597 internal transcribed spacer 1, ...",
 )
@@ -96,7 +89,6 @@ assert parse_fasta_entry(
     "MG707849.1 Phytophthora humicola x inundata isolate SCVWD597 internal transcribed spacer 1, ..."  # noqa: E501
 ) == (
     0,
-    "",
     "Phytophthora humicola x inundata",
     "isolate SCVWD597 internal transcribed spacer 1, ...",
 )

--- a/thapbi_pict/seq_import.py
+++ b/thapbi_pict/seq_import.py
@@ -92,7 +92,7 @@ def main(
             assert genus_species, "Didn't find expected wildcard species line"
 
             def meta_fn(text):
-                return (int(taxid), "", genus_species, "")
+                return int(taxid), genus_species, ""
 
             def sequence_wanted(title):
                 """Check if identifier passess abundance level."""

--- a/thapbi_pict/taxdump.py
+++ b/thapbi_pict/taxdump.py
@@ -169,12 +169,12 @@ def main(tax, db_url, ancestors, debug=True):
         # Is is already there? e.g. prior import
         taxonomy = (
             session.query(Taxonomy)
-            .filter_by(clade="", genus=genus, species="", ncbi_taxid=taxid)
+            .filter_by(genus=genus, species="", ncbi_taxid=taxid)
             .one_or_none()
         )
         if taxonomy is None:
             g_new += 1
-            taxonomy = Taxonomy(clade="", genus=genus, species="", ncbi_taxid=taxid)
+            taxonomy = Taxonomy(genus=genus, species="", ncbi_taxid=taxid)
             session.add(taxonomy)
         else:
             g_old += 1
@@ -184,7 +184,6 @@ def main(tax, db_url, ancestors, debug=True):
     s_old = 0
     s_new = 0
     for taxid, genus, species in genus_species:
-        clade = ""
         aliases = []
 
         if species.split(" ", 1)[0] == genus:
@@ -206,14 +205,12 @@ def main(tax, db_url, ancestors, debug=True):
         # Is is already there? e.g. prior import
         taxonomy = (
             session.query(Taxonomy)
-            .filter_by(clade=clade, genus=genus, species=species, ncbi_taxid=taxid)
+            .filter_by(genus=genus, species=species, ncbi_taxid=taxid)
             .one_or_none()
         )
         if taxonomy is None:
             new += 1
-            taxonomy = Taxonomy(
-                clade=clade, genus=genus, species=species, ncbi_taxid=taxid
-            )
+            taxonomy = Taxonomy(genus=genus, species=species, ncbi_taxid=taxid)
             session.add(taxonomy)
         else:
             old += 1


### PR DESCRIPTION
This removes clade from the database and associated import code. This drops the extra taxonomy entries triggered from importing our legacy curated sequences which have clade information - otherwise the DB is unchanged. The output has not used the clade, so no change there.

This addresses an idea on #7 (refactoring the taxonomy tables), by removing the clade from the taxonomy table. Given the main taxonomy information is the NCBI tree (which does not have the clade), it would make more sense to have a curated extra clade table linked to this if we do decide to put clade support back in.

The main motivation is to allow a more dramatic refactoring and simplification of the import code.
