### PR TITLE
Adding --hmm command line option, allow --hmm '' to skip hmmscan

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,7 @@ jobs:
             # Unpack the tests from the sdist tar-ball
             tar --wildcards '*/tests/*' -zxvf dist/thapbi_pict-*.tar.gz
             tar --wildcards '*/database/*' -zxvf dist/thapbi_pict-*.tar.gz
+            tar --wildcards '*/combined.hmm*' -zxvf dist/thapbi_pict-*.tar.gz
             cd thapbi_pict-*/
             # Run the tests (and confirm the tar-ball is complete)
             tests/run_tests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ script:
  # Now unpack tests from the sdist tar-ball
  - tar --wildcards '*/tests/*' -zxvf dist/thapbi_pict-*.tar.gz
  - tar --wildcards '*/database/*' -zxvf dist/thapbi_pict-*.tar.gz
+ - tar --wildcards '*/combined.hmm*' -zxvf dist/thapbi_pict-*.tar.gz
  - cd thapbi_pict-*/
  # Run the tests (and confirm the tar-ball is complete)
  - tests/run_tests.sh

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Release History
 ======= ========== ============================================================================
 Version Date       Notes
 ======= ========== ============================================================================
+v0.4.4  2019-10-01 Added ``--hmm`` argument for overriding provided ITS1 HMM, or using none.
 v0.4.3  2019-09-26 New ``conflicts`` command reporting genus/species level conflicts in DB.
 v0.4.2  2019-09-26 Drop clade from taxonomy table, require unique species entries.
 v0.4.1  2019-09-16 Include NCBI strains/variants/etc and their synonyms as species synonyms.

--- a/tests/test_legacy-import.sh
+++ b/tests/test_legacy-import.sh
@@ -42,6 +42,14 @@ if [ `sqlite3 $DB "SELECT DISTINCT genus, species FROM taxonomy;" | wc -l` -ne 2
 export DB=database/legacy/database_lax.sqlite
 rm -rf $DB
 thapbi_pict legacy-import -x -d $DB -i database/legacy/database.fasta
+if [ `sqlite3 $DB "SELECT COUNT(id) FROM its1_source;"` -ne "151" ]; then echo "Wrong its1_source count"; false; fi
+if [ `sqlite3 $DB "SELECT COUNT(id) FROM its1_sequence;"` -ne "131" ]; then echo "Wrong its1_sequence count"; false; fi
+# Now try without the HMM filter, no cropping, so more unique (long) sequences
+rm -rf $DB
+thapbi_pict legacy-import -x -d $DB -i database/legacy/database.fasta --hmm ''
+if [ `sqlite3 $DB "SELECT COUNT(id) FROM its1_source;"` -ne "151" ]; then echo "Wrong its1_source count"; false; fi
+if [ `sqlite3 $DB "SELECT COUNT(id) FROM its1_sequence;"` -ne "142" ]; then echo "Wrong its1_sequence count"; false; fi
+
 
 thapbi_pict legacy-import -x -d "sqlite:///:memory:" -i database/legacy/Phytophthora_ITS_database_v0.004.fasta
 

--- a/tests/test_ncbi-import.sh
+++ b/tests/test_ncbi-import.sh
@@ -82,7 +82,7 @@ if [ `sqlite3 $DB "SELECT COUNT(id) FROM data_source;"` -ne "1" ]; then echo "Wr
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM its1_source;"` -ne "105" ]; then echo "Wrong its1_source count"; false; fi
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM its1_sequence;"` -ne "88" ]; then echo "Wrong its1_sequence count"; false; fi
 # Confirm AF271230.1 Pythium undulatum -> Phytophthora undulatum
-thapbi_pict dump -d /tmp/20th_Century_ITS1_validated.sqlite | cut -f 1-4 | grep AF271230.1 | grep Phytophthora
+thapbi_pict dump -d $DB | cut -f 1-4 | grep AF271230.1 | grep Phytophthora
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM taxonomy;"` -ne "258" ]; then echo "Wrong taxonomy count"; false; fi
 # Other values subject to change
 
@@ -109,7 +109,8 @@ export DB=$TMP/20th_Century_ITS1_mixed.sqlite
 rm -rf $DB
 thapbi_pict load-tax -d $DB -t new_taxdump_2019-09-01
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM taxonomy;"` -ne "1380" ]; then echo "Wrong taxonomy count"; false; fi
-thapbi_pict ncbi-import -d $DB -i tests/ncbi-import/20th_Century_ITS1.fasta
+# Make the bundled HMM explicit to test using --hmm here:
+thapbi_pict ncbi-import -d $DB -i tests/ncbi-import/20th_Century_ITS1.fasta --hmm thapbi_pict/hmm/combined.hmm
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM data_source;"` -ne "1" ]; then echo "Wrong data_source count"; false; fi
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM its1_source;"` -ne "105" ]; then echo "Wrong its1_source count"; false; fi
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM its1_sequence;"` -ne "88" ]; then echo "Wrong its1_sequence count"; false; fi

--- a/tests/test_pipeline.sh
+++ b/tests/test_pipeline.sh
@@ -36,7 +36,7 @@ touch $TMP/intermediate/distraction.fasta
 touch $TMP/intermediate/ignore-me.onebp.tsv
 # Run again with some explicit options set (shouldn't change output)
 rm -rf $TMP/output/*
-thapbi_pict pipeline -i tests/reads/ -s $TMP/intermediate -o $TMP/output -m onebp -a 250 -r report
+thapbi_pict pipeline -i tests/reads/ -s $TMP/intermediate -o $TMP/output -m onebp -a 250 -r report --hmm thapbi_pict/hmm/combined.hmm
 diff $TMP/intermediate/DNAMIX_S95_L001.fasta tests/prepare-reads/DNAMIX_S95_L001.fasta
 diff $TMP/output/report.samples.txt tests/pipeline/thapbi-pict.samples.onebp.txt
 diff $TMP/output/report.samples.tsv tests/pipeline/thapbi-pict.samples.onebp.tsv

--- a/tests/test_prepare-reads.sh
+++ b/tests/test_prepare-reads.sh
@@ -28,6 +28,14 @@ rm -rf $TMP/DNAMIX_S95_L001.fasta
 thapbi_pict prepare-reads -o $TMP -i tests/reads/DNAMIX_S95_L001_*.fastq.gz -a 5
 if [ `grep -c "^>" $TMP/DNAMIX_S95_L001.fasta` -ne "24" ]; then echo "Wrong FASTA output count"; false; fi
 
+rm -rf $TMP/DNAMIX_S95_L001.fasta
+thapbi_pict prepare-reads -o $TMP -i tests/reads/DNAMIX_S95_L001_*.fastq.gz -a 5 --hmm thapbi_pict/hmm/combined.hmm
+if [ `grep -c "^>" $TMP/DNAMIX_S95_L001.fasta` -ne "24" ]; then echo "Wrong FASTA output count"; false; fi
+
+rm -rf $TMP/DNAMIX_S95_L001.fasta
+thapbi_pict prepare-reads -o $TMP -i tests/reads/DNAMIX_S95_L001_*.fastq.gz -a 5 --hmm ''
+if [ `grep -c "^>" $TMP/DNAMIX_S95_L001.fasta` -ne "24" ]; then echo "Wrong FASTA output count"; false; fi
+
 echo "Generating mock control file"
 # Using just 50 real reads (50 * 4 = 200 lines)
 set +o pipefail
@@ -46,5 +54,11 @@ rm -rf $TMP/DNAMIX_S95_L001.fasta
 thapbi_pict prepare-reads -o $TMP -i tests/reads/DNAMIX_S95_L001_*.fastq.gz -a 100
 if [ `grep -c "^>" $TMP/DNAMIX_S95_L001.fasta` -ne "7" ]; then echo "Wrong FASTA output count"; false; fi
 diff $TMP/DNAMIX_S95_L001.fasta tests/prepare-reads/DNAMIX_S95_L001.fasta
+
+rm -rf $TMP/DNAMIX_S95_L001.fasta
+thapbi_pict prepare-reads -o $TMP -i tests/reads/DNAMIX_S95_L001_*.fastq.gz -a 100 --hmm ''
+if [ `grep -c "^>" $TMP/DNAMIX_S95_L001.fasta` -ne "7" ]; then echo "Wrong FASTA output count"; false; fi
+# Should be identical but without the HMM names in the FASTA title lines:
+diff <(grep -v ">" $TMP/DNAMIX_S95_L001.fasta) <(grep -v "^>" tests/prepare-reads/DNAMIX_S95_L001.fasta)
 
 echo "$0 - test_prepare-reads.sh passed"

--- a/thapbi_pict/__init__.py
+++ b/thapbi_pict/__init__.py
@@ -25,4 +25,4 @@ automatically from the ``docs/`` folder of the `software repository
 within the source code which document the Python API.
 """
 
-__version__ = "0.4.3"
+__version__ = "0.4.4"

--- a/thapbi_pict/db_import.py
+++ b/thapbi_pict/db_import.py
@@ -76,6 +76,7 @@ def lookup_genus(session, name):
 def import_fasta_file(
     fasta_file,
     db_url,
+    hmm_stem=None,
     name=None,
     debug=True,
     fasta_entry_fn=None,
@@ -109,7 +110,8 @@ def import_fasta_file(
     comes from a sister TSV file, and is cross-referenced by the
     FASTA sequence identifier.
     """
-    check_tools(["hmmscan"], debug)
+    if hmm_stem:
+        check_tools(["hmmscan"], debug)
 
     # Argument validation,
     if fasta_entry_fn is None:
@@ -172,7 +174,9 @@ def import_fasta_file(
     idn_set = set()
     multiple_its1 = False
 
-    for title, seq, hmm_name, its1_seqs in filter_for_ITS1(fasta_file, cache_dir=None):
+    for title, seq, hmm_name, its1_seqs in filter_for_ITS1(
+        fasta_file, hmm=hmm_stem, cache_dir=None
+    ):
         seq_count += 1
         if not its1_seqs:
             assert not hmm_name, hmm_name

--- a/thapbi_pict/legacy.py
+++ b/thapbi_pict/legacy.py
@@ -259,12 +259,19 @@ assert parse_fasta_entry("ACC-ONLY") == (0, "")
 
 
 def main(
-    fasta_file, db_url, name=None, validate_species=False, genus_only=False, debug=True
+    fasta_file,
+    db_url,
+    hmm_stem=None,
+    name=None,
+    validate_species=False,
+    genus_only=False,
+    debug=True,
 ):
     """Implement the ``thapbi_pict legacy-import`` command."""
     return import_fasta_file(
         fasta_file,
         db_url,
+        hmm_stem=hmm_stem,
         name=name,
         debug=debug,
         fasta_entry_fn=split_composite_entry,

--- a/thapbi_pict/ncbi.py
+++ b/thapbi_pict/ncbi.py
@@ -92,12 +92,19 @@ assert parse_fasta_entry(
 
 
 def main(
-    fasta_file, db_url, name=None, validate_species=False, genus_only=False, debug=True
+    fasta_file,
+    db_url,
+    hmm_stem=None,
+    name=None,
+    validate_species=False,
+    genus_only=False,
+    debug=True,
 ):
     """Implement the ``thapbi_pict ncbi-import`` command."""
     return import_fasta_file(
         fasta_file,
         db_url,
+        hmm_stem=hmm_stem,
         name=name,
         debug=debug,
         fasta_entry_fn=None,

--- a/thapbi_pict/seq_import.py
+++ b/thapbi_pict/seq_import.py
@@ -34,6 +34,7 @@ def main(
     inputs,
     method,
     db_url,
+    hmm_stem,
     min_abundance=1000,
     name=None,
     validate_species=False,
@@ -109,6 +110,7 @@ def main(
         import_fasta_file(
             fasta_file,
             db_url,
+            hmm_stem,
             name,
             fasta_entry_fn=sequence_wanted,
             entry_taxonomy_fn=meta_fn,


### PR DESCRIPTION
This is intended to help with (a) exploring different ITS1 HMM, (b) using with other markers, and (c) trying without any HMM filter/cut step.