### PR TITLE
Treat 'includes' like 'synonym' in NCBI taxonomy

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Release History
 ======= ========== ============================================================================
 Version Date       Notes
 ======= ========== ============================================================================
+v0.6.3  2020-01-20 Treat NCBI taxonomy "includes" as synonyms, adds 396 new species aliases.
 v0.6.2  2020-01-14 Memory optimisation to the default ``onebp`` classifier.
 v0.6.1  2020-01-08 Requires at least Python 3.6 as now using f-strings (internal change only).
 v0.6.0  2020-01-08 Stop discarding normally conserved 32bp start of *Phytophthora* ITS1 marker.

--- a/thapbi_pict/__init__.py
+++ b/thapbi_pict/__init__.py
@@ -25,4 +25,4 @@ automatically from the ``docs/`` folder of the `software repository
 within the source code which document the Python API.
 """
 
-__version__ = "0.6.2"
+__version__ = "0.6.3"

--- a/thapbi_pict/db_import.py
+++ b/thapbi_pict/db_import.py
@@ -237,18 +237,16 @@ def import_fasta_file(
     with open(trimmed_fasta) as handle:
         for title, seq in SimpleFastaParser(handle):
             seq_count += 1
+            idn = title.split(None, 1)[0]
 
             if not (min_length <= len(seq) <= max_length):
                 if debug:
-                    sys.stderr.write(
-                        f"DEBUG: Rejected {title} as length {len(seq):d}\n"
-                    )
+                    sys.stderr.write(f"DEBUG: Rejected {idn} as length {len(seq)}\n")
                 continue
 
             # One sequence can have multiple entries
-            idn = title.split(None, 1)[0]
             if idn in idn_set:
-                sys.stderr.write(f"WARNING: Duplicated identifier {idn!r}\n")
+                sys.stderr.write(f"WARNING: Duplicated identifier {idn}\n")
             idn_set.add(idn)
 
             entries = fasta_entry_fn(title)

--- a/thapbi_pict/db_import.py
+++ b/thapbi_pict/db_import.py
@@ -306,7 +306,7 @@ def import_fasta_file(
                 else:
                     taxonomy = lookup_species(session, name)
                 if not taxonomy:
-                    if debug and name not in bad_species:
+                    if validate_species and debug and name not in bad_species:
                         sys.stderr.write(
                             "WARNING: Could not validate species"
                             f" {name!r} from {entry!r}\n"

--- a/thapbi_pict/taxdump.py
+++ b/thapbi_pict/taxdump.py
@@ -53,7 +53,11 @@ def load_names(names_dmp):
             name = parts[1].strip()
             if line.endswith("\t|\tscientific name\t|\n"):
                 names[taxid] = name
-            elif line.endswith("\t|\tsynonym\t|\n"):
+            elif line.endswith("\t|\tsynonym\t|\n") or line.endswith(
+                "\t|\tincludes\t|\n"
+            ):
+                # e.g. Phytophthora aquimorbida 'includes' Phytophthora sp. CCH-2009b
+                # which we want to treat like a synonym
                 try:
                     synonym[taxid].append(name)
                 except KeyError:


### PR DESCRIPTION
Came up as a corner case in the Redekar et al. dataset.