### PR TITLE
Refactor species parsing for import; preload names

### DIFF
--- a/thapbi_pict/seq_import.py
+++ b/thapbi_pict/seq_import.py
@@ -63,13 +63,15 @@ def main(
             for idn, taxid, genus_species in parse_species_tsv(tsv_file):
                 if idn in meta_data:
                     sys.exit("ERROR: Duplicated identifier %r in %r" % (idn, tsv_file))
-                meta_data[idn] = (int(taxid), "", genus_species, "")
+                meta_data[idn] = (int(taxid), "", genus_species)
             if not meta_data:
                 sys.stderr.write(
                     "File %s has no sequences, ignoring %s\n" % (tsv_file, fasta_file)
                 )
                 continue
-            meta_fn = meta_data.get
+
+            def meta_fn(text, known_species=None):
+                return meta_data[text]
 
             def sequence_wanted(title):
                 """Check if identifier in TSV file, and passess abundance level."""
@@ -91,8 +93,8 @@ def main(
                         _, taxid, genus_species, _ = line.split("\t", 3)
             assert genus_species, "Didn't find expected wildcard species line"
 
-            def meta_fn(text):
-                return int(taxid), genus_species, ""
+            def meta_fn(text, known_species=None):
+                return int(taxid), genus_species
 
             def sequence_wanted(title):
                 """Check if identifier passess abundance level."""

--- a/thapbi_pict/utils.py
+++ b/thapbi_pict/utils.py
@@ -58,6 +58,17 @@ def genus_species_name(genus, species):
         return genus
 
 
+def genus_species_split(name):
+    """Return (genus, species) splitting on first space.
+
+    If there are no spaces, returns (name, '') instead.
+    """
+    if " " in name:
+        return name.split(" ", 1)
+    else:
+        return name, ""
+
+
 def species_level(prediction):
     """Is this prediction at species level.
 


### PR DESCRIPTION
Replaces the old NCBI fuzzy species matching (unless in lax mode): now uses the preloaded names and starts with the longest possible string (rather than a two word genus-species).