### PR TITLE
Only one entry in taxonomy table per species

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Release History
 ======= ========== ============================================================================
 Version Date       Notes
 ======= ========== ============================================================================
-v0.4.2  2019-09-20 Dropped clade from the taxonomy table to simplify importing data.
+v0.4.2  2019-09-20 Drop clade from taxonomy table, require unique species entries.
 v0.4.1  2019-09-16 Include NCBI strains/variants/etc and their synonyms as species synonyms.
 v0.4.0  2019-09-12 NCBI taxonomy synonym support; taxonomy import defaults to all *Oomycetes*.
 v0.3.12 2019-09-12 New ``thapbi_pict dump`` option ``-m`` /  ``--minimal`` for DB comparison.

--- a/tests/test_legacy-import.sh
+++ b/tests/test_legacy-import.sh
@@ -26,6 +26,18 @@ thapbi_pict legacy-import -x -d $DB -i tests/legacy-import/dup_seqs.fasta
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM data_source;"` -ne "1" ]; then echo "Wrong data_source count"; false; fi
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM its1_source;"` -ne "8" ]; then echo "Wrong its1_source count"; false; fi
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM its1_sequence;"` -ne "2" ]; then echo "Wrong its1_sequence count"; false; fi
+if [ `sqlite3 $DB "SELECT COUNT(id) FROM taxonomy;"` -ne "8" ]; then echo "Wrong taxonomy count"; false; fi
+if [ `sqlite3 $DB "SELECT DISTINCT genus, species FROM taxonomy;" | wc -l` -ne 8 ]; then echo "Wrong species count"; false; fi
+
+if [ ! -f "new_taxdump_2019-09-01.zip" ]; then curl -L -O "https://ftp.ncbi.nih.gov/pub/taxonomy/taxdump_archive/new_taxdump_2019-09-01.zip"; fi
+if [ ! -d "new_taxdump_2019-09-01" ]; then unzip new_taxdump_2019-09-01.zip -d new_taxdump_2019-09-01; fi
+
+# Try belatedly loading the NCBI taxonomy (Phytophthora only), expect no conflicts:
+thapbi_pict load-tax -d $DB -t new_taxdump_2019-09-01 -a 4783
+if [ `sqlite3 $DB "SELECT COUNT(id) FROM taxonomy WHERE genus='Phytophthora' AND species='infestans';"` -ne 1 ]; then echo "Expected one P. infestans entry."; false; fi
+if [ `sqlite3 $DB "SELECT COUNT(id) FROM taxonomy;"` -ne "266" ]; then echo "Wrong taxonomy count"; false; fi
+if [ `sqlite3 $DB "SELECT DISTINCT genus, species FROM taxonomy;" | wc -l` -ne 266 ]; then echo "Wrong species count"; false; fi
+
 
 export DB=database/legacy/database_lax.sqlite
 rm -rf $DB
@@ -48,9 +60,13 @@ if [ `sqlite3 $DB "SELECT COUNT(id) FROM taxonomy;"` -ne "164" ]; then echo "Wro
 if [ `thapbi_pict dump -d $DB -f fasta | grep -c "^>"` -ne "382" ]; then echo "Wrong FASTA record count"; false; fi
 if [ `thapbi_pict dump -d $DB | grep "synthetic" -c` -ne 4 ]; then echo "Missing four synthetic controls"; false; fi
 
-
-if [ ! -f "new_taxdump_2019-09-01.zip" ]; then curl -L -O "https://ftp.ncbi.nih.gov/pub/taxonomy/taxdump_archive/new_taxdump_2019-09-01.zip"; fi
-if [ ! -d "new_taxdump_2019-09-01" ]; then unzip new_taxdump_2019-09-01.zip -d new_taxdump_2019-09-01; fi
+# Try belatedly loading the NCBI taxonomy (Phytophthora only), expect some conflicts:
+if [ `sqlite3 $DB "SELECT DISTINCT genus, species FROM taxonomy;" | wc -l` -ne 164 ]; then echo "Wrong species count"; false; fi
+thapbi_pict load-tax -d $DB -t new_taxdump_2019-09-01 -a 4783
+if [ `sqlite3 $DB "SELECT COUNT(id) FROM taxonomy WHERE genus='Phytophthora' AND species='infestans';"`-ne 2 ]; then echo "Expected\
+ two P. infestans entries."; false; fi
+if [ `sqlite3 $DB "SELECT COUNT(id) FROM taxonomy;"` -ne "422" ]; then echo "Wrong taxonomy count"; false; fi
+if [ `sqlite3 $DB "SELECT DISTINCT genus, species FROM taxonomy;" | wc -l` -ne 280 ]; then echo "Wrong species count"; false; fi
 
 # Now test with species name validation, load with Phytophthora
 # Then add 172 entries from v5, then 170 entries from v4

--- a/tests/test_legacy-import.sh
+++ b/tests/test_legacy-import.sh
@@ -62,10 +62,10 @@ if [ `thapbi_pict dump -d $DB | grep "synthetic" -c` -ne 4 ]; then echo "Missing
 
 # Try belatedly loading the NCBI taxonomy (Phytophthora only), expect some conflicts:
 if [ `sqlite3 $DB "SELECT DISTINCT genus, species FROM taxonomy;" | wc -l` -ne 164 ]; then echo "Wrong species count"; false; fi
-thapbi_pict load-tax -d $DB -t new_taxdump_2019-09-01 -a 4783
-if [ `sqlite3 $DB "SELECT COUNT(id) FROM taxonomy WHERE genus='Phytophthora' AND species='infestans';"`-ne 2 ]; then echo "Expected\
- two P. infestans entries."; false; fi
-if [ `sqlite3 $DB "SELECT COUNT(id) FROM taxonomy;"` -ne "422" ]; then echo "Wrong taxonomy count"; false; fi
+thapbi_pict load-tax -d $DB -t new_taxdump_2019-09-01 -a 4783 -v
+if [ `sqlite3 $DB "SELECT COUNT(id) FROM taxonomy WHERE genus='Phytophthora' AND species='infestans';"`-ne 1 ]; then echo "Expected\
+ one P. infestans entry."; false; fi
+if [ `sqlite3 $DB "SELECT COUNT(id) FROM taxonomy;"` -ne "280" ]; then echo "Wrong taxonomy count"; false; fi
 if [ `sqlite3 $DB "SELECT DISTINCT genus, species FROM taxonomy;" | wc -l` -ne 280 ]; then echo "Wrong species count"; false; fi
 
 # Now test with species name validation, load with Phytophthora

--- a/thapbi_pict/db_orm.py
+++ b/thapbi_pict/db_orm.py
@@ -45,8 +45,8 @@ class Taxonomy(Base):
 
     __tablename__ = "taxonomy"
     __table_args__ = (
-        Index("taxid_genus_species", "ncbi_taxid", "genus", "species", unique=False),
-        Index("genus_species", "genus", "species", unique=False),
+        Index("taxid_genus_species", "ncbi_taxid", "genus", "species", unique=True),
+        Index("genus_species", "genus", "species", unique=True),
     )
 
     id = Column(Integer, primary_key=True)

--- a/thapbi_pict/taxdump.py
+++ b/thapbi_pict/taxdump.py
@@ -205,9 +205,18 @@ def main(tax, db_url, ancestors, debug=True):
         # Is is already there? e.g. prior import
         taxonomy = (
             session.query(Taxonomy)
-            .filter_by(genus=genus, species=species, ncbi_taxid=taxid)
+            .filter_by(genus=genus, species=species)
             .one_or_none()
         )
+        if taxonomy and taxonomy.ncbi_taxid != taxid:
+            # Prior entry had missing/different taxid, must update it
+            if debug or taxonomy.ncbi_taxid != 0:
+                sys.stderr.write(
+                    "WARNING: %s %s, updating NCBI taxid %i -> %i\n"
+                    % (genus, species, taxonomy.ncbi_taxid, taxid)
+                )
+            taxonomy.ncbi_taxid = taxid
+            session.add(taxonomy)
         if taxonomy is None:
             new += 1
             taxonomy = Taxonomy(genus=genus, species=species, ncbi_taxid=taxid)


### PR DESCRIPTION
Having dropped the clade field, we could still have multiple taxonomy table entries for a single species - typically with and without an NCBI taxid. With these changes we enforce a unique entry, and modify the taxonomy import to update any pre-existing entry.

This will allow simplifications to the sequence import code, to follow in a separate pull request.