### PR TITLE
Offer min-abundance in the classify command.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Release History
 ======= ========== ============================================================================
 Version Date       Notes
 ======= ========== ============================================================================
-v0.7.11 *Pending*  Simplified the ``assess`` command to only work at species/sample level.
+v0.7.11 2021-03-30 ``assess`` now only at sample level. Abundance threshold in ``classify``.
 v0.7.10 2021-03-24 Pipeline includes ``fasta-nr`` command making non-redundant FASTA file.
 v0.7.9  2021-03-15 Option to show unsequenced entries in summary sample report (``-u``).
 v0.7.8  2021-03-11 Only import IUPAC DNA characters to DB. Fixed *N. valdiviana* in default DB.

--- a/tests/test_classify.sh
+++ b/tests/test_classify.sh
@@ -27,7 +27,7 @@ if [ ! -f $DB ]; then echo "Run test_curated-import.sh to setup test DB"; false;
 rm -rf $TMP/classify/
 mkdir -p $TMP/classify/
 cp database/Phytophthora_ITS1_curated.fasta $TMP/classify/
-thapbi_pict classify -m identity -d $DB -i $TMP/classify/Phytophthora_ITS1_curated.fasta
+thapbi_pict classify -m identity -d $DB -i $TMP/classify/Phytophthora_ITS1_curated.fasta -a 0
 if [ "`grep -c -v '^#' $TMP/classify/Phytophthora_ITS1_curated.identity.tsv`" -ne "`grep -c '^>' $TMP/classify/Phytophthora_ITS1_curated.fasta`" ]; then echo "Expected one line per input seq"; false; fi
 
 rm -rf $TMP/DNAMIX_S95_L001.identity.tsv
@@ -76,7 +76,7 @@ rm -rf $TMP/hmm_trim.*.tsv
 # Swarm classifier can't cope with multiple HMM hits...
 for M in identity onebp blast 1s3g; do
     echo "Checking HMM trim corner cases with $M"
-    thapbi_pict classify -d $DB -i tests/classify/hmm_trim.fasta -o $TMP/ -m $M
+    thapbi_pict classify -d $DB -i tests/classify/hmm_trim.fasta -o $TMP/ -m $M -a 50
     diff $TMP/hmm_trim.$M.tsv tests/classify/hmm_trim.$M.tsv
 done
 

--- a/tests/test_classify.sh
+++ b/tests/test_classify.sh
@@ -27,7 +27,7 @@ if [ ! -f $DB ]; then echo "Run test_curated-import.sh to setup test DB"; false;
 rm -rf $TMP/classify/
 mkdir -p $TMP/classify/
 cp database/Phytophthora_ITS1_curated.fasta $TMP/classify/
-thapbi_pict classify -m identity -d $DB -i $TMP/classify/Phytophthora_ITS1_curated.fasta -a 0
+thapbi_pict classify -m identity -d $DB -i $TMP/classify/Phytophthora_ITS1_curated.fasta
 if [ "`grep -c -v '^#' $TMP/classify/Phytophthora_ITS1_curated.identity.tsv`" -ne "`grep -c '^>' $TMP/classify/Phytophthora_ITS1_curated.fasta`" ]; then echo "Expected one line per input seq"; false; fi
 
 rm -rf $TMP/DNAMIX_S95_L001.identity.tsv

--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -1226,7 +1226,14 @@ def main(args=None):
     )
     subcommand_parser.add_argument("-i", "--input", **ARG_INPUT_FASTA)
     subcommand_parser.add_argument("--ignore-prefixes", **ARG_IGNORE_PREFIXES)
-    subcommand_parser.add_argument("-a", "--abundance", **ARG_FASTQ_MIN_ABUNDANCE)
+    subcommand_parser.add_argument(
+        "-a",
+        "--abundance",
+        type=int,
+        default=0,
+        help="Mininum abundance applied to unique marker sequences in each "
+        "FASTA sample file, default 0 (classify all).",
+    )
     subcommand_parser.add_argument("-d", "--database", **ARG_DB_INPUT)
     subcommand_parser.add_argument("-m", "--method", **ARG_METHOD_OUTPUT)
     subcommand_parser.add_argument(

--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -255,6 +255,7 @@ def classify(args=None):
         method=args.method,
         out_dir=args.output,
         ignore_prefixes=tuple(args.ignore_prefixes),
+        min_abundance=args.abundance,
         tmp_dir=args.temp,
         debug=args.verbose,
         cpu=args.cpu,
@@ -411,6 +412,7 @@ def pipeline(args=None):
         method=args.method,
         out_dir=intermediate_dir,
         ignore_prefixes=tuple(args.ignore_prefixes),  # not really needed
+        min_abundance=args.abundance,
         tmp_dir=args.temp,
         debug=args.verbose,
         cpu=args.cpu,
@@ -1224,6 +1226,7 @@ def main(args=None):
     )
     subcommand_parser.add_argument("-i", "--input", **ARG_INPUT_FASTA)
     subcommand_parser.add_argument("--ignore-prefixes", **ARG_IGNORE_PREFIXES)
+    subcommand_parser.add_argument("-a", "--abundance", **ARG_FASTQ_MIN_ABUNDANCE)
     subcommand_parser.add_argument("-d", "--database", **ARG_DB_INPUT)
     subcommand_parser.add_argument("-m", "--method", **ARG_METHOD_OUTPUT)
     subcommand_parser.add_argument(

--- a/thapbi_pict/assess.py
+++ b/thapbi_pict/assess.py
@@ -288,7 +288,7 @@ def extract_global_tally(tally, sp_list):
         if pred:
             all_sp.update(pred.split(";"))
     assert "" not in all_sp
-    for sp in sp_list:
+    for sp in all_sp:
         assert sp in sp_list, sp
 
     x = Counter()

--- a/thapbi_pict/assess.py
+++ b/thapbi_pict/assess.py
@@ -442,6 +442,8 @@ def main(
             tp = fp = fn = 0
             tn = boring_species_tn
             if not boring_species_count:
+                assert boring_species_tn == 0
+                # No point printing this line
                 continue
         else:
             assert species_level(sp)

--- a/thapbi_pict/utils.py
+++ b/thapbi_pict/utils.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2020 by Peter Cock, The James Hutton Institute.
+# Copyright 2018-2021 by Peter Cock, The James Hutton Institute.
 # All rights reserved.
 # This file is part of the THAPBI Phytophthora ITS1 Classifier Tool (PICT),
 # and is released under the "MIT License Agreement". Please see the LICENSE
@@ -366,6 +366,17 @@ def abundance_values_in_fasta(fasta_file, gzipped=False):
                 hmm = ""  # prepared with no HMM
             max_a[hmm] = max(a, max_a[hmm])
     return unique, total, max_a
+
+
+def abundance_filter_fasta(input_fasta, output_fasta, min_abundance):
+    """Apply a minimum abundance filter to a FASTA file."""
+    with open(input_fasta) as in_handle:
+        with open(output_fasta, "w") as out_handle:
+            for title, seq in SimpleFastaParser(in_handle):
+                a = abundance_from_read_name(title.split(None, 1)[0])
+                if a < min_abundance:
+                    continue
+                out_handle.write(f">{title}\n{seq}\n")
 
 
 def file_to_sample_name(filename):


### PR DESCRIPTION
Useful with slower classifiers like 1s3g when the FASTA intermediate files were prepared at lower abundance.
