### PR TITLE
Extend -q / --requiremeta to read report and pipeline

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Release History
 ======= ========== ============================================================================
 Version Date       Notes
 ======= ========== ============================================================================
+v0.6.14 2020-03-11 Extend ``-q`` or ``--requiremeta`` to pipeline and read report.
 v0.6.13 2020-03-09 New classifier method ``substr`` for testing with poorly trimmed DB content.
 v0.6.12 2020-03-09 New advanced setting ``--merged-cache`` intended for multiple marker use.
 v0.6.11 2020-03-02 Updated genus-level only NCBI import, restrict to those with 32bp leader.

--- a/tests/sample-summary/classify-meta-req.blast.tsv
+++ b/tests/sample-summary/classify-meta-req.blast.tsv
@@ -1,2 +1,2 @@
-#TaxID	Species	Description	Date	Sequencing sample	Seq-count	Unknown	Peronospora	Phytophthora	Phytophthora aleatoria;Phytophthora cactorum	Phytophthora andina;Phytophthora infestans;Phytophthora ipomoeae	Phytophthora cambivora;Phytophthora x cambivora	Phytophthora cinnamomi	Phytophthora cryptogea;Phytophthora pseudocryptogea	Phytophthora ramorum
-4787	Phytophthora infestans	Single isolate positive control	2018	P-infestans-T30-4	63000	0	0	63000	0	63000	0	0	0	0
+#TaxID	Species	Description	Date	Sequencing sample	Seq-count	Phytophthora	Phytophthora andina;Phytophthora infestans;Phytophthora ipomoeae
+4787	Phytophthora infestans	Single isolate positive control	2018	P-infestans-T30-4	63000	63000	63000

--- a/tests/sample-summary/classify-meta-req.onebp.tsv
+++ b/tests/sample-summary/classify-meta-req.onebp.tsv
@@ -1,2 +1,2 @@
-#TaxID	Species	Description	Date	Sequencing sample	Seq-count	Unknown	Phytophthora	Phytophthora aleatoria;Phytophthora cactorum	Phytophthora andina;Phytophthora infestans;Phytophthora ipomoeae	Phytophthora cambivora;Phytophthora x cambivora	Phytophthora cinnamomi	Phytophthora ramorum
-4787	Phytophthora infestans	Single isolate positive control	2018	P-infestans-T30-4	63000	500	62500	0	62500	0	0	0
+#TaxID	Species	Description	Date	Sequencing sample	Seq-count	Unknown	Phytophthora	Phytophthora andina;Phytophthora infestans;Phytophthora ipomoeae
+4787	Phytophthora infestans	Single isolate positive control	2018	P-infestans-T30-4	63000	500	62500	62500

--- a/tests/test_read-summary.sh
+++ b/tests/test_read-summary.sh
@@ -30,4 +30,9 @@ thapbi_pict read-summary -i tests/prepare-reads/DNAMIX_S95_L001.fasta  $TMP/thap
 thapbi_pict read-summary --input tests/classify/P-infestans-T30-4.fasta tests/classify/P-infestans-T30-4.onebp.tsv -o $TMP/read-summary_onebp.tsv -t tests/classify/P-infestans-T30-4.meta.tsv -x 1 -c 2,3,4,5 -e $TMP/read-summary_onebp.xlsx
 diff $TMP/read-summary_onebp.tsv tests/classify/P-infestans-T30-4.summary.tsv
 
+# Now require metadata, but give entire folder as input
+thapbi_pict read-summary --input tests/classify/ -o $TMP/read-summary_onebp.tsv -t tests/classify/P-infestans-T30-4.meta.tsv -x 1 -c 2,3,4,5 -e $TMP/read-summary_onebp.xlsx -q
+diff $TMP/read-summary_onebp.tsv tests/classify/P-infestans-T30-4.summary.tsv
+
+
 echo "$0 - test_read-summary.sh passed"

--- a/thapbi_pict/__init__.py
+++ b/thapbi_pict/__init__.py
@@ -24,4 +24,4 @@ automatically from the ``docs/`` folder of the `software repository
 within the source code which document the Python API.
 """
 
-__version__ = "0.6.13"
+__version__ = "0.6.14"

--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -302,6 +302,7 @@ def read_summary(args=None):
         metadata_groups=args.metagroups,
         metadata_fieldnames=args.metafields,
         metadata_index=args.metaindex,
+        require_metadata=args.requiremeta,
         ignore_prefixes=tuple(args.ignore_prefixes),
         debug=args.verbose,
     )
@@ -382,6 +383,8 @@ def pipeline(args=None):
 
     hmm = expand_hmm_argument(args.hmm)
 
+    # TODO - apply require_metadata=True to the prepare and classify steps?
+
     fasta_files = prepare(
         fastq=args.input,
         negative_controls=args.negctrls,
@@ -447,6 +450,7 @@ def pipeline(args=None):
         metadata_groups=args.metagroups,
         metadata_fieldnames=args.metafields,
         metadata_index=args.metaindex,
+        require_metadata=args.requiremeta,
         ignore_prefixes=tuple(args.ignore_prefixes),
         debug=args.verbose,
     )
@@ -466,6 +470,7 @@ def pipeline(args=None):
         metadata_groups=args.metagroups,
         metadata_fieldnames=args.metafields,
         metadata_index=args.metaindex,
+        require_metadata=args.requiremeta,
         ignore_prefixes=tuple(args.ignore_prefixes),
         debug=args.verbose,
     )
@@ -789,6 +794,10 @@ ARG_METAFIELDS = dict(  # noqa: C408
     "Use in conjunction with -m / --metadata argument.",
 )
 
+# "-q", "--requiremeta",
+ARG_REQUIREMETA = dict(  # noqa: C408
+    action="store_true", help="Ignore any input files without metadata for report.",
+)
 
 # Command line definition
 # =======================
@@ -880,6 +889,7 @@ def main(args=None):
         "in samples. Very slow with large database.",
     )
     subcommand_parser.add_argument("--merged-cache", **ARG_MERGED_CACHE)
+    subcommand_parser.add_argument("-q", "--requiremeta", **ARG_REQUIREMETA)
     # Can't use -t for --temp as already using for --metadata:
     subcommand_parser.add_argument("--temp", **ARG_TEMPDIR)
     subcommand_parser.add_argument("--cpu", **ARG_CPU)
@@ -1370,6 +1380,7 @@ def main(args=None):
     subcommand_parser.add_argument("-x", "--metaindex", **ARG_METAINDEX)
     subcommand_parser.add_argument("-g", "--metagroups", **ARG_METAGROUPS)
     subcommand_parser.add_argument("-f", "--metafields", **ARG_METAFIELDS)
+    subcommand_parser.add_argument("-q", "--requiremeta", **ARG_REQUIREMETA)
     subcommand_parser.add_argument("-v", "--verbose", **ARG_VERBOSE)
     subcommand_parser.set_defaults(func=read_summary)
     del subcommand_parser  # To prevent acidentally adding more
@@ -1439,12 +1450,7 @@ def main(args=None):
     subcommand_parser.add_argument("-x", "--metaindex", **ARG_METAINDEX)
     subcommand_parser.add_argument("-g", "--metagroups", **ARG_METAGROUPS)
     subcommand_parser.add_argument("-f", "--metafields", **ARG_METAFIELDS)
-    subcommand_parser.add_argument(
-        "-q",
-        "--requiremeta",
-        action="store_true",
-        help="Ignore any input files without metadata.",
-    )
+    subcommand_parser.add_argument("-q", "--requiremeta", **ARG_REQUIREMETA)
     subcommand_parser.add_argument("-v", "--verbose", **ARG_VERBOSE)
     subcommand_parser.set_defaults(func=sample_summary)
     del subcommand_parser  # To prevent acidentally adding more


### PR DESCRIPTION
As part of this, does some overdue refactoring of the metadata loading to bring the two reports a little closer, cross reference #218.

Also fixed a bug in the sample reports not dropping species columns from discarded samples.