### PR TITLE
Support for flipping reads based on primer direction

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Release History
 ======= ========== ============================================================================
 Version Date       Notes
 ======= ========== ============================================================================
-v0.4.4  2019-10-01 Added ``--hmm`` argument for overriding provided ITS1 HMM, or using none.
+v0.4.4  2019-10-01 New ``--hmm`` & ``--flip`` arguments for ``prepare-reads`` and ``pipeline``.
 v0.4.3  2019-09-26 New ``conflicts`` command reporting genus/species level conflicts in DB.
 v0.4.2  2019-09-26 Drop clade from taxonomy table, require unique species entries.
 v0.4.1  2019-09-16 Include NCBI strains/variants/etc and their synonyms as species synonyms.

--- a/tests/test_pipeline.sh
+++ b/tests/test_pipeline.sh
@@ -35,8 +35,9 @@ touch $TMP/intermediate/unwanted.identity.tsv
 touch $TMP/intermediate/distraction.fasta
 touch $TMP/intermediate/ignore-me.onebp.tsv
 # Run again with some explicit options set (shouldn't change output)
+# Using --flip will have no effect as already have the intermediate files
 rm -rf $TMP/output/*
-thapbi_pict pipeline -i tests/reads/ -s $TMP/intermediate -o $TMP/output -m onebp -a 250 -r report --hmm thapbi_pict/hmm/combined.hmm
+thapbi_pict pipeline -i tests/reads/ -s $TMP/intermediate -o $TMP/output -m onebp -a 250 -r report --hmm thapbi_pict/hmm/combined.hmm --flip
 diff $TMP/intermediate/DNAMIX_S95_L001.fasta tests/prepare-reads/DNAMIX_S95_L001.fasta
 diff $TMP/output/report.samples.txt tests/pipeline/thapbi-pict.samples.onebp.txt
 diff $TMP/output/report.samples.tsv tests/pipeline/thapbi-pict.samples.onebp.tsv

--- a/tests/test_prepare-reads.sh
+++ b/tests/test_prepare-reads.sh
@@ -24,6 +24,11 @@ rm -rf $TMP/DNAMIX_S95_L001.fasta
 thapbi_pict prepare-reads -o $TMP -i tests/reads/DNAMIX_S95_L001_*.fastq.gz -a 0
 if [ `grep -c "^>" $TMP/DNAMIX_S95_L001.fasta` -ne "735" ]; then echo "Wrong FASTA output count"; false; fi
 
+# In this case, --flip makes no difference
+rm -rf $TMP/DNAMIX_S95_L001.fasta
+thapbi_pict prepare-reads -o $TMP -i tests/reads/DNAMIX_S95_L001_*.fastq.gz -a 0 --flip
+if [ `grep -c "^>" $TMP/DNAMIX_S95_L001.fasta` -ne "735" ]; then echo "Wrong FASTA output count"; false; fi
+
 rm -rf $TMP/DNAMIX_S95_L001.fasta
 thapbi_pict prepare-reads -o $TMP -i tests/reads/DNAMIX_S95_L001_*.fastq.gz -a 5
 if [ `grep -c "^>" $TMP/DNAMIX_S95_L001.fasta` -ne "24" ]; then echo "Wrong FASTA output count"; false; fi

--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -192,6 +192,7 @@ def prepare_reads(args=None):
         primer_dir=args.primers,
         left_primer=args.left,
         right_primer=args.right,
+        flip=args.flip,
         min_abundance=args.abundance,
         tmp_dir=args.temp,
         debug=args.verbose,
@@ -345,8 +346,9 @@ def pipeline(args=None):
         out_dir=intermediate_dir,
         hmm_stem=hmm,
         primer_dir=None,
-        left_primer=ARG_PRIMER_LEFT["default"],
-        right_primer=ARG_PRIMER_RIGHT["default"],
+        left_primer=args.left,
+        right_primer=args.right,
+        flip=args.flip,
         min_abundance=args.abundance,
         tmp_dir=args.temp,
         debug=args.verbose,
@@ -528,6 +530,13 @@ ARG_GENUS_ONLY = dict(  # noqa: C408
 
 # Prepare reads arguments
 # =======================
+
+# "--flip",
+ARG_FLIP = dict(  # noqa: C408
+    default=False,
+    action="store_true",
+    help="Also check reverse complement when looking for primers.",
+)
 
 # "-l", "--left",
 ARG_PRIMER_LEFT = dict(  # noqa: C408
@@ -723,6 +732,10 @@ def main(args=None):
     parser_pipeline.add_argument("-a", "--abundance", **ARG_FASTQ_MIN_ABUNDANCE)
     parser_pipeline.add_argument("-d", "--database", **ARG_DB_INPUT)
     parser_pipeline.add_argument("--hmm", **ARG_HMM)
+    # Not using -l and -r for primers as used -r for report:
+    parser_pipeline.add_argument("--left", **ARG_PRIMER_LEFT)
+    parser_pipeline.add_argument("--right", **ARG_PRIMER_RIGHT)
+    parser_pipeline.add_argument("--flip", **ARG_FLIP)
     parser_pipeline.add_argument("-m", "--method", **ARG_METHOD_OUTPUT)
     parser_pipeline.add_argument("-t", "--metadata", **ARG_METADATA)
     parser_pipeline.add_argument("-c", "--metacols", **ARG_METACOLS)
@@ -956,6 +969,7 @@ def main(args=None):
     )
     parser_prepare_reads.add_argument("-l", "--left", **ARG_PRIMER_LEFT)
     parser_prepare_reads.add_argument("-r", "--right", **ARG_PRIMER_RIGHT)
+    parser_prepare_reads.add_argument("--flip", **ARG_FLIP)
     parser_prepare_reads.add_argument("-t", "--temp", **ARG_TEMPDIR)
     parser_prepare_reads.add_argument("-v", "--verbose", **ARG_VERBOSE)
     parser_prepare_reads.add_argument("--cpu", **ARG_CPU)

--- a/thapbi_pict/prepare.py
+++ b/thapbi_pict/prepare.py
@@ -327,6 +327,7 @@ def prepare_sample(
     failed_primer_name,
     left_primer,
     right_primer,
+    flip,
     hmm_stem,
     min_abundance,
     control,
@@ -388,6 +389,25 @@ def prepare_sample(
     )
     if not os.path.isfile(trimmed_fasta):
         sys.exit("ERROR: Expected file %r from cutadapt\n" % trimmed_fasta)
+
+    if flip:
+        # Only check those which failed to find primers on initial orientation
+        trimmed_flipped_fasta = os.path.join(tmp, "cutadapt_flipped.fasta")
+        if failed_primer_name:
+            bad_primer_fasta = os.path.join(tmp, "bad_primers_flipped.fasta")
+        else:
+            bad_primer_fasta = None
+        run_cutadapt(
+            merged_fastq,
+            trimmed_flipped_fasta,
+            bad_primer_fasta,
+            reverse_complement(right_primer),
+            reverse_complement(left_primer),
+            debug=debug,
+            cpu=cpu,
+        )
+        if not os.path.isfile(trimmed_flipped_fasta):
+            sys.exit("ERROR: Expected file %r from cutadapt\n" % trimmed_flipped_fasta)
 
     # deduplicate and apply minimum abundance threshold
     merged_fasta = os.path.join(tmp, "dedup_trimmed.fasta")
@@ -590,6 +610,7 @@ def main(
             failed_primer_name,
             left_primer,
             right_primer,
+            flip,
             hmm_stem,
             control_min_abundance if control else sample_min_abundance,
             control,

--- a/thapbi_pict/prepare.py
+++ b/thapbi_pict/prepare.py
@@ -463,6 +463,7 @@ def main(
     primer_dir,
     left_primer,
     right_primer,
+    flip=False,
     min_abundance=100,
     tmp_dir=None,
     debug=False,


### PR DESCRIPTION
With some library preparations, expect about 50% of the reads to be inverted - so this can make a big difference to the apparent yield.

This is hopefully a short-term implementation by calling cutadapt twice, there are open issues for enhancing cutadapt to do this itself:

https://github.com/marcelm/cutadapt/issues/220
https://github.com/marcelm/cutadapt/issues/402