### PR TITLE
v0.6.4 - primer arguments to curated-import

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Release History
 ======= ========== ============================================================================
 Version Date       Notes
 ======= ========== ============================================================================
+v0.6.4  2020-01-20 Accept primer arguments to ``curated-import`` command.
 v0.6.3  2020-01-20 Treat NCBI taxonomy "includes" as synonyms, adds 396 new species aliases.
 v0.6.2  2020-01-14 Memory optimisation to the default ``onebp`` classifier.
 v0.6.1  2020-01-08 Requires at least Python 3.6 as now using f-strings (internal change only).

--- a/docs/custom_database/build_db.rst
+++ b/docs/custom_database/build_db.rst
@@ -220,8 +220,13 @@ supply curated data as described next.
 Curated import
 --------------
 
-The ``thapbi_pict curated-import`` mentioned above differs from the
-``thapbi_pict ncbi-import`` command in two key points. First, it expects
-the sequences to be pre-trimmed (it does not look for an remove primers).
+The ``thapbi_pict curated-import`` used above differs from the
+``thapbi_pict ncbi-import`` command in two key points. First, by default it
+expects the sequences to be pre-trimmed (it does not do primer trimming).
 Second, it does not use heuristics but simply assumes the FASTA description
 line is an identifier followed by the species name *only*.
+
+Well actually, ``thapbi_pict curated-import`` is a little more sophisiticated
+as it allows a non-redundant FASTA input where a single sequence can have
+several entries in the same record using a separator which defaults to the
+semi-colon, e.g. ``>ID2 genus species one;ID2 genus species two``.

--- a/thapbi_pict/__init__.py
+++ b/thapbi_pict/__init__.py
@@ -25,4 +25,4 @@ automatically from the ``docs/`` folder of the `software repository
 within the source code which document the Python API.
 """
 
-__version__ = "0.6.3"
+__version__ = "0.6.4"

--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 by Peter Cock, The James Hutton Institute.
+# Copyright 2018-2020 by Peter Cock, The James Hutton Institute.
 # All rights reserved.
 # This file is part of the THAPBI Phytophthora ITS1 Classifier Tool (PICT),
 # and is released under the "MIT License Agreement". Please see the LICENSE
@@ -156,6 +156,8 @@ def curated_import(args=None):
         name=args.name,
         validate_species=not args.lax,
         genus_only=args.genus,
+        left_primer=args.left,
+        right_primer=args.right,
         sep=args.sep,
         debug=args.verbose,
     )
@@ -625,6 +627,9 @@ ARG_PRIMER_LEFT = dict(  # noqa: C408
     "Default 21bp ITS6 'GAAGGTGAAGTCGTAACAAGG' from Cooke "
     "et al. 2000 https://doi.org/10.1006/fgbi.2000.1202",
 )
+ARG_PRIMER_LEFT_BLANK = dict(  # noqa: C408
+    type=str, default="", metavar="PRIMER", help="Left primer sequence, default blank."
+)
 
 # "-r", "--right",
 ARG_PRIMER_RIGHT = dict(  # noqa: C408
@@ -637,6 +642,9 @@ ARG_PRIMER_RIGHT = dict(  # noqa: C408
     "'GCARRGACTTTCGTCCCYRC' from Scibetta et al. 2012 "
     "https://doi.org/10.1016/j.mimet.2011.12.012 - meaning "
     "look for 'GYRGGGACGAAAGTCYYTGC' after marker.",
+)
+ARG_PRIMER_RIGHT_BLANK = dict(  # noqa: C408
+    type=str, default="", metavar="PRIMER", help="Right primer sequence, default blank."
 )
 
 # "--hmm",
@@ -860,7 +868,9 @@ def main(args=None):
         "ncbi-import",
         description="Load an NCBI format ITS1 FASTA file into a database. "
         "By default verifies species names against a pre-loaded taxonomy, "
-        "non-matching entries are rejected.",
+        "non-matching entries are rejected. In lax mode uses heuristics to "
+        "split the species and any following free text - see also the "
+        "curated-import command which avoids this ambiguity.",
     )
     subcommand_parser.add_argument(
         "-i", "--input", type=str, required=True, help="One ITS1 fasta filename."
@@ -946,6 +956,9 @@ def main(args=None):
         "curated-import",
         description="Load a curated marker FASTA file into a database. "
         "Treats the FASTA title lines as identitier, space, species. "
+        "Also supports multiple entries in a single record using a FASTA "
+        "title line of identifier1, space, species1, separator, identifier2, "
+        "space, species2, etc. "
         "By default verifies species names against a pre-loaded taxonomy, "
         "non-matching entries are rejected.",
     )
@@ -958,6 +971,8 @@ def main(args=None):
     subcommand_parser.add_argument("-n", "--name", **ARG_NAME)
     subcommand_parser.add_argument("-x", "--lax", **ARG_LAX)
     subcommand_parser.add_argument("-g", "--genus", **ARG_GENUS_ONLY)
+    subcommand_parser.add_argument("-l", "--left", **ARG_PRIMER_LEFT_BLANK)
+    subcommand_parser.add_argument("-r", "--right", **ARG_PRIMER_RIGHT_BLANK)
     subcommand_parser.add_argument("-s", "--sep", **ARG_FASTA_SEP)
     subcommand_parser.add_argument("-v", "--verbose", **ARG_VERBOSE)
     subcommand_parser.set_defaults(func=curated_import)

--- a/thapbi_pict/curated.py
+++ b/thapbi_pict/curated.py
@@ -1,4 +1,4 @@
-# Copyright 2019 by Peter Cock, The James Hutton Institute.
+# Copyright 2019-2020 by Peter Cock, The James Hutton Institute.
 # All rights reserved.
 # This file is part of the THAPBI Phytophthora ITS1 Classifier Tool (PICT),
 # and is released under the "MIT License Agreement". Please see the LICENSE
@@ -47,6 +47,8 @@ def main(
     name=None,
     validate_species=False,
     genus_only=False,
+    left_primer=None,
+    right_primer=None,
     sep=";",
     debug=True,
 ):
@@ -62,4 +64,6 @@ def main(
         entry_taxonomy_fn=parse_fasta_entry,
         validate_species=validate_species,
         genus_only=genus_only,
+        left_primer=left_primer,
+        right_primer=right_primer,
     )


### PR DESCRIPTION
This was a somewhat arbitrary restriction, although I have done this defaulting to no left or right primer (keeping existing behaviour).