### PR TITLE
new command: fasta-nr

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Release History
 ======= ========== ============================================================================
 Version Date       Notes
 ======= ========== ============================================================================
+v0.4.8  *Pending*  New ``fasta-nr`` command for use in alternatives to ``prepare-reads``.
 v0.4.7  2019-10-10 New ``--minlen`` & ``--maxlen`` args for ``prepare-reads`` and ``pipeline``.
 v0.4.6  2019-10-02 Forgot to include updated DB with the PyPI release.
 v0.4.5  2019-10-02 Apply primer trimming to ``ncbi-import`` (crop if primers found).

--- a/thapbi_pict/__init__.py
+++ b/thapbi_pict/__init__.py
@@ -25,4 +25,4 @@ automatically from the ``docs/`` folder of the `software repository
 within the source code which document the Python API.
 """
 
-__version__ = "0.4.7"
+__version__ = "0.4.8"

--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -1056,7 +1056,8 @@ def main(args=None):
         type=str,
         default="-",
         metavar="PATH",
-        help="Single output filename, '-' for stdout (default).",
+        help="Single output filename, '-' for stdout (default). "
+        "Can be a directory if a single -i/-r input file given.",
     )
     parser_fasta_nr.add_argument(
         "-a",

--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -210,6 +210,24 @@ def prepare_reads(args=None):
         return return_code
 
 
+def fasta_nr(args=None):
+    """Subcommand to prepare non-redundant MD5 named FASTA files."""
+    from .fasta_nr import main
+
+    if not (args.input or args.revcomp):
+        sys.exit("ERROR: Require at least one of -i/--input or -r/--revcomp")
+
+    return main(
+        inputs=args.input,
+        revcomp=args.revcomp,
+        output=args.output,
+        min_abundance=args.abundance,
+        min_length=args.minlen,
+        max_length=args.maxlen,
+        debug=args.verbose,
+    )
+
+
 def classify(args=None):
     """Subcommand to classify FASTA sequences using a database."""
     from .classify import main
@@ -1005,6 +1023,53 @@ def main(args=None):
     parser_prepare_reads.add_argument("--cpu", **ARG_CPU)
     parser_prepare_reads.set_defaults(func=prepare_reads)
     del parser_prepare_reads  # To prevent acidentally adding more
+
+    parser_fasta_nr = subparsers.add_parser(
+        "fasta-nr",
+        description="Prepare non-redundant FASTA file using MD5 naming.",
+        epilog="Each unique sequence will be named <MD5>_<count> using "
+        "the MD5 checksum of the upper case sequence and its total "
+        "abundance. Input files may use <prefix>_<count> naming, this "
+        "count will be used for the associated sequence.",
+    )
+    parser_fasta_nr.add_argument(
+        "-i",
+        "--input",
+        type=str,
+        required=False,
+        nargs="+",
+        metavar="INPUT",
+        help="One or more FASTA files.",
+    )
+    parser_fasta_nr.add_argument(
+        "-r",
+        "--revcomp",
+        type=str,
+        required=False,
+        metavar="INPUT",
+        help="One or more FASTA files as input "
+        "to be reverse-complemented on loading.",
+    )
+    parser_fasta_nr.add_argument(
+        "-o",
+        "--output",
+        type=str,
+        default="-",
+        metavar="PATH",
+        help="Single output filename, '-' for stdout (default).",
+    )
+    parser_fasta_nr.add_argument(
+        "-a",
+        "--abundance",
+        type=int,
+        default=str(DEFAULT_MIN_ABUNDANCE),
+        help="Mininum abundance to require before outputing a sequence. "
+        "Default %i as in prepare-reads." % DEFAULT_MIN_ABUNDANCE,
+    )
+    parser_fasta_nr.add_argument("--minlen", **ARG_MIN_LENGTH)
+    parser_fasta_nr.add_argument("--maxlen", **ARG_MAX_LENGTH)
+    parser_fasta_nr.add_argument("-v", "--verbose", **ARG_VERBOSE)
+    parser_fasta_nr.set_defaults(func=fasta_nr)
 
     # classify
     parser_classify = subparsers.add_parser(

--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -1063,9 +1063,9 @@ def main(args=None):
         "-a",
         "--abundance",
         type=int,
-        default=str(DEFAULT_MIN_ABUNDANCE),
+        default=0,
         help="Mininum abundance to require before outputing a sequence. "
-        "Default %i as in prepare-reads." % DEFAULT_MIN_ABUNDANCE,
+        "Default no minimum.",
     )
     parser_fasta_nr.add_argument("--minlen", **ARG_MIN_LENGTH)
     parser_fasta_nr.add_argument("--maxlen", **ARG_MAX_LENGTH)

--- a/thapbi_pict/fasta_nr.py
+++ b/thapbi_pict/fasta_nr.py
@@ -10,6 +10,7 @@ This implements the ``thapbi_pict fasta-nr ...`` command, and does part
 of the work of the ``thapbi_pict prepare-reads`` command.
 """
 
+import os
 import sys
 
 from collections import Counter
@@ -42,6 +43,19 @@ def main(
     assert isinstance(inputs, list)
     assert isinstance(revcomp, list)
     assert inputs or revcomp
+
+    if os.path.isdir(output):
+        if len(inputs + revcomp) == 1:
+            output = os.path.join(output, os.path.basename((inputs + revcomp)[0]))
+            if debug:
+                sys.stderr.write(
+                    "DEBUG: Single input with directory as ouput, writing to %s\n"
+                    % output
+                )
+        else:
+            sys.exit(
+                "ERROR: Output directory can only be used with a single input file"
+            )
 
     counts = Counter()
     for filename in inputs:

--- a/thapbi_pict/fasta_nr.py
+++ b/thapbi_pict/fasta_nr.py
@@ -31,12 +31,17 @@ def main(
     debug=False,
 ):
     """Implement the ``thapbi_pict fasta-nr`` command."""
+    if not inputs:
+        inputs = []
+    if not revcomp:
+        revcomp = []
     if isinstance(inputs, str):
         inputs = [inputs]
     if isinstance(revcomp, str):
         revcomp = [revcomp]
     assert isinstance(inputs, list)
     assert isinstance(revcomp, list)
+    assert inputs or revcomp
 
     counts = Counter()
     for filename in inputs:

--- a/thapbi_pict/prepare.py
+++ b/thapbi_pict/prepare.py
@@ -220,16 +220,23 @@ def save_nr_fasta(counts, output_fasta, min_abundance=0):
 
     Returns the number of sequences accepted (above any minimum
     abundance specified).
+
+    Use output_fasta='-' for standard out.
     """
     accepted = 0
     values = sorted((-count, seq) for seq, count in counts.items())
-    with open(output_fasta, "w") as out_handle:
-        for count, seq in values:
-            if -count < min_abundance:
-                # Sorted, so everything hereafter is too rare
-                break
-            out_handle.write(">%s_%i\n%s\n" % (md5seq(seq), -count, seq))
-            accepted += 1
+    if output_fasta == "-":
+        out_handle = sys.stdout
+    else:
+        out_handle = open(output_fasta, "w")
+    for count, seq in values:
+        if -count < min_abundance:
+            # Sorted, so everything hereafter is too rare
+            break
+        out_handle.write(">%s_%i\n%s\n" % (md5seq(seq), -count, seq))
+        accepted += 1
+    if output_fasta != "-":
+        out_handle.close()
     return accepted
 
 


### PR DESCRIPTION
For use in alternative pipelines to calling ``thapbi_pict prepare-reads`` (e.g. additional steps for barcode demultiplexing).