### PR TITLE
Optional post-read-merging cache setting

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Release History
 ======= ========== ============================================================================
 Version Date       Notes
 ======= ========== ============================================================================
+v0.6.12 *Pending*  New advanced setting ``--merged-cache`` intended for multiple marker use.
 v0.6.11 2020-03-02 Updated genus-level only NCBI import, restrict to those with 32bp leader.
 v0.6.10 2020-02-24 Treat I (for inosine as in tRNA) in primers as N (IUPAC code for any base).
 v0.6.9  2020-02-20 Allow pre-primer-trimmed FASTQ. Fixed row coloring when missing samples.

--- a/examples/endangered_species/run.sh
+++ b/examples/endangered_species/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eup pipeline
 
-echo NOTE: Expected first time run time is about XXX hours,
+echo NOTE: Expected first time run time is about 1.5 hours,
 echo repeat runs about 1 minute just to regenerate reports.
 echo
 
@@ -14,10 +14,12 @@ function analyse {
 
     echo "Running analysis for $NAME"
     mkdir -p intermediate/$NAME/
-    thapbi_pict prepare-reads -i raw_data/ -o intermediate/$NAME/ --left $LEFT --right $RIGHT
+    thapbi_pict prepare-reads --left $LEFT --right $RIGHT \
+		-i raw_data/ --merged-cache tmp_merged/ -o intermediate/$NAME/
     thapbi_pict fasta-nr -i intermediate/$NAME/*.fasta -o summary/$NAME.all.fasta
     thapbi_pict classify -i summary/$NAME.all.fasta -o summary/ -d references/$NAME.sqlite
     thapbi_pict pipeline -d references/${NAME}.sqlite --showdb \
+		--merged-cache tmp_merged/ \
 		--left $LEFT --right $RIGHT \
                 -i raw_data/ expected/ \
                 -s intermediate/$NAME/ -o summary/ -r $NAME \

--- a/examples/endangered_species/setup.sh
+++ b/examples/endangered_species/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eup pipeline
 
-mkdir -p raw_data/ expected/ intermediate/ intermediate_pool/ summary/
+mkdir -p raw_data/ expected/ tmp_merged/ intermediate/ intermediate_pool/ summary/
 if [ ! -f raw_download/MD5SUM.txt ]; then
     echo "ERROR: Missing raw_download/MD5SUM.txt"
     false

--- a/tests/test_pipeline.sh
+++ b/tests/test_pipeline.sh
@@ -44,4 +44,18 @@ diff $TMP/output/report.samples.onebp.tsv tests/pipeline/thapbi-pict.samples.one
 diff $TMP/output/report.reads.onebp.tsv tests/pipeline/thapbi-pict.reads.onebp.tsv
 diff $TMP/output/report.edit-graph.xgmml tests/pipeline/thapbi-pict.edit-graph.xgmml
 
+
+# Clear the intermediate, run again with --merged-cache
+rm -rf $TMP/intermediate_with_cache $TMP/output $TMP/merged_cache
+mkdir $TMP/intermediate_with_cache $TMP/output $TMP/merged_cache
+thapbi_pict pipeline --merged-cache $TMP/merged_cache -s $TMP/intermediate_with_cache -o $TMP/output -i tests/reads/
+for F in $TMP/intermediate_with_cache/*.fasta; do
+    diff $F $TMP/intermediate/${F##*/}
+done
+diff $TMP/intermediate/DNAMIX_S95_L001.fasta tests/prepare-reads/DNAMIX_S95_L001.fasta
+diff $TMP/output/thapbi-pict.samples.onebp.txt tests/pipeline/thapbi-pict.samples.onebp.txt
+diff $TMP/output/thapbi-pict.samples.onebp.tsv tests/pipeline/thapbi-pict.samples.onebp.tsv
+diff $TMP/output/thapbi-pict.reads.onebp.tsv tests/pipeline/thapbi-pict.reads.onebp.tsv
+diff $TMP/output/thapbi-pict.edit-graph.xgmml tests/pipeline/thapbi-pict.edit-graph.xgmml
+
 echo "$0 - test_pipeline.sh passed"

--- a/tests/test_prepare-reads.sh
+++ b/tests/test_prepare-reads.sh
@@ -21,18 +21,24 @@ set -o pipefail
 
 # Try a real example
 rm -rf $TMP/DNAMIX_S95_L001.fasta
+rm -rf $TMP/merged_cache/
+mkdir $TMP/merged_cache/
 thapbi_pict prepare-reads -o $TMP -i tests/reads/DNAMIX_S95_L001_*.fastq.gz \
 	    -a 0 --left GAAGGTGAAGTCGTAACAAGGTTTCCGTAGGTGAACCTGCGGAAGGATCATTA
 if [ `grep -c "^>" $TMP/DNAMIX_S95_L001.fasta` -ne "735" ]; then echo "Wrong FASTA output count"; false; fi
 
 # In this case, --flip makes no difference
+# Using merged cache also should make no difference
 rm -rf $TMP/DNAMIX_S95_L001.fasta
 thapbi_pict prepare-reads -o $TMP -i tests/reads/DNAMIX_S95_L001_*.fastq.gz \
-	    -a 0 --left GAAGGTGAAGTCGTAACAAGGTTTCCGTAGGTGAACCTGCGGAAGGATCATTA --flip
+	    --flip --merged-cache $TMP/merged_cache/ \
+	    -a 0 --left GAAGGTGAAGTCGTAACAAGGTTTCCGTAGGTGAACCTGCGGAAGGATCATTA
 if [ `grep -c "^>" $TMP/DNAMIX_S95_L001.fasta` -ne "735" ]; then echo "Wrong FASTA output count"; false; fi
 
 rm -rf $TMP/DNAMIX_S95_L001.fasta
+# Reusing the pre-primer time pre-abundance cache here:
 thapbi_pict prepare-reads -o $TMP -i tests/reads/DNAMIX_S95_L001_*.fastq.gz \
+	    --merged-cache $TMP/merged_cache/ \
 	    -a 5 --left GAAGGTGAAGTCGTAACAAGGTTTCCGTAGGTGAACCTGCGGAAGGATCATTA
 if [ `grep -c "^>" $TMP/DNAMIX_S95_L001.fasta` -ne "24" ]; then echo "Wrong FASTA output count"; false; fi
 

--- a/thapbi_pict/__init__.py
+++ b/thapbi_pict/__init__.py
@@ -24,4 +24,4 @@ automatically from the ``docs/`` folder of the `software repository
 within the source code which document the Python API.
 """
 
-__version__ = "0.6.11"
+__version__ = "0.6.12"

--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -210,6 +210,7 @@ def prepare_reads(args=None):
         min_length=args.minlen,
         max_length=args.maxlen,
         ignore_prefixes=tuple(args.ignore_prefixes),
+        merged_cache=args.merged_cache,
         tmp_dir=args.temp,
         debug=args.verbose,
         cpu=args.cpu,
@@ -394,6 +395,7 @@ def pipeline(args=None):
         min_length=args.minlen,
         max_length=args.maxlen,
         ignore_prefixes=tuple(args.ignore_prefixes),
+        merged_cache=args.merged_cache,
         tmp_dir=args.temp,
         debug=args.verbose,
         cpu=args.cpu,
@@ -567,6 +569,16 @@ ARG_METHOD_INPUT = dict(  # noqa: C408
     default=DEFAULT_METHOD,
     choices=list(method_classifier),
     help=f"Classify method (to infer filenames), default '{DEFAULT_METHOD}'.",
+)
+
+# "--merged-cache",
+ARG_MERGED_CACHE = dict(  # noqa: C408
+    type=str,
+    required=False,
+    metavar="DIRNAME",
+    help="Advanced option. Cache directory for temporary sample FASTA files after "
+    "trimming and merging, but before primer trimming and abundance threshold. "
+    "Intended for multi-primer analyses from a pooled sequencing run.",
 )
 
 # "-t", "--temp",
@@ -867,6 +879,7 @@ def main(args=None):
         help="Show DB entries in edit-graph, regardless of their abundance "
         "in samples. Very slow with large database.",
     )
+    subcommand_parser.add_argument("--merged-cache", **ARG_MERGED_CACHE)
     # Can't use -t for --temp as already using for --metadata:
     subcommand_parser.add_argument("--temp", **ARG_TEMPDIR)
     subcommand_parser.add_argument("--cpu", **ARG_CPU)
@@ -1126,6 +1139,7 @@ def main(args=None):
     subcommand_parser.add_argument("-l", "--left", **ARG_PRIMER_LEFT)
     subcommand_parser.add_argument("-r", "--right", **ARG_PRIMER_RIGHT)
     subcommand_parser.add_argument("--flip", **ARG_FLIP)
+    subcommand_parser.add_argument("--merged-cache", **ARG_MERGED_CACHE)
     subcommand_parser.add_argument("-t", "--temp", **ARG_TEMPDIR)
     subcommand_parser.add_argument("-v", "--verbose", **ARG_VERBOSE)
     subcommand_parser.add_argument("--cpu", **ARG_CPU)

--- a/thapbi_pict/prepare.py
+++ b/thapbi_pict/prepare.py
@@ -500,6 +500,7 @@ def main(
     min_length=0,
     max_length=sys.maxsize,
     ignore_prefixes=None,
+    merged_cache=None,
     tmp_dir=None,
     debug=False,
     cpu=0,

--- a/thapbi_pict/prepare.py
+++ b/thapbi_pict/prepare.py
@@ -309,9 +309,11 @@ def make_nr_fasta(
         elif weighted_input:
             for title, seq in SimpleFastaParser(handle):
                 assert min_len <= len(seq) <= max_len, f"{_} len {len(seq)}"
-                assert title.count(" ") == 0, title
+                assert title.count(" ") == 0 or (
+                    title.count(" ") == 1 and title.endswith(" rc")
+                ), title
                 assert title.count("_") == 1 and title[32] == "_", title
-                counts[seq.upper()] += abundance_from_read_name(title)
+                counts[seq.upper()] += abundance_from_read_name(title.split(None, 1)[0])
         else:
             for _, seq in SimpleFastaParser(handle):
                 assert min_len <= len(seq) <= max_len, f"{_} len {len(seq)}"

--- a/thapbi_pict/prepare.py
+++ b/thapbi_pict/prepare.py
@@ -188,10 +188,16 @@ def run_cutadapt(
     """
     if not left_primer and not right_primer:
         # special case!
-        from Bio.SeqIO import convert
+        if long_in.endswith(".fasta.gz"):
+            # Should the main intermediates be gzipped?
+            return run(f"cat {long_in} | gunzip > {trimmed_out}", debug=debug)
+        elif long_in.endswith(".fastq"):
+            from Bio.SeqIO import convert
 
-        convert(long_in, "fastq", trimmed_out, "fasta")
-        return 0
+            convert(long_in, "fastq", trimmed_out, "fasta")
+            return 0
+        else:
+            sys.exit(f"ERROR: called on {long_in} with no primers")
     cmd = ["cutadapt"]
     if bad_out:
         cmd += ["--untrimmed-output", bad_out]


### PR DESCRIPTION
See #257 and idea for a cache of (gzipped) NR FASTA files from the trimming and merging step, prior to primer trimming.

Needs unit test coverage as the code path is slightly different with and without the cache (zipped or not, NR or not).