### PR TITLE
Make metadata -x default 1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Release History
 ======= ========== ============================================================================
 Version Date       Notes
 ======= ========== ============================================================================
+v0.6.8  *Pending*  More complete worked examples. Metadata ``-x`` default now column 1.
 v0.6.7  2020-02-13 Method in ``pipeline`` filenames; max sample abundance in read reports.
 v0.6.6  2020-02-05 Coloring groups in ``sample-report``. Can call assessment from ``pipeline``.
 v0.6.5  2020-01-27 Do ``--flip`` in ``prepare-reads`` using cutadapt v2.8 or later.

--- a/examples/fungal_mock/README.rst
+++ b/examples/fungal_mock/README.rst
@@ -135,9 +135,9 @@ Sample-type, Group, Protocol, Condition, Replicate, MiSeq Name. The purpose here
 is to group the samples logically (sorting on accession or MiSeq Name would not
 work), and suitable for group colouring.
 
-Argument ``-x 1`` indicates the filename stem can be found in column 1, Accession.
-We might have downloaded the files and used the author original names, in which
-case ``-x 2`` ought to work.
+Argument ``-x 1`` (default, so not needed) indicates the filename stem can be
+found in column 1, Accession. We might have downloaded the files and used the
+author original names, in which case ``-x 2`` ought to work.
 
 Argument ``-g 6`` means assign colour bands using column 6, Group. This is used
 in the Excel reports.

--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -745,13 +745,12 @@ ARG_METACOLS = dict(  # noqa: C408
 # "-x", "--metaindex",
 ARG_METAINDEX = dict(  # noqa: C408
     type=int,
-    default="0",
+    default="1",
     metavar="COL",
     help="If using metadata, which column contains the sequenced sample "
-    "names. Default is the first column requested as metadata output "
-    "with the -c / --metacols argument. This column can contain multiple "
-    "semi-colon separated names catering to the fact that a field sample "
-    "could be sequenced multiple times with technical replicates.",
+    "names. Default 1. Field can contain multiple semi-colon separated names "
+    "catering to the fact that a field sample could be sequenced multiple "
+    "times with technical replicates.",
 )
 
 # "-g", "--metagroups",


### PR DESCRIPTION
Given the column sorting behaviour (and group colouring), using the first selected extra column is rarely the best choice. Also nicer if index column is not one of the extra columns (as then get duplication - although the replicates case is a bit different).