### PR TITLE
Force FASTA output from cutadapt

### DIFF
--- a/thapbi_pict/prepare.py
+++ b/thapbi_pict/prepare.py
@@ -268,7 +268,7 @@ def run_cutadapt(
             return total, total
         else:
             sys.exit(f"ERROR: called on {long_in} with no primers")
-    cmd = ["cutadapt"]
+    cmd = ["cutadapt", "--fasta"]
     if bad_out:
         cmd += ["--untrimmed-output", bad_out]
     else:


### PR DESCRIPTION
In changing from cutadapt 2.8 (and dnaio 0.4.1) on our old cluster to cutadapt 2.10 (and dnaio 0.5.0) on our new cluster, this seems to be needed now to not get FASTQ.

Have not dug into what changed.

TravisCI currently skips cutadapt.

CircleCI tests failing, perhaps unrelated and down to a general version change:

```
+ diff /tmp/DNAMIX_S95_L001.fasta tests/prepare-reads/DNAMIX_S95_L001.fasta
7c7
< #abundance:3325
---
> #abundance:3322
11c11
< >d8613e80b8803b13f7ea5d097f8fe46f_813
---
> >d8613e80b8803b13f7ea5d097f8fe46f_812
15,16d14
< >468dc60921568e6ca5c197d04032eb44_299
< TTTCCGTAGGTGAACCTGCGGAAGGATCATTACCACACCTAAAAAACTTTCCACGTGAACCGTATCAACCTTTTTAAATTGGGGGCTCCCGTCTGGCCGGCCGGTTCTCGGCTGGCTGGGTGGCGGCTCTATCATGGCGACCGCTTGGGCCTCGGCCTGGGCTAGTAGCGTATTTTTTAAACCCATTCCTAATTACTGAATATACT
18a17,18
> >468dc60921568e6ca5c197d04032eb44_298
> TTTCCGTAGGTGAACCTGCGGAAGGATCATTACCACACCTAAAAAACTTTCCACGTGAACCGTATCAACCTTTTTAAATTGGGGGCTCCCGTCTGGCCGGCCGGTTCTCGGCTGGCTGGGTGGCGGCTCTATCATGGCGACCGCTTGGGCCTCGGCCTGGGCTAGTAGCGTATTTTTTAAACCCATTCCTAATTACTGAATATACT
21c21
< >7f3b213656cc5541bdcdf4692a3ed5bb_259
---
> >7f3b213656cc5541bdcdf4692a3ed5bb_258
```