### PR TITLE
Apply primer cutting during NCBI import

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Release History
 ======= ========== ============================================================================
 Version Date       Notes
 ======= ========== ============================================================================
+v0.4.5  *Pending*  Apply primer trimming to ``ncbi-import`` (crop if primers found).
 v0.4.4  2019-10-02 New ``--hmm`` & ``--flip`` arguments for ``prepare-reads`` and ``pipeline``.
 v0.4.3  2019-09-26 New ``conflicts`` command reporting genus/species level conflicts in DB.
 v0.4.2  2019-09-26 Drop clade from taxonomy table, require unique species entries.

--- a/tests/classify/multiple_its1.blast.tsv
+++ b/tests/classify/multiple_its1.blast.tsv
@@ -3,4 +3,4 @@
 38d778725a0980551712792f25f4efab_12345	0		No BLAST hit
 8c4e2e7a564b9bfb0aad57b5c1f8f0e4_123	70742	Peronospora	1 BLAST hits (bit score 427). Unique taxonomy match
 9c842ca976a1592bf41d1f7599f7a94d_1234	2025987	Nothophytophthora	3 BLAST hits (bit score 100). Unique taxonomy match
-c52fa56b053580551c86a2b7e94ff29b_12345	70742	Peronospora	1 BLAST hits (bit score 244). Unique taxonomy match
+c52fa56b053580551c86a2b7e94ff29b_12345	70742	Peronospora	1 BLAST hits (bit score 246). Unique taxonomy match

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -18,8 +18,13 @@ time tests/test_woody_hosts.sh
 time tests/test_dump.sh
 time tests/test_load-tax.sh
 time tests/test_legacy-import.sh
-time tests/test_ncbi-import.sh
 time tests/test_conflicts.sh
+
+if ! [ -x "$(command -v cutadapt)" ]; then
+    echo 'WARNING: cutadapt not installed, skipping some tests'
+else
+    time tests/test_ncbi-import.sh
+fi
 
 # Currently can't easily install these on TravisCI
 if ! [ -x "$(command -v flash)" ]; then

--- a/tests/test_dump.sh
+++ b/tests/test_dump.sh
@@ -19,15 +19,15 @@ set -x
 thapbi_pict dump -s fallax 2>&1 | grep "species requires a single genus"
 set -o pipefail
 
-if [ `thapbi_pict dump | grep -c -v "^#"` -ne 15017 ]; then echo "Wrong source count for table dump"; false; fi
-if [ `thapbi_pict dump -f fasta | grep -c "^>"` -ne 15017 ]; then echo "Wrong sourse count for fasta dump"; false; fi
+if [ `thapbi_pict dump | grep -c -v "^#"` -ne 15008 ]; then echo "Wrong source count for table dump"; false; fi
+if [ `thapbi_pict dump -f fasta | grep -c "^>"` -ne 15008 ]; then echo "Wrong sourse count for fasta dump"; false; fi
 
-if [ `thapbi_pict dump --minimal | grep -c -v "^#"` -ne 3642 ]; then echo "Wrong sequence count for table dump"; false; fi
-if [ `thapbi_pict dump -m -f fasta | grep -c "^>"` -ne 3642 ]; then echo "Wrong sequence count for fasta dump"; false; fi
+if [ `thapbi_pict dump --minimal | grep -c -v "^#"` -ne 3636 ]; then echo "Wrong sequence count for table dump"; false; fi
+if [ `thapbi_pict dump -m -f fasta | grep -c "^>"` -ne 3636 ]; then echo "Wrong sequence count for fasta dump"; false; fi
 
 # With genus filter,
-if [ `thapbi_pict dump -f fasta -g Phytophthora | grep -c "^>"` -ne 13045 ]; then echo "Wrong source for Phytophthora genus"; false; fi
-if [ `thapbi_pict dump -f fasta -g Phytophthora -m | grep -c "^>"` -ne 2979 ]; then echo "Wrong sequence for Phytophthora genus"; false; fi
+if [ `thapbi_pict dump -f fasta -g Phytophthora | grep -c "^>"` -ne 13033 ]; then echo "Wrong source for Phytophthora genus"; false; fi
+if [ `thapbi_pict dump -f fasta -g Phytophthora -m | grep -c "^>"` -ne 2968 ]; then echo "Wrong sequence for Phytophthora genus"; false; fi
 
 # With genus and species filter,
 if [ `thapbi_pict dump -f fasta -g Phytophthora -s "fallax, andina" | grep -c "^>"` -ne 7 ]; then echo "Wrong source for two species"; false; fi

--- a/tests/test_ncbi-import.sh
+++ b/tests/test_ncbi-import.sh
@@ -40,22 +40,22 @@ rm -rf $DB
 thapbi_pict load-tax -d $DB -t new_taxdump_2019-09-01
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM taxonomy;"` -ne "1378" ]; then echo "Wrong taxonomy count"; false; fi
 # NCBI import at genus level only, as used in bundled ITS1_DB.sqlite
+# 5 sequences all with multiple HMM matches, but after primer trimming most become single HMM entries.
 thapbi_pict ncbi-import -d $DB -g -i tests/ncbi-import/multiple_hmm.fasta -n "NCBI examples with multiple HMM matches"
-# WARNING: 2 HMM matches in MF370571.1
-# WARNING: 2 HMM matches in MH169111.1
-# WARNING: Discarding exactly duplicated ITS1 matches in DQ641247.1
-# File tests/ncbi-import/multiple_hmm.fasta had 5 sequences. Found 5 ITS1, of which 5 accepted.
+# WARNING: 2 HMM matches in MF095142.1
+# WARNING: Uncultured, so ignoring 'MF095142.1 Uncultured Peronosporaceae clone MZOo17 small subunit ri...'
+# WARNING: 2 HMM matches in KP691407.1
+# WARNING: Uncultured, so ignoring 'KP691407.1 Uncultured Phytophthora clone sp3 18S ribosomal RNA gene...'
+# File tests/ncbi-import/multiple_hmm.fasta had 5 sequences. Found 5 with ITS1, of which 3 accepted.
 # Of 5 potential entries, 0 unparsable, 2 failed sp. validation, 3 OK.
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM data_source;"` -ne "1" ]; then echo "Wrong data_source count"; false; fi
-if [ `sqlite3 $DB "SELECT COUNT(id) FROM its1_source;"` -ne "5" ]; then echo "Wrong its1_source count"; false; fi
-if [ `sqlite3 $DB "SELECT COUNT(id) FROM its1_sequence;"` -ne "5" ]; then echo "Wrong its1_sequence count"; false; fi
+if [ `sqlite3 $DB "SELECT COUNT(id) FROM its1_source;"` -ne "3" ]; then echo "Wrong its1_source count"; false; fi
+if [ `sqlite3 $DB "SELECT COUNT(id) FROM its1_sequence;"` -ne "3" ]; then echo "Wrong its1_sequence count"; false; fi
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM taxonomy;"` -ne "1378" ]; then echo "Wrong taxonomy count"; false; fi
 # Debugging output,
 # $ sqlite3 $DB "SELECT md5, LENGTH(its1_sequence.sequence), source_accession FROM its1_sequence, its1_source WHERE its1_sequence.id=its1_source.its1_id;"
 # 63fa728c0fe76536f13eb593df99bd46|179|MF370571.1
-# a42d385f25a9f1b10d0642ad8a72a584|116|MF370571.1
 # 4c9e98f437ca0f55d0d8ba3b2928239c|199|MH169111.1
-# 158774f117b3e6058b22ba9ef877f346|199|MH169111.1
 # 7f27d3a8f7150e0ee7ad64073e6da6b5|170|DQ641247.1
 if [ `sqlite3 $DB "SELECT MAX(LENGTH(sequence)) FROM its1_sequence;"` -ne "199" ]; then echo "Wrong max ITS1 sequence length"; false; fi
 

--- a/thapbi_pict/__init__.py
+++ b/thapbi_pict/__init__.py
@@ -25,4 +25,4 @@ automatically from the ``docs/`` folder of the `software repository
 within the source code which document the Python API.
 """
 
-__version__ = "0.4.4"
+__version__ = "0.4.5"

--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -115,6 +115,9 @@ def ncbi_import(args=None):
         name=args.name,
         validate_species=not args.lax,
         genus_only=args.genus,
+        left_primer=args.left,
+        right_primer=args.right,
+        tmp_dir=args.temp,
         debug=args.verbose,
     )
 
@@ -543,8 +546,8 @@ ARG_PRIMER_LEFT = dict(  # noqa: C408
     type=str,
     default="GAAGGTGAAGTCGTAACAAGGTTTCCGTAGGTGAACCTGCGGAAGGATCATTA",
     metavar="PRIMER",
-    help="Left primer sequence, finds and removes from start of "
-    "merged read pairs. Can use IUPAC ambiguity codes. "
+    help="Left primer sequence, find and remove from start of "
+    "marker sequence. Can use IUPAC ambiguity codes. "
     "Default 21bp ITS6 'GAAGGTGAAGTCGTAACAAGG' from Cooke "
     "et al. 2000 https://doi.org/10.1006/fgbi.2000.1202 and "
     "conserved 32bp 'TTTCCGTAGGTGAACCTGCGGAAGGATCATTA'.",
@@ -555,12 +558,12 @@ ARG_PRIMER_RIGHT = dict(  # noqa: C408
     type=str,
     default="GCARRGACTTTCGTCCCYRC",
     metavar="PRIMER",
-    help="Right primer sequence, finds and removes reverse "
-    "complement from end of merged read pairs. Can use "
+    help="Right primer sequence, find and remove reverse "
+    "complement from end of marker sequence. Can use "
     "IUPAC ambiguity codes. Default 20bp 5.8S-1R primer "
     "'GCARRGACTTTCGTCCCYRC' from Scibetta et al. 2012 "
     "https://doi.org/10.1016/j.mimet.2011.12.012 - meaning "
-    "looks for 'GYRGGGACGAAAGTCYYTGC' in merged reads.",
+    "look for 'GYRGGGACGAAAGTCYYTGC' after marker.",
 )
 
 # "--hmm",
@@ -790,6 +793,9 @@ def main(args=None):
     parser_ncbi_import.add_argument("-n", "--name", **ARG_NAME)
     parser_ncbi_import.add_argument("-x", "--lax", **ARG_LAX)
     parser_ncbi_import.add_argument("-g", "--genus", **ARG_GENUS_ONLY)
+    parser_ncbi_import.add_argument("-l", "--left", **ARG_PRIMER_LEFT)
+    parser_ncbi_import.add_argument("-r", "--right", **ARG_PRIMER_RIGHT)
+    parser_ncbi_import.add_argument("-t", "--temp", **ARG_TEMPDIR)
     parser_ncbi_import.add_argument("-v", "--verbose", **ARG_VERBOSE)
     parser_ncbi_import.set_defaults(func=ncbi_import)
     del parser_ncbi_import  # To prevent acidentally adding more

--- a/thapbi_pict/ncbi.py
+++ b/thapbi_pict/ncbi.py
@@ -98,6 +98,9 @@ def main(
     name=None,
     validate_species=False,
     genus_only=False,
+    left_primer=None,
+    right_primer=None,
+    tmp_dir=None,
     debug=True,
 ):
     """Implement the ``thapbi_pict ncbi-import`` command."""
@@ -111,4 +114,7 @@ def main(
         entry_taxonomy_fn=parse_fasta_entry,
         validate_species=validate_species,
         genus_only=genus_only,
+        left_primer=left_primer,
+        right_primer=right_primer,
+        tmp_dir=tmp_dir,
     )


### PR DESCRIPTION
The NCBI import sequences are often far longer than the region of interest, where primer trimming makes sense. Equally, they can be short enough that the primers matches are not present. Therefore this calls ``cutadapt`` to crop and remove either primer (even if one one is present), and keep all the sequences regardless.

This will largely address #192.