### PR TITLE
MD5 as 16 bytes vs 32 char hex string in hash cloud

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Release History
 ======= ========== ============================================================================
 Version Date       Notes
 ======= ========== ============================================================================
-v0.6.4  2020-01-20 Accept primer arguments to ``curated-import`` command.
+v0.6.4  2020-01-23 ``curated-import`` accepts primers. Reduced memory usage for ``onebp``.
 v0.6.3  2020-01-20 Treat NCBI taxonomy "includes" as synonyms, adds 396 new species aliases.
 v0.6.2  2020-01-14 Memory optimisation to the default ``onebp`` classifier.
 v0.6.1  2020-01-08 Requires at least Python 3.6 as now using f-strings (internal change only).

--- a/thapbi_pict/utils.py
+++ b/thapbi_pict/utils.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 by Peter Cock, The James Hutton Institute.
+# Copyright 2018-2020 by Peter Cock, The James Hutton Institute.
 # All rights reserved.
 # This file is part of the THAPBI Phytophthora ITS1 Classifier Tool (PICT),
 # and is released under the "MIT License Agreement". Please see the LICENSE
@@ -226,8 +226,23 @@ assert sorted(expand_IUPAC_ambiguity_codes("GYRGGGACGAAAGTCYYTGC")) == [
 ]
 
 
+def md5seq_16b(seq):
+    r"""Return MD5 16-byte digest hash of the (upper case) sequence.
+
+    >>> md5seq_16b("ACGT")
+    b'\xf1\xf8\xf4\xbfA;\x16\xad\x13W"\xaaE\x91\x04>'
+
+    """
+    return hashlib.md5(seq.upper().encode("ascii")).digest()
+
+
 def md5seq(seq):
-    """Return MD5 hash of the (upper case) sequence."""
+    """Return MD5 32-letter hex digest of the (upper case) sequence.
+
+    >>> md5seq("ACGT")
+    'f1f8f4bf413b16ad135722aa4591043e'
+
+    """
     return hashlib.md5(seq.upper().encode("ascii")).hexdigest()
 
 


### PR DESCRIPTION
Further improves on memory usage over building the onebp cloud dictionary using the sequence strings as keys (the change in v0.6.2, see #234)