### PR TITLE
Set metadata encoding explicitly

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Release History
 ======= ========== ============================================================================
 Version Date       Notes
 ======= ========== ============================================================================
+v0.9.1  *Pending*  Can specify the metadata TSV file encoding at the command line.
 v0.9.0  2021-04-19 Dropped use of Trimmomatic, faster and slightly higher read counts.
 v0.8.4  2021-04-13 Speed up re-running by delaying method setup until and if required.
 v0.8.3  2021-04-13 Include abundance threshold in summary reports (if varied by sample).

--- a/tests/test_ena-submit.sh
+++ b/tests/test_ena-submit.sh
@@ -21,10 +21,14 @@ echo "Checking ena-submit"
 thapbi_pict ena-submit 2>&1 | grep "the following arguments are required"
 set -o pipefail
 
-thapbi_pict ena-submit -i tests/reads/ -t tests/reads/metadata.tsv -c 5 -x 1 -o $TMP/ena_submit.tsv
+thapbi_pict ena-submit -i tests/reads/ -t tests/reads/metadata.tsv -c 5 -x 1 \
+    -o $TMP/ena_submit.tsv -e UTF-8
 diff $TMP/ena_submit.tsv tests/reads/ena_submit.tsv
 
-thapbi_pict ena-submit -i tests/reads/ -t tests/reads/metadata.tsv -c 5 -x 1 -o $TMP/ena_submit_custom.tsv --library "Test set" --instrument "Illumina Widget" --design "Ad hoc" --protocol "Making it up" --insert 275
+thapbi_pict ena-submit -i tests/reads/ -t tests/reads/metadata.tsv -c 5 -x 1 \
+    -o $TMP/ena_submit_custom.tsv --metaencoding latin1 \
+    --library "Test set" --instrument "Illumina Widget" \
+    --design "Ad hoc" --protocol "Making it up" --insert 275
 diff $TMP/ena_submit_custom.tsv tests/reads/ena_submit_custom.tsv
 
 echo "$0 - test_ena-submit.sh passed"

--- a/tests/test_pipeline.sh
+++ b/tests/test_pipeline.sh
@@ -38,7 +38,7 @@ touch $TMP/intermediate/ignore-me.onebp.tsv
 # Run again with some explicit options set (shouldn't change output)
 # Using --flip will have no effect as already have the intermediate files
 rm -rf $TMP/output/*
-thapbi_pict pipeline -i tests/reads/ -s $TMP/intermediate -o $TMP/output -m onebp -a 250 -r report --hmm thapbi_pict/hmm/controls.hmm --flip
+thapbi_pict pipeline -i tests/reads/ -s $TMP/intermediate -o $TMP/output -m onebp -a 250 -r report --hmm thapbi_pict/hmm/controls.hmm --flip --metaencoding UTF-8
 diff $TMP/intermediate/DNAMIX_S95_L001.fasta tests/prepare-reads/DNAMIX_S95_L001.fasta
 diff $TMP/output/report.samples.onebp.txt tests/pipeline/thapbi-pict.samples.onebp.txt
 diff $TMP/output/report.samples.onebp.tsv tests/pipeline/thapbi-pict.samples.onebp.tsv

--- a/tests/test_summary.sh
+++ b/tests/test_summary.sh
@@ -54,7 +54,9 @@ thapbi_pict summary --input tests/classify/P-infestans-T30-4.fasta tests/classif
 diff $TMP/summary.reads.onebp.tsv tests/classify/P-infestans-T30-4.summary.tsv
 
 # Now require metadata, but give entire folder as input
-thapbi_pict summary --input tests/classify/ -o $TMP/ -r summary -t tests/classify/P-infestans-T30-4.meta.tsv -x 1 -c 2,3,4,5 -r summary -q
+thapbi_pict summary --input tests/classify/ -o $TMP/ -r summary \
+    -t tests/classify/P-infestans-T30-4.meta.tsv -x 1 -c 2,3,4,5 -e latin1 \
+    -r summary -q
 diff $TMP/summary.reads.onebp.tsv tests/classify/P-infestans-T30-4.summary.tsv
 
 

--- a/thapbi_pict/__init__.py
+++ b/thapbi_pict/__init__.py
@@ -24,4 +24,4 @@ automatically from the ``docs/`` folder of the `software repository
 within the source code which document the Python API.
 """
 
-__version__ = "0.9.0"
+__version__ = "0.9.1"

--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -303,6 +303,7 @@ def summary(args=None):
         method=args.method,
         min_abundance=args.abundance,
         metadata_file=args.metadata,
+        metadata_encoding=args.metaencoding,
         metadata_cols=args.metacols,
         metadata_groups=args.metagroups,
         metadata_fieldnames=args.metafields,
@@ -438,6 +439,7 @@ def pipeline(args=None):
         method=args.method,
         min_abundance=args.abundance,
         metadata_file=args.metadata,
+        metadata_encoding=args.metaencoding,
         metadata_cols=args.metacols,
         metadata_groups=args.metagroups,
         metadata_fieldnames=args.metafields,
@@ -526,6 +528,7 @@ def ena_submit(args=None):
         fastq=args.input,
         output=args.output,
         metadata_file=args.metadata,
+        metadata_encoding=args.metaencoding,
         metadata_cols=args.metacols,
         metadata_fieldnames=args.metafields,
         metadata_index=args.metaindex,
@@ -756,6 +759,15 @@ ARG_METADATA = dict(  # noqa: C408
     "sample name. Must also specify the columns with -c / --metacols. ",
 )
 
+# "-e", "--metaencoding",
+ARG_METAENCODING = dict(  # noqa: C408
+    type=str,
+    default="",
+    metavar="ENCODING",
+    help="Optional encoding of the metadata table, e.g. 'UTF-8', 'latin1', "
+    "or if exporting from Microsoft Excel on macOS use 'macintosh'.",
+)
+
 # "-c", "--metacols",
 ARG_METACOLS = dict(  # noqa: C408
     type=str,
@@ -890,6 +902,7 @@ def main(args=None):
     subcommand_parser.add_argument("--flip", **ARG_FLIP)
     subcommand_parser.add_argument("-m", "--method", **ARG_METHOD_OUTPUT)
     subcommand_parser.add_argument("-t", "--metadata", **ARG_METADATA)
+    subcommand_parser.add_argument("-e", "--metaencoding", **ARG_METAENCODING)
     subcommand_parser.add_argument("-c", "--metacols", **ARG_METACOLS)
     subcommand_parser.add_argument("-x", "--metaindex", **ARG_METAINDEX)
     subcommand_parser.add_argument("-g", "--metagroups", **ARG_METAGROUPS)
@@ -1391,6 +1404,7 @@ def main(args=None):
         "abundance entries).",
     )
     subcommand_parser.add_argument("-t", "--metadata", **ARG_METADATA)
+    subcommand_parser.add_argument("-e", "--metaencoding", **ARG_METAENCODING)
     subcommand_parser.add_argument("-c", "--metacols", **ARG_METACOLS)
     subcommand_parser.add_argument("-x", "--metaindex", **ARG_METAINDEX)
     subcommand_parser.add_argument("-g", "--metagroups", **ARG_METAGROUPS)
@@ -1505,6 +1519,7 @@ def main(args=None):
         help="File to write to (default '-' meaning stdout)",
     )
     subcommand_parser.add_argument("-t", "--metadata", **ARG_METADATA)
+    subcommand_parser.add_argument("-e", "--metaencoding", **ARG_METAENCODING)
     subcommand_parser.add_argument("-c", "--metacols", **ARG_METACOLS)
     subcommand_parser.add_argument("-x", "--metaindex", **ARG_METAINDEX)
     subcommand_parser.add_argument("-f", "--metafields", **ARG_METAFIELDS)

--- a/thapbi_pict/ena_submit.py
+++ b/thapbi_pict/ena_submit.py
@@ -98,6 +98,7 @@ def main(
     fastq,
     output,
     metadata_file=None,
+    metadata_encoding=None,
     metadata_cols=None,
     metadata_fieldnames=None,
     metadata_index=None,
@@ -144,6 +145,7 @@ def main(
 
     (metadata, _, meta_names, group_col,) = load_metadata(
         metadata_file,
+        metadata_encoding,
         metadata_cols,
         None,  # i.e. metadata_groups=None,
         metadata_fieldnames,

--- a/thapbi_pict/summary.py
+++ b/thapbi_pict/summary.py
@@ -639,6 +639,7 @@ def main(
     method,
     min_abundance=1,
     metadata_file=None,
+    metadata_encoding=None,
     metadata_cols=None,
     metadata_groups=None,
     metadata_fieldnames=None,
@@ -658,6 +659,7 @@ def main(
 
     (stem_to_meta, meta_to_stem, meta_names, group_col,) = load_metadata(
         metadata_file,
+        metadata_encoding,
         metadata_cols,
         metadata_groups,
         metadata_fieldnames,

--- a/thapbi_pict/utils.py
+++ b/thapbi_pict/utils.py
@@ -529,6 +529,7 @@ def parse_species_tsv(tabular_file, min_abundance=0, req_species_level=False):
 
 def load_metadata(
     metadata_file,
+    metadata_encoding,
     metadata_cols,
     metadata_groups=None,
     metadata_name_row=1,
@@ -538,6 +539,8 @@ def load_metadata(
     debug=False,
 ):
     """Load specified metadata as several lists.
+
+    The encoding argument can be None or "", meaning use the default.
 
     The columns argument should be a string like "1,3,5" - a comma
     separated list of columns to output. The column numbers are assumed
@@ -620,15 +623,20 @@ def load_metadata(
 
     names = [""] * len(value_cols)  # default
     meta = {}
+    if not metadata_encoding:
+        metadata_encoding = None
     try:
-        # Try with default encoding first...
-        with open(metadata_file) as handle:
+        # Use metadata_encoding=None to try with default encoding:
+        with open(metadata_file, encoding=metadata_encoding) as handle:
             lines = list(handle)
     except UnicodeDecodeError:
-        # Automatically try latin1, which seems to be
-        # default when save tab-delimited from macOS Excel
-        with open(metadata_file, encoding="latin1") as handle:
-            lines = list(handle)
+        if metadata_encoding:
+            sys.exit(
+                f"ERROR: Specified encoding {metadata_encoding!r}"
+                f" incompatible with {metadata_file}"
+            )
+        else:
+            sys.exit(f"ERROR: Default encoding incompatible with {metadata_file}")
 
     if metadata_name_row:
         line = lines[metadata_name_row - 1]


### PR DESCRIPTION
The old hard-coded fallback on ``latin1`` did not work all the time, e.g. working with the metadata for this paper:

> Vélez *et al.* (2020) *Phytophthora austrocedri* in Argentina and
> Co-Inhabiting Phytophthoras: Roles of Anthropogenic and Abiotic Factors
> in Species Distribution and Diversity
> https://doi.org/10.3390/f11111223
> https://www.ebi.ac.uk/ena/data/view/PRJEB40677

This has accented characters like El Bolsón, or mallín, and degree symbols in the GPS coordinates. Getting the encoding right is key here - and saving TSV from Excel for Mac was using the legacy "macintosh" encoding not "latin1".