### PR TITLE
Include rebuilding of the default DB as a test

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,12 +12,15 @@ recursive-include thapbi_pict *.py
 recursive-include thapbi_pict/hmm controls.hmm*
 include thapbi_pict/ITS1_DB.sqlite
 
-# Deliberately not bothering to anything in database via wildcards.
+# Deliberately not risking everying in database/ via wildcards.
 # e.g. NCBI taxonomy or symlinks to control plate positive controls.
 include database/README.rst
 include database/ITS1_DB.sql
+include database/build_ITS1_DB.sh
 include database/controls.fasta
 include database/Phytophthora_ITS1_curated.fasta
+include database/2021-01-28-ITS_Peronosporales_w32.fasta
+include database/single_isolates/*.fasta
 
 # The following is better than a blanket include wildcard * but
 # this still risks unwanted includes of any working files:

--- a/database/build_CURATED+NCBI.sh
+++ b/database/build_CURATED+NCBI.sh
@@ -7,30 +7,48 @@ TAX=new_taxdump_2021-01-01
 DB=CURATED+NCBI
 rm -rf "$DB.sqlite" "$DB.fasta" "$DB.txt" "$DB.sql"
 
-thapbi_pict load-tax -d "$DB.sqlite" -t "$TAX"
-thapbi_pict curated-import -d "$DB.sqlite" -i "$CURATED"
-thapbi_pict ncbi-import -d "$DB.sqlite" -i 2021-01-28-ITS_Peronosporales_w32.fasta -g --minlen 150 --maxlen 750
-
-# Add hoc fix for two accessions potentially having wrong genus
-sqlite3 "$DB.sqlite" "DELETE FROM its1_sequence WHERE id IN (SELECT its1_sequence.id FROM its1_sequence JOIN its1_source ON its1_sequence.id = its1_source.its1_id WHERE source_accession IN ('AY742739.1', 'JX122744.1'));"
-sqlite3 "$DB.sqlite" "DELETE FROM its1_source WHERE source_accession IN ('AY742739.1', 'JX122744.1');"
+# 4762 = Oomycetes
+thapbi_pict load-tax -d "$DB.sqlite" -t "$TAX" -a 4762
 
 # Ad-hoc fix for NCBI taxonomy not yet having caught up with community consensus.
 # At the 7th Meeting of the International Union of Forest Research Organisations
 # Working Party (IUFRO) 7.02.09, Phytophthoras in forests and natural ecosystems,
 # a decision was made to adhere to the original and correct version of the species
 # name, Phytophthora austrocedri.
+#
+# First, rename 'Phytophthora austrocedri' synonym to 'Phytophthora austrocedrae'
+sqlite3 "$DB.sqlite" "UPDATE synonym SET name='Phytophthora austrocedrae' WHERE name='Phytophthora austrocedri';"
+# Change 'Phytophthora austrocedrae' main entry to 'Phytophthora austrocedri'
 sqlite3 "$DB.sqlite" "UPDATE taxonomy SET species='austrocedri' WHERE genus='Phytophthora' AND species='austrocedrae'"
+# Should now be able to import data using either name.
 
-# The known value files are now using Phytophthora austrocedri, not P. austrocedrae
-# thapbi_pict seq-import -d "$DB.sqlite" -i thapbi20180709p1_MetaControls/prepared_reads_${VERSION}/*.fasta thapbi20180709p1_MetaControls/positive_controls/*.known.tsv
-
-# Add the G-BLOCK synthetic controls
+# ==========================
+# G-BLOCK synthetic controls
+# ==========================
 sqlite3 "$DB.sqlite" "INSERT INTO taxonomy (ncbi_taxid, genus, species) VALUES (32630, 'synthetic', 'construct C1');"
 sqlite3 "$DB.sqlite" "INSERT INTO taxonomy (ncbi_taxid, genus, species) VALUES (32630, 'synthetic', 'construct C2');"
 sqlite3 "$DB.sqlite" "INSERT INTO taxonomy (ncbi_taxid, genus, species) VALUES (32630, 'synthetic', 'construct C3');"
 sqlite3 "$DB.sqlite" "INSERT INTO taxonomy (ncbi_taxid, genus, species) VALUES (32630, 'synthetic', 'construct C4');"
 thapbi_pict curated-import -d "$DB.sqlite" -i controls.fasta
+
+# ===============
+# Single isolates
+# ===============
+# FASTA files prepared via thapbi_pict prepare-reads and curated-seq steps:
+# thapbi_pict curated-import -d "$DB.sqlite" -i single_isolates/*.fasta
+
+# ===================
+# NCBI at genus level
+# ===================
+thapbi_pict ncbi-import -d "$DB.sqlite" -i 2021-01-28-ITS_Peronosporales_w32.fasta -g --minlen 150 --maxlen 750
+# Add hoc fix for two accessions potentially having wrong genus
+sqlite3 "$DB.sqlite" "DELETE FROM its1_sequence WHERE id IN (SELECT its1_sequence.id FROM its1_sequence JOIN its1_source ON its1_sequence.id = its1_source.its1_id WHERE source_accession IN ('AY742739.1', 'JX122744.1'));"
+sqlite3 "$DB.sqlite" "DELETE FROM its1_source WHERE source_accession IN ('AY742739.1', 'JX122744.1');"
+
+# =================
+# Curated sequences
+# =================
+thapbi_pict curated-import -d "$DB.sqlite" -i "$CURATED"
 
 thapbi_pict dump -m -d "$DB.sqlite" -o "$DB.txt"
 thapbi_pict dump -m -f fasta -d "$DB.sqlite" -o "$DB.fasta"

--- a/database/build_CURATED+NCBI.sh
+++ b/database/build_CURATED+NCBI.sh
@@ -3,7 +3,7 @@ VERSION=`thapbi_pict -v | sed "s/THAPBI PICT //g"`
 echo "Using THAPBI PICT $VERSION"
 set -euo pipefail
 CURATED=Phytophthora_ITS1_curated.fasta
-TAX=new_taxdump_2021-01-01
+TAX=taxdmp_2021-01-01
 DB=CURATED+NCBI
 rm -rf "$DB.sqlite" "$DB.fasta" "$DB.txt" "$DB.sql"
 

--- a/database/build_CURATED.sh
+++ b/database/build_CURATED.sh
@@ -7,22 +7,48 @@ TAX=new_taxdump_2021-01-01
 DB=CURATED
 rm -rf "$DB.sqlite" "$DB.fasta" "$DB.txt" "$DB.sql"
 
-thapbi_pict load-tax -d "$DB.sqlite" -t "$TAX"
-thapbi_pict curated-import -d "$DB.sqlite" -i "$CURATED" -v
+# 4762 = Oomycetes
+thapbi_pict load-tax -d "$DB.sqlite" -t "$TAX" -a 4762
 
 # Ad-hoc fix for NCBI taxonomy not yet having caught up with community consensus.
 # At the 7th Meeting of the International Union of Forest Research Organisations
 # Working Party (IUFRO) 7.02.09, Phytophthoras in forests and natural ecosystems,
 # a decision was made to adhere to the original and correct version of the species
 # name, Phytophthora austrocedri.
+#
+# First, rename 'Phytophthora austrocedri' synonym to 'Phytophthora austrocedrae'
+sqlite3 "$DB.sqlite" "UPDATE synonym SET name='Phytophthora austrocedrae' WHERE name='Phytophthora austrocedri';"
+# Change 'Phytophthora austrocedrae' main entry to 'Phytophthora austrocedri'
 sqlite3 "$DB.sqlite" "UPDATE taxonomy SET species='austrocedri' WHERE genus='Phytophthora' AND species='austrocedrae'"
+# Should now be able to import data using either name.
 
-# Add the G-BLOCK synthetic controls
+# ==========================
+# G-BLOCK synthetic controls
+# ==========================
 sqlite3 "$DB.sqlite" "INSERT INTO taxonomy (ncbi_taxid, genus, species) VALUES (32630, 'synthetic', 'construct C1');"
 sqlite3 "$DB.sqlite" "INSERT INTO taxonomy (ncbi_taxid, genus, species) VALUES (32630, 'synthetic', 'construct C2');"
 sqlite3 "$DB.sqlite" "INSERT INTO taxonomy (ncbi_taxid, genus, species) VALUES (32630, 'synthetic', 'construct C3');"
 sqlite3 "$DB.sqlite" "INSERT INTO taxonomy (ncbi_taxid, genus, species) VALUES (32630, 'synthetic', 'construct C4');"
 thapbi_pict curated-import -d "$DB.sqlite" -i controls.fasta
+
+# ===============
+# Single isolates
+# ===============
+# FASTA files prepared via thapbi_pict prepare-reads and curated-seq steps:
+# thapbi_pict curated-import -d "$DB.sqlite" -i single_isolates/*.fasta
+
+# ===================
+# NCBI at genus level
+# ===================
+# thapbi_pict ncbi-import -d "$DB.sqlite" -i 2021-01-28-ITS_Peronosporales_w32.fasta -g --minlen 150 --maxlen 750
+# Add hoc fix for two accessions potentially having wrong genus
+# sqlite3 "$DB.sqlite" "DELETE FROM its1_sequence WHERE id IN (SELECT its1_sequence.id FROM its1_sequence JOIN its1_source ON its1_sequence.id = its1_source.its1_id WHERE source_accession IN ('AY742739.1', 'JX122744.1'));"
+# sqlite3 "$DB.sqlite" "DELETE FROM its1_source WHERE source_accession IN ('AY742739.1', 'JX122744.1');"
+
+# =================
+# Curated sequences
+# =================
+thapbi_pict curated-import -d "$DB.sqlite" -i "$CURATED"
 
 thapbi_pict dump -m -d "$DB.sqlite" -o "$DB.txt"
 thapbi_pict dump -m -f fasta -d "$DB.sqlite" -o "$DB.fasta"

--- a/database/build_CURATED.sh
+++ b/database/build_CURATED.sh
@@ -3,7 +3,7 @@ VERSION=`thapbi_pict -v | sed "s/THAPBI PICT //g"`
 echo "Using THAPBI PICT $VERSION"
 set -euo pipefail
 CURATED=Phytophthora_ITS1_curated.fasta
-TAX=new_taxdump_2021-01-01
+TAX=taxdmp_2021-01-01
 DB=CURATED
 rm -rf "$DB.sqlite" "$DB.fasta" "$DB.txt" "$DB.sql"
 

--- a/database/build_ITS1_DB.sh
+++ b/database/build_ITS1_DB.sh
@@ -9,12 +9,6 @@ rm -rf "$DB.sqlite" "$DB.fasta" "$DB.txt" "$DB.sql"
 
 # 4762 = Oomycetes
 thapbi_pict load-tax -d "$DB.sqlite" -t "$TAX" -a 4762
-thapbi_pict curated-import -d "$DB.sqlite" -i "$CURATED"
-thapbi_pict ncbi-import -d "$DB.sqlite" -i 2021-01-28-ITS_Peronosporales_w32.fasta -g --minlen 150 --maxlen 750
-
-# Add hoc fix for two accessions potentially having wrong genus
-sqlite3 "$DB.sqlite" "DELETE FROM its1_sequence WHERE id IN (SELECT its1_sequence.id FROM its1_sequence JOIN its1_source ON its1_sequence.id = its1_source.its1_id WHERE source_accession IN ('AY742739.1', 'JX122744.1'));"
-sqlite3 "$DB.sqlite" "DELETE FROM its1_source WHERE source_accession IN ('AY742739.1', 'JX122744.1');"
 
 # Ad-hoc fix for NCBI taxonomy not yet having caught up with community consensus.
 # At the 7th Meeting of the International Union of Forest Research Organisations
@@ -23,29 +17,38 @@ sqlite3 "$DB.sqlite" "DELETE FROM its1_source WHERE source_accession IN ('AY7427
 # name, Phytophthora austrocedri.
 #
 # First, rename 'Phytophthora austrocedri' synonym to 'Phytophthora austrocedrae'
-sqlite3 ITS1_DB.sqlite "UPDATE synonym SET name='Phytophthora austrocedrae' WHERE name='Phytophthora austrocedri';"
+sqlite3 "$DB.sqlite" "UPDATE synonym SET name='Phytophthora austrocedrae' WHERE name='Phytophthora austrocedri';"
 # Change 'Phytophthora austrocedrae' main entry to 'Phytophthora austrocedri'
 sqlite3 "$DB.sqlite" "UPDATE taxonomy SET species='austrocedri' WHERE genus='Phytophthora' AND species='austrocedrae'"
 # Should now be able to import data using either name.
-# The known value files are using Phytophthora austrocedri, not P. austrocedrae
 
-# This is how the single isolate control FASTA files were prepared,
-# now under version control:
-#
-# mkdir thapbi20180709p1_MetaControls/prepared_reads_${VERSION}/
-#
-# thapbi_pict prepare-reads -i thapbi20180709p1_MetaControls/raw_data -o thapbi20180709p1_MetaControls/prepared_reads_${VERSION}/
-#
-# thapbi_pict curated-seq -i thapbi20180709p1_MetaControls/prepared_reads_${VERSION}/*.fasta thapbi20180709p1_MetaControls/positive_controls/*.known.tsv -o single_isolates/
-
-thapbi_pict curated-import -d "$DB.sqlite" -i single_isolates/*.fasta
-
-# Add the G-BLOCK synthetic controls
+# ==========================
+# G-BLOCK synthetic controls
+# ==========================
 sqlite3 "$DB.sqlite" "INSERT INTO taxonomy (ncbi_taxid, genus, species) VALUES (32630, 'synthetic', 'construct C1');"
 sqlite3 "$DB.sqlite" "INSERT INTO taxonomy (ncbi_taxid, genus, species) VALUES (32630, 'synthetic', 'construct C2');"
 sqlite3 "$DB.sqlite" "INSERT INTO taxonomy (ncbi_taxid, genus, species) VALUES (32630, 'synthetic', 'construct C3');"
 sqlite3 "$DB.sqlite" "INSERT INTO taxonomy (ncbi_taxid, genus, species) VALUES (32630, 'synthetic', 'construct C4');"
 thapbi_pict curated-import -d "$DB.sqlite" -i controls.fasta
+
+# ===============
+# Single isolates
+# ===============
+# FASTA files prepared via thapbi_pict prepare-reads and curated-seq steps:
+thapbi_pict curated-import -d "$DB.sqlite" -i single_isolates/*.fasta
+
+# ===================
+# NCBI at genus level
+# ===================
+thapbi_pict ncbi-import -d "$DB.sqlite" -i 2021-01-28-ITS_Peronosporales_w32.fasta -g --minlen 150 --maxlen 750
+# Add hoc fix for two accessions potentially having wrong genus
+sqlite3 "$DB.sqlite" "DELETE FROM its1_sequence WHERE id IN (SELECT its1_sequence.id FROM its1_sequence JOIN its1_source ON its1_sequence.id = its1_source.its1_id WHERE source_accession IN ('AY742739.1', 'JX122744.1'));"
+sqlite3 "$DB.sqlite" "DELETE FROM its1_source WHERE source_accession IN ('AY742739.1', 'JX122744.1');"
+
+# =================
+# Curated sequences
+# =================
+thapbi_pict curated-import -d "$DB.sqlite" -i "$CURATED"
 
 thapbi_pict dump -m -d "$DB.sqlite" -o "$DB.txt"
 thapbi_pict dump -m -f fasta -d "$DB.sqlite" -o "$DB.fasta"

--- a/database/build_ITS1_DB.sh
+++ b/database/build_ITS1_DB.sh
@@ -3,7 +3,7 @@ VERSION=`thapbi_pict -v | sed "s/THAPBI PICT //g"`
 echo "Using THAPBI PICT $VERSION"
 set -euo pipefail
 CURATED=Phytophthora_ITS1_curated.fasta
-TAX=new_taxdump_2021-01-01
+TAX=taxdmp_2021-01-01
 DB=ITS1_DB
 rm -rf "$DB.sqlite" "$DB.fasta" "$DB.txt" "$DB.sql"
 

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -18,6 +18,8 @@ if [ ! -f tests/run_tests.sh ]; then
     false
 fi
 
+time tests/test_build_db.sh
+
 time tests/test_woody_hosts.sh
 
 time tests/test_ena-submit.sh

--- a/tests/test_build_db.sh
+++ b/tests/test_build_db.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# Copyright 2021 by Peter Cock, The James Hutton Institute.
+# All rights reserved.
+# This file is part of the THAPBI Phytophthora ITS1 Classifier Tool (PICT),
+# and is released under the "MIT License Agreement". Please see the LICENSE
+# file that should have been included as part of this package.
+
+IFS=$'\n\t'
+set -euo pipefail
+
+export TMP=${TMP:-/tmp}
+export `grep ^TAX= database/build_ITS1_DB.sh`
+
+if [ ! -f "${TAX}.zip" ]; then curl -L -O "https://ftp.ncbi.nih.gov/pub/taxonomy/taxdump_archive/${TAX}.zip"; fi
+if [ ! -d "database/${TAX}" ]; then unzip ${TAX}.zip nodes.dmp names.dmp -d database/${TAX}; fi
+
+echo "===================================================="
+echo "Loading expected DB and exporting as table and FASTA"
+echo "===================================================="
+set -x
+
+export DB=$TMP/expected_ITS1_DB
+rm -rf $DB.*
+sqlite3 $DB.sqlite < database/ITS1_DB.sql
+
+thapbi_pict dump -m -f fasta -d "$DB.sqlite" -o "$DB.fasta"
+thapbi_pict dump -m -d "$DB.sqlite" -o "$DB.txt"
+
+set +x
+echo "========================="
+echo "Rebuilding the default DB"
+echo "========================="
+set -x
+
+cd database/
+rm -rf ITS1_DB.sqlite ITS1_DB.sql ITS1_DB.txt ITS1_DB.fasta
+./build_ITS1_DB.sh
+cd ..
+
+set +x
+echo "========================================"
+echo "Checking rebuilt DB matches expectations"
+echo "========================================"
+set -x
+
+diff "$DB.fasta" database/ITS1_DB.fasta
+diff "$DB.txt" database/ITS1_DB.txt
+# git diff database/ITS1_DB.sql
+
+echo "$0 - test_build_db.sh passed"

--- a/tests/test_load-tax.sh
+++ b/tests/test_load-tax.sh
@@ -19,30 +19,32 @@ set -x
 thapbi_pict load-tax 2>&1 | grep "the following arguments are required"
 set -o pipefail
 
+# Same taxonomy as test_ncbi-import.sh (new style, ~100MB)
 if [ ! -f "new_taxdump_2019-09-01.zip" ]; then curl -L -O "https://ftp.ncbi.nih.gov/pub/taxonomy/taxdump_archive/new_taxdump_2019-09-01.zip"; fi
 if [ ! -d "new_taxdump_2019-09-01" ]; then unzip new_taxdump_2019-09-01.zip nodes.dmp names.dmp -d new_taxdump_2019-09-01; fi
 
 thapbi_pict load-tax -d "sqlite:///:memory:" -t new_taxdump_2019-09-01
 
-if [ ! -f "taxdmp_2014-08-01.zip" ]; then curl -L -O "https://ftp.ncbi.nih.gov/pub/taxonomy/taxdump_archive/taxdmp_2014-08-01.zip"; fi
-if [ ! -d "taxdmp_2014-08-01" ]; then unzip taxdmp_2014-08-01.zip nodes.dmp names.dmp -d taxdmp_2014-08-01; fi
+# Same taxonomy as database/build_ITS1_DB.sh via tests/test_build_db.sh (old style, ~50MB)
+export `grep ^TAX= database/build_ITS1_DB.sh`
+if [ ! -f "${TAX}.zip" ]; then curl -L -O "https://ftp.ncbi.nih.gov/pub/taxonomy/taxdump_archive/${TAX}.zip"; fi
+if [ ! -d "database/${TAX}" ]; then unzip ${TAX}.zip nodes.dmp names.dmp -d database/${TAX}; fi
 
 # Defaults to all Oomycetes
-thapbi_pict load-tax -d "sqlite:///:memory:" -t taxdmp_2014-08-01
+thapbi_pict load-tax -d "sqlite:///:memory:" -t "database/${TAX}"
 
 # Request Phytophthora and Peronospora
-thapbi_pict load-tax -d sqlite:///:memory: -t taxdmp_2014-08-01 -a 4783,70742
+thapbi_pict load-tax -d sqlite:///:memory: -t "database/${TAX}" -a 4783,70742
 
 # Request all Peronosporales
-thapbi_pict load-tax -d sqlite:///:memory: -t taxdmp_2014-08-01 -a 4776
+thapbi_pict load-tax -d sqlite:///:memory: -t "database/${TAX}" -a 4776
 
 # 6231 = Nematoda
-thapbi_pict load-tax -d sqlite:///:memory: -t taxdmp_2014-08-01 -a 6231
-# thapbi_pict load-tax -d sqlite:///:memory: -t new_taxdump_2019-09-01 -a 6231
+thapbi_pict load-tax -d sqlite:///:memory: -t "database/${TAX}" -a 6231
 
 # Check this error condition
 set +o pipefail
-thapbi_pict load-tax -d sqlite:///:memory: -t taxdmp_2014-08-01 -a 12908 2>&1 | grep "Could not identify any genus names"
+thapbi_pict load-tax -d sqlite:///:memory: -t "database/${TAX}" -a 12908 2>&1 | grep "Could not identify any genus names"
 set -o pipefail
 
 echo "$0 - test_load-tax.sh passed"

--- a/tests/test_load-tax.sh
+++ b/tests/test_load-tax.sh
@@ -20,12 +20,12 @@ thapbi_pict load-tax 2>&1 | grep "the following arguments are required"
 set -o pipefail
 
 if [ ! -f "new_taxdump_2019-09-01.zip" ]; then curl -L -O "https://ftp.ncbi.nih.gov/pub/taxonomy/taxdump_archive/new_taxdump_2019-09-01.zip"; fi
-if [ ! -d "new_taxdump_2019-09-01" ]; then unzip new_taxdump_2019-09-01.zip -d new_taxdump_2019-09-01; fi
+if [ ! -d "new_taxdump_2019-09-01" ]; then unzip new_taxdump_2019-09-01.zip nodes.dmp names.dmp -d new_taxdump_2019-09-01; fi
 
 thapbi_pict load-tax -d "sqlite:///:memory:" -t new_taxdump_2019-09-01
 
 if [ ! -f "taxdmp_2014-08-01.zip" ]; then curl -L -O "https://ftp.ncbi.nih.gov/pub/taxonomy/taxdump_archive/taxdmp_2014-08-01.zip"; fi
-if [ ! -d "taxdmp_2014-08-01" ]; then unzip taxdmp_2014-08-01.zip -d taxdmp_2014-08-01; fi
+if [ ! -d "taxdmp_2014-08-01" ]; then unzip taxdmp_2014-08-01.zip nodes.dmp names.dmp -d taxdmp_2014-08-01; fi
 
 # Defaults to all Oomycetes
 thapbi_pict load-tax -d "sqlite:///:memory:" -t taxdmp_2014-08-01

--- a/tests/test_ncbi-import.sh
+++ b/tests/test_ncbi-import.sh
@@ -22,7 +22,7 @@ thapbi_pict ncbi-import -d sqlite:///:memory: --input tests/ncbi-import/20th_Cen
 set -o pipefail
 
 if [ ! -f "new_taxdump_2019-09-01.zip" ]; then curl -L -O "https://ftp.ncbi.nih.gov/pub/taxonomy/taxdump_archive/new_taxdump_2019-09-01.zip"; fi
-if [ ! -d "new_taxdump_2019-09-01" ]; then unzip new_taxdump_2019-09-01.zip -d new_taxdump_2019-09-01; fi
+if [ ! -d "new_taxdump_2019-09-01" ]; then unzip new_taxdump_2019-09-01.zip nodes.dmp names.dmp -d new_taxdump_2019-09-01; fi
 
 
 # Check hybrid like "Phytophthora humicola x Phytophthora inundata"


### PR DESCRIPTION
Requires including source files not only in version control (already done recently), but in the tar-ball manifest (due to how I setup the test suite).