### PR TITLE
Skip HMM check on seq-import

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Release History
 ======= ========== ============================================================================
 Version Date       Notes
 ======= ========== ============================================================================
+v0.5.2  2019-11-25 Removed redundant use of HMM filter in ``seq-import`` command.
 v0.5.1  2019-11-22 Updated NCBI taxonomy, adds *Phytophthora oreophila* and *P. cacuminis*.
 v0.5.0  2019-11-21 Only use HMM as a filter, not for trimming in DB import or classify steps.
 v0.4.19 2019-11-19 Additional curated entries in default ITS1 database.

--- a/thapbi_pict/__init__.py
+++ b/thapbi_pict/__init__.py
@@ -25,4 +25,4 @@ automatically from the ``docs/`` folder of the `software repository
 within the source code which document the Python API.
 """
 
-__version__ = "0.5.1"
+__version__ = "0.5.2"

--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -132,7 +132,6 @@ def seq_import(args=None):
         inputs=args.input,
         method=args.method,
         db_url=expand_database_argument(args.database),
-        hmm_stem=expand_hmm_argument(args.hmm),
         min_abundance=args.abundance,
         name=args.name,
         validate_species=not args.lax,
@@ -928,7 +927,6 @@ def main(args=None):
         "ITS1 database)." % (DEFAULT_MIN_ABUNDANCE * 10, DEFAULT_MIN_ABUNDANCE),
     )
     subcommand_parser.add_argument("-d", "--database", **ARG_DB_WRITE)
-    subcommand_parser.add_argument("--hmm", **ARG_HMM)
     subcommand_parser.add_argument("-n", "--name", **ARG_NAME)
     subcommand_parser.add_argument("-x", "--lax", **ARG_LAX)
     subcommand_parser.add_argument("-g", "--genus", **ARG_GENUS_ONLY)

--- a/thapbi_pict/seq_import.py
+++ b/thapbi_pict/seq_import.py
@@ -34,7 +34,6 @@ def main(
     inputs,
     method,
     db_url,
-    hmm_stem,
     min_abundance=1000,
     name=None,
     validate_species=False,
@@ -113,7 +112,7 @@ def main(
         import_fasta_file(
             fasta_file,
             db_url,
-            hmm_stem,
+            "",  # not using HMM as prepare-reads did this for us
             name,
             fasta_entry_fn=sequence_wanted,
             entry_taxonomy_fn=meta_fn,


### PR DESCRIPTION
The HMM filtering will have already been done in ``prepare-reads``, so it is redundant to do it again in ``seq-import``.

Includes a DB rebuild confirming this.