### PR TITLE
Import with SINTAX or OBITools style annotated FASTA

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Release History
 ======= ========== ============================================================================
 Version Date       Notes
 ======= ========== ============================================================================
-v0.9.7  *Pending*  Dropped some minor functionality which hindered future changes.
+v0.9.7  *Pending*  Support USEARCH SINTAX and OBITools FASTA conventions in ``import`` command.
 v0.9.6  2021-05-21 Updated default DB taxonomy, Peronosporales & Pythiales up to 450bp only.
 v0.9.5  2021-05-10 Simplified to just one ``import`` command for pre-trimmed FASTA input.
 v0.9.4  2021-05-05 Dropped unused metadata fields from DB schema. Fixed GML format edit graphs.

--- a/database/build_CURATED+NCBI.sh
+++ b/database/build_CURATED+NCBI.sh
@@ -39,7 +39,7 @@ thapbi_pict import -d "$DB.sqlite" -i controls.fasta
 # ===================
 # NCBI at genus level
 # ===================
-thapbi_pict import -d "$DB.sqlite" -i 2021-05-20-ITS_Oomycota_w32.fasta --ncbi -g --minlen 150 --maxlen 450
+thapbi_pict import -d "$DB.sqlite" -i 2021-05-20-ITS_Oomycota_w32.fasta -c ncbi -g --minlen 150 --maxlen 450
 # Add hoc fix for some accessions apparently with wrong genus
 BAD="('MN128447.1', 'MK794853.1', 'MK794848.1', 'MK795051.1', 'HQ237483.1', 'KP183959.1', 'MW426376.1', 'MW426384.1', 'KY785380.1', 'KY785381.1', 'KU715054.1', 'GQ149496.1', 'JF916542.1')"
 sqlite3 "$DB.sqlite" "DELETE FROM its1_sequence WHERE id IN (SELECT its1_sequence.id FROM its1_sequence JOIN its1_source ON its1_sequence.id = its1_source.its1_id WHERE source_accession IN $BAD);"
@@ -48,7 +48,7 @@ sqlite3 "$DB.sqlite" "DELETE FROM its1_source WHERE source_accession IN $BAD;"
 # =================
 # Curated sequences
 # =================
-thapbi_pict import -d "$DB.sqlite" -i Phytophthora_ITS1_curated.fasta Nothophytophthora_ITS1_curated.fasta --maxlen 450
+thapbi_pict import -d "$DB.sqlite" -i Phytophthora_ITS1_curated.fasta Nothophytophthora_ITS1_curated.fasta --maxlen 450 -s ";"
 
 thapbi_pict dump -m -d "$DB.sqlite" -o "$DB.txt"
 thapbi_pict dump -m -f fasta -d "$DB.sqlite" -o "$DB.fasta"

--- a/database/build_CURATED.sh
+++ b/database/build_CURATED.sh
@@ -39,7 +39,7 @@ thapbi_pict import -d "$DB.sqlite" -i controls.fasta
 # ===================
 # NCBI at genus level
 # ===================
-# thapbi_pict import -d "$DB.sqlite" -i 2021-05-20-ITS_Oomycota_w32.fasta --ncbi -g --minlen 150 --maxlen 450
+# thapbi_pict import -d "$DB.sqlite" -i 2021-05-20-ITS_Oomycota_w32.fasta -c ncbi -g --minlen 150 --maxlen 450
 # Add hoc fix for some accessions apparently with wrong genus
 # BAD="('MN128447.1', 'MK794853.1', 'MK794848.1', 'MK795051.1', 'HQ237483.1', 'KP183959.1', 'MW426376.1', 'MW426384.1', 'KY785380.1', 'KY785381.1', 'KU715054.1', 'GQ149496.1', 'JF916542.1')"
 # sqlite3 "$DB.sqlite" "DELETE FROM its1_sequence WHERE id IN (SELECT its1_sequence.id FROM its1_sequence JOIN its1_source ON its1_sequence.id = its1_source.its1_id WHERE source_accession IN $BAD);"
@@ -48,7 +48,7 @@ thapbi_pict import -d "$DB.sqlite" -i controls.fasta
 # =================
 # Curated sequences
 # =================
-thapbi_pict import -d "$DB.sqlite" -i Phytophthora_ITS1_curated.fasta Nothophytophthora_ITS1_curated.fasta --maxlen 450
+thapbi_pict import -d "$DB.sqlite" -i Phytophthora_ITS1_curated.fasta Nothophytophthora_ITS1_curated.fasta --maxlen 450 -s ";"
 
 thapbi_pict dump -m -d "$DB.sqlite" -o "$DB.txt"
 thapbi_pict dump -m -f fasta -d "$DB.sqlite" -o "$DB.fasta"

--- a/database/build_ITS1_DB.sh
+++ b/database/build_ITS1_DB.sh
@@ -39,7 +39,7 @@ thapbi_pict import -d "$DB.sqlite" -i single_isolates/*.fasta
 # ===================
 # NCBI at genus level
 # ===================
-thapbi_pict import -d "$DB.sqlite" -i 2021-05-20-ITS_Oomycota_w32.fasta --ncbi -g --minlen 150 --maxlen 450
+thapbi_pict import -d "$DB.sqlite" -i 2021-05-20-ITS_Oomycota_w32.fasta -c ncbi -g --minlen 150 --maxlen 450
 # Add hoc fix for some accessions apparently with wrong genus
 BAD="('MN128447.1', 'MK794853.1', 'MK794848.1', 'MK795051.1', 'HQ237483.1', 'KP183959.1', 'MW426376.1', 'MW426384.1', 'KY785380.1', 'KY785381.1', 'KU715054.1', 'GQ149496.1', 'JF916542.1')"
 sqlite3 "$DB.sqlite" "DELETE FROM its1_sequence WHERE id IN (SELECT its1_sequence.id FROM its1_sequence JOIN its1_source ON its1_sequence.id = its1_source.its1_id WHERE source_accession IN $BAD);"
@@ -48,7 +48,7 @@ sqlite3 "$DB.sqlite" "DELETE FROM its1_source WHERE source_accession IN $BAD;"
 # =================
 # Curated sequences
 # =================
-thapbi_pict import -d "$DB.sqlite" -i Phytophthora_ITS1_curated.fasta Nothophytophthora_ITS1_curated.fasta --maxlen 450
+thapbi_pict import -d "$DB.sqlite" -i Phytophthora_ITS1_curated.fasta Nothophytophthora_ITS1_curated.fasta --maxlen 450 -s ";"
 
 thapbi_pict dump -m -d "$DB.sqlite" -o "$DB.txt"
 thapbi_pict dump -m -f fasta -d "$DB.sqlite" -o "$DB.fasta"

--- a/examples/drained_ponds/run.sh
+++ b/examples/drained_ponds/run.sh
@@ -7,7 +7,7 @@ echo
 
 if [ ! -f NCBI_12S.sqlite ]; then
     echo "Building 12S database from NCBI sequences"
-    thapbi_pict import -d NCBI_12S.sqlite -i NCBI_12S.fasta -x
+    thapbi_pict import -d NCBI_12S.sqlite -i NCBI_12S.fasta -x -s ";"
 fi
 
 # Primers, quoting Muri et al:

--- a/examples/endangered_species/run.sh
+++ b/examples/endangered_species/run.sh
@@ -22,12 +22,12 @@ function analyse {
         echo "Building database for $NAME"
         # Assume pre-trimmed
         thapbi_pict import -i references/${NAME}.fasta -d references/${NAME}.sqlite \
-            -x --minlen $MINLEN
+            -x -s ";" --minlen $MINLEN
     fi
     echo "Adding $NAME to pooled database"
     # This is a big hack, just for the assess command to work on the pool:
     thapbi_pict import -i references/${NAME}.fasta -d references/pooled.sqlite \
-        -x --minlen $MINLEN
+        -x -s ";" --minlen $MINLEN
 
     echo "Running analysis for $NAME"
     mkdir -p intermediate/$NAME/

--- a/examples/fecal_sequel/run.sh
+++ b/examples/fecal_sequel/run.sh
@@ -13,12 +13,12 @@ mkdir -p intermediate/ summary/
 # Setup two database, FASTA files are both already primer trimmed
 if [ ! -f COI_430_bats.sqlite ]; then
     echo "Setting up first database"
-    thapbi_pict import -d COI_430_bats.sqlite -i COI_430_bats.fasta -x
+    thapbi_pict import -d COI_430_bats.sqlite -i COI_430_bats.fasta -x -s ";"
 fi
 if [ ! -f COI_ext_bats.sqlite ]; then
     echo "Setting up extended database"
     cp COI_430_bats.sqlite COI_ext_bats.sqlite
-    thapbi_pict import -d COI_ext_bats.sqlite -i observed_3_bats.fasta -x
+    thapbi_pict import -d COI_ext_bats.sqlite -i observed_3_bats.fasta -x -s ";"
 fi
 
 echo ---------------------------------------------------------------

--- a/examples/great_lakes/run.sh
+++ b/examples/great_lakes/run.sh
@@ -12,7 +12,7 @@ function analyse {
     if [ ! -f ${NAME}.sqlite ]; then
         echo "Building $NAME database"
         # Pre-trimmed, not validating species names
-        thapbi_pict import -d ${NAME}.sqlite -i $NAME.fasta -x
+        thapbi_pict import -d ${NAME}.sqlite -i $NAME.fasta -x -s ";"
     fi
 
     echo "Running analysis"

--- a/examples/recycled_water/run.sh
+++ b/examples/recycled_water/run.sh
@@ -28,7 +28,7 @@ if [ ! -f Redekar_et_al_2019_sup_table_3.sqlite ]; then
 
     # Using -x / --lax (does not insist on taxonomy match)
     # Not giving primers, sequences are already trimmed
-    thapbi_pict import -x \
+    thapbi_pict import -x -s ";" \
             -d Redekar_et_al_2019_sup_table_3.sqlite \
             -i Redekar_et_al_2019_sup_table_3.fasta
 fi

--- a/tests/test_assess.sh
+++ b/tests/test_assess.sh
@@ -22,7 +22,7 @@ set -o pipefail
 
 export DB=$TMP/seven.sqlite
 rm -rf $DB
-thapbi_pict import -d $DB -i tests/assess/seven.fasta -x
+thapbi_pict import -d $DB -i tests/assess/seven.fasta -x -s ";"
 
 # Simple examples with expected output to compare against
 for SAMPLE in ex1 ex2 ex3 ex4 unclassified fp; do

--- a/tests/test_curated-import.sh
+++ b/tests/test_curated-import.sh
@@ -36,17 +36,22 @@ echo "Curated ITS1 with taxdump"
 export DB=$TMP/curated.sqlite
 rm -rf $DB
 thapbi_pict load-tax -d $DB -t new_taxdump_2019-09-01
-thapbi_pict import -d $DB -i database/Phytophthora_ITS1_curated.fasta
+thapbi_pict import -d $DB -i database/Phytophthora_ITS1_curated.fasta -s ";"
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM data_source;"` -ne "1" ]; then echo "Wrong data_source count"; false; fi
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM its1_source;"` -ne "215" ]; then echo "Wrong its1_source count"; false; fi
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM its1_sequence;"` -ne "190" ]; then echo "Wrong its1_sequence count"; false; fi
 
 echo "With duplicated sequences (and multi-entry records using Ctrl+A)"
-# Note this file uses Ctrl+A separator (default value for -s argument with --ncbi)
-# Only 6 FASTA records, but two are double entries so want 8 here.
+# Note this file uses Ctrl+A separator:
+#
+# $ grep $'\001' tests/curated-import/dup_seqs.fasta
+# >DDD Phytophthora fourEEE Phytophthora five
+# >FFF Phytophthora alphaGGG Phytophthora beta
+#
+# Only 6 FASTA records, but two are double entries so want 8 here
 export DB=$TMP/dup_seqs.sqlite
 rm -rf $DB
-thapbi_pict import -x -d $DB -i tests/curated-import/dup_seqs.fasta --ncbi
+thapbi_pict import -x -d $DB -i tests/curated-import/dup_seqs.fasta -c ncbi -s $'\001'
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM data_source;"` -ne "1" ]; then echo "Wrong data_source count"; false; fi
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM its1_source;"` -ne "8" ]; then echo "Wrong its1_source count"; false; fi
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM its1_sequence;"` -ne "2" ]; then echo "Wrong its1_sequence count"; false; fi
@@ -59,7 +64,7 @@ echo "With duplicated sequences (ignoring the multi-entry record naming)"
 # Expect 6 entries, and two very silly species names!
 export DB=$TMP/dup_seqs_bad.sqlite
 rm -rf $DB
-thapbi_pict import -x -d $DB -i tests/curated-import/dup_seqs.fasta
+thapbi_pict import -x -d $DB -i tests/curated-import/dup_seqs.fasta -c simple -s ";"
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM data_source;"` -ne "1" ]; then echo "Wrong data_source count"; false; fi
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM its1_source;"` -ne "6" ]; then echo "Wrong its1_source count"; false; fi
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM its1_sequence;"` -ne "2" ]; then echo "Wrong its1_sequence count"; false; fi
@@ -70,7 +75,7 @@ echo "Redekar supplementary table 3"
 export DB=$TMP/Redekar_et_al_2019_sup_table_3.sqlite
 rm -rf $DB
 # This uses the semi-colon separator
-thapbi_pict import -x -d $DB -i examples/recycled_water/Redekar_et_al_2019_sup_table_3.fasta
+thapbi_pict import -x -d $DB -i examples/recycled_water/Redekar_et_al_2019_sup_table_3.fasta -s ";"
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM data_source;"` -ne "1" ]; then echo "Wrong data_source count"; false; fi
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM its1_source;"` -ne "1451" ]; then echo "Wrong its1_source count"; false; fi
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM its1_sequence;"` -ne "838" ]; then echo "Wrong its1_sequence count"; false; fi

--- a/tests/test_ncbi-import.sh
+++ b/tests/test_ncbi-import.sh
@@ -22,7 +22,7 @@ echo "===================="
 set -x
 thapbi_pict import 2>&1 | grep "the following arguments are required"
 # Cannot use validation without having some taxonomy entries
-thapbi_pict import --ncbi -d sqlite:///:memory: --input tests/ncbi-import/20th_Century_ITS1.fasta 2>&1 | grep "Taxonomy table empty"
+thapbi_pict import -c ncbi -d sqlite:///:memory: --input tests/ncbi-import/20th_Century_ITS1.fasta 2>&1 | grep "Taxonomy table empty"
 set -o pipefail
 
 if [ ! -f "new_taxdump_2019-09-01.zip" ]; then curl -L -O "https://ftp.ncbi.nih.gov/pub/taxonomy/taxdump_archive/new_taxdump_2019-09-01.zip"; fi
@@ -34,7 +34,7 @@ if [ ! -d "new_taxdump_2019-09-01" ]; then unzip new_taxdump_2019-09-01.zip node
 export DB=$TMP/hybrid.sqlite
 rm -rf $DB
 thapbi_pict load-tax -d $DB -t new_taxdump_2019-09-01
-thapbi_pict import --ncbi -d $DB -i tests/ncbi-import/hybrid.fasta
+thapbi_pict import -c ncbi -d $DB -i tests/ncbi-import/hybrid.fasta
 if [ `thapbi_pict dump -d $DB | grep -c "humicola x inundata"` -ne "1" ]; then echo "Expected humicola x inundata"; false; fi
 
 
@@ -47,7 +47,7 @@ if [ `sqlite3 $DB "SELECT COUNT(id) FROM taxonomy;"` -ne "1378" ]; then echo "Wr
 # 5 sequences all with multiple HMM matches, but after primer trimming most become single HMM entries.
 cutadapt --quiet -g $LEFT tests/ncbi-import/multiple_hmm.fasta \
 | cutadapt --quiet -a $RIGHT_RC -o $TMP/multiple_hmm.fasta /dev/stdin
-thapbi_pict import --ncbi -d $DB -g -i $TMP/multiple_hmm.fasta \
+thapbi_pict import -c ncbi -d $DB -g -i $TMP/multiple_hmm.fasta \
             -n "NCBI examples with multiple HMM matches"
 # WARNING: 2 HMM matches in MF095142.1
 # WARNING: Uncultured, so ignoring 'MF095142.1 Uncultured Peronosporaceae clone MZOo17 small subunit ri...'
@@ -77,7 +77,7 @@ cat tests/ncbi-import/20th_Century_ITS1_Peronosporaceae.fasta | sed "s/ P\./ Phy
 
 export DB=$TMP/20th_Century_ITS1.sqlite
 rm -rf $DB
-thapbi_pict import --ncbi -x -d $DB -i $TMP/20th_Century_ITS1.fasta
+thapbi_pict import -c ncbi -x -d $DB -i $TMP/20th_Century_ITS1.fasta
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM data_source;"` -ne "1" ]; then echo "Wrong data_source count"; false; fi
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM its1_source;"` -ne "120" ]; then echo "Wrong its1_source count"; false; fi
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM its1_sequence;"` -ne "103" ]; then echo "Wrong its1_sequence count"; false; fi
@@ -92,7 +92,7 @@ thapbi_pict load-tax -d $DB -t new_taxdump_2019-09-01 -a 4783
 if [ `sqlite3 $DB "SELECT COUNT(DISTINCT genus) FROM taxonomy;"` -ne "1" ]; then echo "Wrong genus count"; false; fi
 if [ `sqlite3 $DB "SELECT COUNT(DISTINCT species) FROM taxonomy;"` -ne "258" ]; then echo "Wrong species count"; false; fi
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM taxonomy;"` -ne "258" ]; then echo "Wrong taxonomy count"; false; fi
-thapbi_pict import --ncbi -d $DB -i $TMP/20th_Century_ITS1.fasta
+thapbi_pict import -c ncbi -d $DB -i $TMP/20th_Century_ITS1.fasta
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM data_source;"` -ne "1" ]; then echo "Wrong data_source count"; false; fi
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM its1_source;"` -ne "120" ]; then echo "Wrong its1_source count"; false; fi
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM its1_sequence;"` -ne "103" ]; then echo "Wrong its1_sequence count"; false; fi
@@ -110,7 +110,7 @@ export DB=$TMP/20th_Century_ITS1_genus_only.sqlite
 rm -rf $DB
 thapbi_pict load-tax -d $DB -t new_taxdump_2019-09-01
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM taxonomy;"` -ne "1378" ]; then echo "Wrong taxonomy count"; false; fi
-thapbi_pict import --ncbi -d $DB -i $TMP/20th_Century_ITS1.fasta -g
+thapbi_pict import -c ncbi -d $DB -i $TMP/20th_Century_ITS1.fasta -g
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM data_source;"` -ne "1" ]; then echo "Wrong data_source count"; false; fi
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM its1_source;"` -ne "120" ]; then echo "Wrong its1_source count"; false; fi
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM its1_sequence;"` -ne "103" ]; then echo "Wrong its1_sequence count"; false; fi
@@ -124,13 +124,13 @@ export DB=$TMP/20th_Century_ITS1_mixed.sqlite
 rm -rf $DB
 thapbi_pict load-tax -d $DB -t new_taxdump_2019-09-01
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM taxonomy;"` -ne "1378" ]; then echo "Wrong taxonomy count"; false; fi
-thapbi_pict import --ncbi -d $DB -i $TMP/20th_Century_ITS1.fasta
+thapbi_pict import -c ncbi -d $DB -i $TMP/20th_Century_ITS1.fasta
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM data_source;"` -ne "1" ]; then echo "Wrong data_source count"; false; fi
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM its1_source;"` -ne "120" ]; then echo "Wrong its1_source count"; false; fi
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM its1_sequence;"` -ne "103" ]; then echo "Wrong its1_sequence count"; false; fi
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM taxonomy;"` -ne "1378" ]; then echo "Wrong taxonomy count"; false; fi
 if [ `thapbi_pict dump -d $DB -f fasta | grep "^>" | grep  " Phytophthora " -c` -ne 101 ]; then echo "Wrong Phytophthora species count"; false; fi
-thapbi_pict import --ncbi -d $DB -i $TMP/20th_Century_ITS1_Peronosporaceae.fasta -g
+thapbi_pict import -c ncbi -d $DB -i $TMP/20th_Century_ITS1_Peronosporaceae.fasta -g
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM data_source;"` -ne "2" ]; then echo "Wrong data_source count"; false; fi
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM its1_source;"` -ne "269" ]; then echo "Wrong its1_source count"; false; fi
 if [ `sqlite3 $DB "SELECT COUNT(id) FROM its1_sequence;"` -ne "109" ]; then echo "Wrong its1_sequence count"; false; fi

--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -15,6 +15,7 @@ import sys
 
 from . import __version__
 from .classify import method_classify_file as method_classifier
+from .db_import import fasta_parsing_function as fasta_conventions
 from .utils import find_requested_files
 from .utils import primer_clean
 
@@ -100,10 +101,10 @@ def db_import(args=None):
         min_length=args.minlen,
         max_length=args.maxlen,
         name=args.name,
+        convention=args.convention,
+        sep=args.sep,
         validate_species=not args.lax,
-        ncbi_heuristics=args.ncbi,
         genus_only=args.genus,
-        sep=(CTRL_A if args.ncbi else ";") if args.sep is None else args.sep,
         ignore_prefixes=tuple(args.ignore_prefixes),
         tmp_dir=args.temp,
         debug=args.verbose,
@@ -916,9 +917,12 @@ def main(args=None):
         "unless using -x / --lax in which case any word is accepted as a genus).",
     )
     subcommand_parser.add_argument(
-        "--ncbi",
-        action="store_true",
-        help="Enable NCBI naming style heuristics.",
+        "-c",
+        "--convention",
+        type=str,
+        default="simple",
+        choices=list(fasta_conventions),
+        help="Which naming convention does the FASTA file follow.",
     )
     subcommand_parser.add_argument(
         "-s",
@@ -926,8 +930,8 @@ def main(args=None):
         type=str,
         default=None,
         metavar="CHAR",
-        help="FASTA description multi-entry separator. Default semi-colon or "
-        "Ctrl+A with --ncbi. Use '' if single entries.",
+        help="FASTA description multi-entry separator character. Default none "
+        "meaning assume single entries.",
     )
     subcommand_parser.add_argument("--ignore-prefixes", **ARG_IGNORE_PREFIXES)
     subcommand_parser.add_argument("-t", "--temp", **ARG_TEMPDIR)

--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -27,7 +27,7 @@ from .utils import primer_clean
 DEFAULT_METHOD = "onebp"
 DEFAULT_MIN_ABUNDANCE = 100
 CTRL_A = chr(1)
-IGNORE_PREFIXES = ("Undetermined",)
+IGNORE_PREFIXES = ("Undetermined_", "unknown_")
 
 # Argument validation functions
 # =============================
@@ -530,8 +530,8 @@ ARG_IGNORE_PREFIXES = dict(  # noqa: C408
     nargs="+",
     metavar="STEM",
     default=IGNORE_PREFIXES,
-    help="One or more filename prefixes to ignore, default %s"
-    % ", ".join(repr(_) for _ in IGNORE_PREFIXES),
+    help="One or more filename prefixes to ignore, default "
+    + " ".join(IGNORE_PREFIXES),
 )
 
 # "-m", "--method",

--- a/thapbi_pict/db_import.py
+++ b/thapbi_pict/db_import.py
@@ -516,6 +516,9 @@ def main(
     (function default) if single entries are expected.
     """
     if sep:
+        if convention in ["sintax", "obitools"]:
+            sys.exit(f"ERROR: Can't use separator with {convention} naming.")
+
         if debug:
             sys.stderr.write(f"DEBUG: Splitting each FASTA entry using {sep!r}.\n")
 

--- a/thapbi_pict/db_import.py
+++ b/thapbi_pict/db_import.py
@@ -418,8 +418,6 @@ def main(
 
     For curated FASTA files, omit ``--ncbi`` and use ``--sep ';'``
     or whatever multi-entry separator you are using.
-
-    Primer trimming is done if and only if primers are given.
     """
     if sep:
 


### PR DESCRIPTION
USEARCH and VSEARCH use the SINTAX format https://drive5.com/usearch/manual/tax_annot.html

OBITools uses another style https://pythonhosted.org/OBITools/attributes.html

Our separator setting does not make sense with these conventions, only on the simple and NCBI style (although even there an appropriate character is needed). Now defaults to no separator.