### PR TITLE
Disable negative control HMMER3 scan by default

### DIFF
--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -708,11 +708,11 @@ ARG_PRIMER_RIGHT_BLANK = dict(  # noqa: C408
 # "--hmm",
 ARG_HMM = dict(  # noqa: C408
     type=str,
-    default="-",
+    default="",
     metavar="PATH",
     help="Location of negative control HMMER3 Hidden Markov Model "
     "file, filename stem without the '.h3i', '.h3f', etc extension. "
-    "Use '' for none, or '-' for default four synthetic controls (default).",
+    "Use '' for none (default), or '-' for our four synthetic ITS1 controls.",
 )
 
 # Common pipeline arguments

--- a/thapbi_pict/prepare.py
+++ b/thapbi_pict/prepare.py
@@ -748,9 +748,6 @@ def main(
         # e.g. -n "" or -n "-"
         negative_controls = [_ for _ in negative_controls if _ and _ != "-"]
 
-    if negative_controls and not hmm_stem:
-        sys.exit("ERROR: If using negative controls, must use --hmm too.")
-
     check_tools(["flash", "cutadapt"], debug)
     if hmm_stem:
         check_tools(["hmmscan"], debug)


### PR DESCRIPTION
This is extremely specific to our own Phytophthora ITS1 sequencing project, and while harmless on other datasets is a pointless performance overhead.

We can probably do this without HMMER3 anyway - which would mean one less dependency (and a dependency not available on Windows too)...