### PR TITLE
Fix fasta-nr when inputs have abundance and descriptions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Release History
 ======= ========== ============================================================================
 Version Date       Notes
 ======= ========== ============================================================================
+v0.4.16 2019-11-15 Bug fix in ``fasta-nr`` when using input records with descriptions.
 v0.4.15 2019-11-04 Harmonised ``dump`` FASTA & ``curated-import`` with semi-colon separator.
 v0.4.14 2019-10-23 Configurable FASTA entry separator for ``curated-import`` & ``ncbi-import``.
 v0.4.13 2019-10-22 Fix 5 cases missing ``A`` near end, ``...CTGAAAACT`` to ``...CTGAAAAACT``.

--- a/tests/test_fasta-nr.sh
+++ b/tests/test_fasta-nr.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Copyright 2018-2019 by Peter Cock, The James Hutton Institute.
+# All rights reserved.
+# This file is part of the THAPBI Phytophthora ITS1 Classifier Tool (PICT),
+# and is released under the "MIT License Agreement". Please see the LICENSE
+# file that should have been included as part of this package.
+
+IFS=$'\n\t'
+set -eu
+# Note not using "set -o pipefail" until after check error message with grep
+
+export TMP=${TMP:-/tmp}
+
+echo "================="
+echo "Checking fasta-nr"
+echo "================="
+set -x
+thapbi_pict fasta-nr 2>&1 | grep "Require at least one of"
+set -o pipefail
+
+rm -rf $TMP/all.fasta
+thapbi_pict fasta-nr -i tests/prepare-reads/DNAMIX_S95_L001.fasta -o $TMP/all.fasta
+# Should be identical bar the loss of the HMM names in FASTA descriptions
+diff /tmp/pc40583/all.fasta <(cut -f 1 -d " " tests/prepare-reads/DNAMIX_S95_L001.fasta)
+
+echo "$0 - test_fasta-nr.sh passed"

--- a/thapbi_pict/__init__.py
+++ b/thapbi_pict/__init__.py
@@ -25,4 +25,4 @@ automatically from the ``docs/`` folder of the `software repository
 within the source code which document the Python API.
 """
 
-__version__ = "0.4.15"
+__version__ = "0.4.16"

--- a/thapbi_pict/fasta_nr.py
+++ b/thapbi_pict/fasta_nr.py
@@ -65,7 +65,7 @@ def main(
         with open(filename) as handle:
             for _, seq in SimpleFastaParser(handle):
                 if min_length <= len(seq) <= max_length:
-                    a = abundance_from_read_name(_)
+                    a = abundance_from_read_name(_.split(None, 1)[0])
                     counts[seq.upper()] += a
     for filename in revcomp:
         if debug:
@@ -73,7 +73,7 @@ def main(
         with open(filename) as handle:
             for _, seq in SimpleFastaParser(handle):
                 if min_length <= len(seq) <= max_length:
-                    a = abundance_from_read_name(_)
+                    a = abundance_from_read_name(_.split(None, 1)[0])
                     counts[reverse_complement(seq.upper())] += a
 
     if counts:


### PR DESCRIPTION
Tried using the command in a slightly different context which revealed this limitation.

Added a basic test too.