### PR TITLE
low-memory onebp and 1s3g etc implementation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Release History
 ======= ========== ============================================================================
 Version Date       Notes
 ======= ========== ============================================================================
-v0.10.0 *Pending*  Reworked to handle multiple markers - uses a modified DB schema.
+v0.10.0 *Pending*  Reworked to handle larger DB and multiple markers. Modified the DB schema.
 v0.9.9  2021-07-08 Dropped SWARM based classifiers. Single intermediate TSV file in pipeline.
 v0.9.8  2021-06-17 Dropped edit-graph in pipeline. Require full length primers in merged reads.
 v0.9.7  2021-06-04 Support USEARCH SINTAX and OBITools FASTA conventions in ``import`` command.

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -45,8 +45,7 @@ The second stage of the pipeline offers a choice of classifier algorithms:
   or insertion).
 - Up to one base pair away for a species level match (like the default
   ``onebp`` method), but falling back on up to 3bp, 4bp or 5bp away for a
-  genus level match (``1s3g``, ``1s4g``, ``1s5g``). The current simplistic
-  implementation is too slow for use with very large databases.
+  genus level match (``1s3g``, ``1s4g``, ``1s5g``).
 - Perfect substring (``substr``). Like the identity classifier, but also
   allows for the query sequence to be a perfect substring of a database entry.
   Useful if the database entries have not all been trimmed exactly.

--- a/thapbi_pict/classify.py
+++ b/thapbi_pict/classify.py
@@ -388,26 +388,27 @@ def dist_in_db(session, marker_name, seq, debug=False):
     taxid, genus_species, note = onebp_match_in_db(session, marker_name, seq)
     if genus_species:
         return taxid, genus_species, note
+    assert seq not in db_seqs
 
     # Else any matches from 2 bp up to X bp away, and will take genus only:
     min_dist = 0
-    best = {}
+    best = set()
+    # Any matches are at least 2bp away, will take genus only.
+    # Fall back on brute force! But only on a minority of cases
     for db_seq in db_seqs:
         dist = levenshtein(seq, db_seq)
         if dist > max_dist_genus:
             pass
         elif dist == min_dist:
             # Best equal
-            best[db_seq] = dist
+            best.add(db_seq)
         elif dist < min_dist or min_dist == 0:
             # New winner
             min_dist = dist
-            best[db_seq] = dist
+            best = {db_seq}
     if not best:
         assert min_dist == 0, min_dist
         return 0, "", f"No matches up to distance {max_dist_genus}"
-    if seq in db_seqs:
-        assert seq in best and best[seq] == 0
     note = f"{len(best)} matches at distance {min_dist}"
     assert min_dist > 1  # Should have caught via onebp_match_in_db!
 

--- a/thapbi_pict/classify.py
+++ b/thapbi_pict/classify.py
@@ -404,6 +404,10 @@ def dist_in_db(session, marker_name, seq, debug=False):
         # Found 1bp away entries in DB at species level, done :)
         return taxid, genus_species, note
 
+    if seq in db_seqs:
+        # Could have cached this genus-only perfect match
+        return perfect_match_in_db(session, marker_name, seq)
+
     # Nothing at species level within 1bp, take genus only info
     genus = {
         _.genus


### PR DESCRIPTION
Work for #346: Do not pre-build the onebp variant cloud when DB very large, instead consider the cloud for each query sequence.

This benefits greatly from working on all the unique queries in one batch as per the pipeline since v0.9.9

Test case over 5000 unique sequences,

```
$ grep -c "^>" thapbi-pict-ITS1_DB-v0.9.0.all_reads.fasta
5012
```

Currently DB has far fewer unique entries:

```
$ thapbi_pict dump -m -f fasta | grep -c "^>"
Wrote 1206 fasta format entries
1206
```

Using the current release v0.9.9 as a base line,

```
$ mprof run --include-children  thapbi_pict classify -i thapbi-pict-ITS1_DB-v0.9.0.all_reads.fasta -d ../../../database/ITS1_DB-v0.9.9.sqlite -o - > /tmp/cloud.tsv &&  mprof plot
Expanded 1206 marker sequences from DB into cloud of 1733078 1bp different variants
Running onebp classifier on thapbi-pict-ITS1_DB-v0.9.0.all_reads.fasta
onebp classifier assigned species/genus to 70846631 of 90984852 sequences from 1 files
Using last profile data.
```

![cloud](https://user-images.githubusercontent.com/63959/127129935-4bc45abb-c414-4ebb-85f8-aee7291f8702.png)

This exploratory branch:

```
$ mprof run --include-children  thapbi_pict classify -i thapbi-pict-ITS1_DB-v0.9.0.all_reads.fasta -o - > /tmp/inverted.tsv && mprof plot
DB has 3473 unique marker sequences, too many to pre-compute a variant cloud.
Running onebp classifier on thapbi-pict-ITS1_DB-v0.9.0.all_reads.fasta
onebp classifier assigned species/genus to 67370074 of 90984852 sequences from 1 files
Using last profile data.
```

![inverted](https://user-images.githubusercontent.com/63959/127128150-ac2cb851-85da-450b-9e0b-b5efb3d96883.png)

(As an aside, need to tune the SQL for pulling out the unique sequences for the current marker - 3473 over 1206 is a side effect of the join)

So, on this real world example about 1/10 of the memory, and slightly faster. The old approach no longer makes sense in the pipeline (although it will probably still be faster if classifying lots of FASTA files).