### PR TITLE
Abundance threshold as fraction of marker reads for sample

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Release History
 ======= ========== ============================================================================
 Version Date       Notes
 ======= ========== ============================================================================
+v0.10.3 *Pending*  New ``-f`` / ``--abundance-fraction`` setting, off by default.
 v0.10.2 2021-11-05 Updates to default curated DB, and small changes to NCBI taxonomy loading.
 v0.10.1 2021-07-28 Fix for using SQLAlchemy v1.3 (previous release needed v1.4).
 v0.10.0 2021-07-28 Rework to handle larger DB and multiple markers. Modifies DB schema.

--- a/docs/examples/drained_ponds/presence_absence.rst
+++ b/docs/examples/drained_ponds/presence_absence.rst
@@ -13,9 +13,10 @@ Quoting the Muri *et al.* (2020) paper:
     blanks and PCR negatives, a second arbitrary threshold was applied and all
     records occurring with less than 50 reads assigned were removed.
 
-THAPBI PICT currently only implements an absolute minimum read abundance
+THAPBI PICT initially only implemented an absolute minimum read abundance
 threshold, and setting this to at least 10 excludes low-frequency noise. We
-have also used a threshold of 50 to match the original paper.
+have used ``-a 50`` for an absolute threshold of 50, and ``-f 0.001`` for a
+0.1% sample specific factional threshold to match the paper.
 
 At this threshold, the 4 cichlid "positive" samples, 6 PCR "negative", and 8
 "blank" controls are perfect - as far as the fish go. We do see unexpected
@@ -24,33 +25,37 @@ in the field "blanks":
 
 .. code:: console
 
-    $ grep -E "(^#|positive|negative|blank)" summary/drained_ponds.12S.samples.onebp.tsv | cut -f 5,10-11,15
+    $ grep -E "(^#|positive|negative|blank)" summary/drained_ponds.12S.samples.onebp.tsv | cut -f 5,10-11,15-16
     <SEE TABLE BELOW>
 
 Or, filter/search ``summary/drained_ponds.12S.samples.onebp.tsv`` in Excel:
 
-======== ================= =========================================================================== ==========
-control  Sequencing sample Classification summary                                                      Read count
-======== ================= =========================================================================== ==========
-blank    SRR11949861       -                                                                           0
-blank    SRR11949885       -                                                                           0
-blank    SRR11949884       (Off-target) Homo sapiens, (Off-target) Sus scrofa                          544
-blank    SRR11949883       (Off-target) Bos taurus, (Off-target) Homo sapiens, (Off-target) Sus scrofa 1629
-blank    SRR11949882       (Off-target) Anatidae (waterfowl)                                           61
-blank    SRR11949881       (Off-target) Homo sapiens                                                   56
-blank    SRR11949880       (Off-target) Anatidae (waterfowl), (Off-target) Homo sapiens                436
-blank    SRR11949834       (Off-target) Homo sapiens                                                   175
-negative SRR11949908       -                                                                           0
-negative SRR11949907       (Off-target) Gallus gallus, (Off-target) Homo sapiens                       606
-negative SRR11949851       -                                                                           0
-negative SRR11949850       -                                                                           0
-negative SRR11949838       (Off-target) Homo sapiens                                                   71
-negative SRR11949837       (Off-target) Homo sapiens                                                   356
-positive SRR11949836       Astatotilapia calliptera(*), Maylandia zebra(*)                             39748
-positive SRR11949835       Astatotilapia calliptera(*), Maylandia zebra(*)                             39244
-positive SRR11949906       Astatotilapia calliptera(*), Maylandia zebra(*)                             62249
-positive SRR11949849       Astatotilapia calliptera(*), Maylandia zebra(*)                             24567
-======== ================= =========================================================================== ==========
+======== ================= =========================================================================== ========= ==========
+control  Sequencing sample Classification summary                                                      Threshold Read count
+======== ================= =========================================================================== ========= ==========
+blank    SRR11949861       -                                                                           50        0
+blank    SRR11949885       -                                                                           50        0
+blank    SRR11949884       (Off-target) Homo sapiens, (Off-target) Sus scrofa                          50        544
+blank    SRR11949883       (Off-target) Bos taurus, (Off-target) Homo sapiens, (Off-target) Sus scrofa 50        1629
+blank    SRR11949882       (Off-target) Anatidae (waterfowl)                                           50        61
+blank    SRR11949881       (Off-target) Homo sapiens                                                   50        56
+blank    SRR11949880       (Off-target) Anatidae (waterfowl), (Off-target) Homo sapiens                50        436
+blank    SRR11949834       (Off-target) Homo sapiens                                                   50        175
+negative SRR11949908       -                                                                           50        0
+negative SRR11949907       (Off-target) Gallus gallus, (Off-target) Homo sapiens                       50        606
+negative SRR11949851       -                                                                           50        0
+negative SRR11949850       -                                                                           50        0
+negative SRR11949838       (Off-target) Homo sapiens                                                   50        71
+negative SRR11949837       (Off-target) Homo sapiens                                                   50        356
+positive SRR11949836       Astatotilapia calliptera(*), Maylandia zebra(*)                             50        39748
+positive SRR11949835       Astatotilapia calliptera(*), Maylandia zebra(*)                             50        39244
+positive SRR11949906       Astatotilapia calliptera(*), Maylandia zebra(*)                             65        62249
+positive SRR11949849       Astatotilapia calliptera(*), Maylandia zebra(*)                             50        24567
+======== ================= =========================================================================== ========= ==========
+
+Only in one sample (``SRR11949906``, a positive control) was the percentage
+based abundance threshold stricter than the absolute threshold (65 not 50),
+and it still gives the highest number of reads.
 
 Note that the positive samples only yield a single unique sequence (MD5
 checksum ``17dbc1c331d17cd075aabd6f710a039b``) which matches both the cichlid
@@ -98,43 +103,42 @@ You might prefer to open this in Excel:
 =================================== === === === ====
 #Species                            TP  FP  FN  TN
 =================================== === === === ====
-OVERALL                             440 411 324 5854
+OVERALL                             433 388 331 5877
 (Off-target) Anatidae (waterfowl)   0   70  0   29
 (Off-target) Apodemus               0   4   0   95
-(Off-target) Ardea cinerea          0   13  0   86
-(Off-target) Bos taurus             0   5   0   94
-(Off-target) Canis lupus familiaris 0   11  0   88
+(Off-target) Ardea cinerea          0   11  0   88
+(Off-target) Bos taurus             0   3   0   96
+(Off-target) Canis lupus familiaris 0   7   0   92
 (Off-target) Capra hircus           0   1   0   98
 (Off-target) Columba                0   47  0   52
 (Off-target) Gallinula chloropus    0   50  0   49
 (Off-target) Gallus gallus          0   13  0   86
 (Off-target) Homo sapiens           0   83  0   16
-(Off-target) Ovis aries             0   21  0   78
+(Off-target) Ovis aries             0   17  0   82
 (Off-target) Ovis dalli             0   1   0   98
 (Off-target) Phalacrocorax carbo    0   25  0   74
-(Off-target) Sturnus                0   4   0   95
-(Off-target) Sus scrofa             0   18  0   81
-(Off-target) Turdus                 0   8   0   91
+(Off-target) Sturnus                0   3   0   96
+(Off-target) Sus scrofa             0   16  0   83
+(Off-target) Turdus                 0   7   0   92
 Abramis brama                       65  0   16  18
 Acipenser spp.                      0   0   9   90
 Alburnus mossulensis                0   1   0   98
 Astatotilapia calliptera            4   0   0   95
-Barbus barbus                       49  0   32  18
+Barbus barbus                       46  0   35  18
 Carassius carassius                 64  0   17  18
-Ctenopharyngodon idella             3   16  6   74
+Ctenopharyngodon idella             3   15  6   75
 Cyprinus carpio                     61  0   20  18
 Maylandia zebra                     4   0   0   95
-Notemigonus crysoleucas             0   1   0   98
-Perca fluviatilis                   42  0   39  18
+Perca fluviatilis                   40  0   41  18
 Pseudorasbora parva                 0   2   0   97
 Rutilus rutilus                     63  0   18  18
-Scardinius erythrophthalmus         7   0   74  18
+Scardinius erythrophthalmus         6   0   75  18
 Silurus glanis                      9   0   0   90
-Spinibarbus denticulatus            0   16  0   83
+Spinibarbus denticulatus            0   11  0   88
 Squalidus gracilis                  0   1   0   98
-Squalius cephalus                   7   0   74  18
+Squalius cephalus                   6   0   75  18
 Tinca tinca                         62  0   19  18
-OTHER 36 SPECIES IN DB              0   0   0   3564
+OTHER 37 SPECIES IN DB              0   0   0   3663
 =================================== === === === ====
 
 False positives
@@ -222,8 +226,8 @@ sample names match.
 Other Fish
 ~~~~~~~~~~
 
-We also see one false positive for each of the three fish species *Alburnus
-mossulensis*, *Notemigonus crysoleucas*, and *Squalidus gracilis*:
+We also see one false positive for each of the two fish species *Alburnus
+mossulensis*, and *Squalidus gracilis*:
 
 .. code:: console
 
@@ -232,12 +236,8 @@ mossulensis*, *Notemigonus crysoleucas*, and *Squalidus gracilis*:
     $ grep 916da937dccfd5d29502e83713e5d998 intermediate/12S/*.fasta
     intermediate/12S/SRR11949859.fasta:>916da937dccfd5d29502e83713e5d998_98
 
-.. code:: console
-
-    $ grep "Notemigonus crysoleucas" summary/drained_ponds.12S.reads.onebp.tsv | cut -f 1-2
-    03f1d4c484ccc0026d851f42fbdb835a  Abramis brama;Notemigonus crysoleucas
-    $ grep 03f1d4c484ccc0026d851f42fbdb835a intermediate/12S/*.fasta
-    intermediate/12S/SRR11949887.fasta:>03f1d4c484ccc0026d851f42fbdb835a_51
+This sequence is ambiguous with equally good matches to expected species
+*Abramis brama*. Again, we might remove *Alburnus mossulensis* from the DB?
 
 .. code:: console
 
@@ -246,9 +246,7 @@ mossulensis*, *Notemigonus crysoleucas*, and *Squalidus gracilis*:
     $ grep c0d532d1c6f8ffff9c72ac4a1873151c intermediate/12S/*.fasta
     intermediate/12S/SRR11949871.fasta:>c0d532d1c6f8ffff9c72ac4a1873151c_82
 
-In two cases the sequences are ambiguous with equally good matches to expected
-species *Abramis brama*. Again, we might remove *Alburnus mossulensis* and
-*Notemigonus crysoleucas* from the DB?
+This sequence match is with AP011393.1 in the provided reference set.
 
 False negatives
 ---------------
@@ -269,7 +267,7 @@ For example, we report *Barbus barbus* in 49 samples, versus:
 
     In addition, *Barbus barbus* was detected at two sites (202 reads), ...
 
-We found *Scardinius erythrophthalmus* in seven samples:
+We found *Scardinius erythrophthalmus* in six samples:
 
 .. code:: console
 
@@ -281,7 +279,6 @@ We found *Scardinius erythrophthalmus* in seven samples:
     intermediate/12S/SRR11949870.fasta:>2a53392fe4add5780f959b56407423d0_120
     intermediate/12S/SRR11949879.fasta:>2a53392fe4add5780f959b56407423d0_156
     intermediate/12S/SRR11949886.fasta:>2a53392fe4add5780f959b56407423d0_76
-    intermediate/12S/SRR11949891.fasta:>2a53392fe4add5780f959b56407423d0_76
     intermediate/12S/SRR11949893.fasta:>2a53392fe4add5780f959b56407423d0_136
 
 Quoting the original paper:

--- a/docs/examples/soil_nematodes/overview.rst
+++ b/docs/examples/soil_nematodes/overview.rst
@@ -2,10 +2,11 @@ High level overview
 ===================
 
 The high level summary is that all the samples have high coverage, much higher
-than most of the examples we have used. There is minimal off target signal
-(from the other primer sets), and the no template blanks have lower yields.
-The read counts in the blanks are high, but happily do not appear to contain
-nematode sequence.
+than most of the examples we have used. The coverage also varies between
+samples - making a fractional minimum abundance threshold attractive here.
+There is minimal off target signal (from the other primer sets), and the no
+template blanks have lower yields. The read counts in the blanks are high, but
+happily do not appear to contain nematode sequence.
 
 Per-marker yield
 ----------------
@@ -16,32 +17,32 @@ at the command line or in Excel.
 
 .. code:: console
 
-    $ cut -f 1,2,5-8 summary/NF1-18Sr2b.samples.onebp.tsv
+    $ cut -f 1,2,5-9 summary/NF1-18Sr2b.samples.onebp.tsv
     <SEE TABLE BELOW>
 
 Or open the Excel version ``summary/NF1-18Sr2b.samples.onebp.xlsx``, and focus
 on those early columns:
 
-============= ====== ========= ======= ======== ==========
-#marker       sample Raw FASTQ Flash   Cutadapt Read count
-============= ====== ========= ======= ======== ==========
-D3Af-D3Br     Blank  1193593   1039205 0        0
-D3Af-D3Br     MC1    3897994   3317661 0        0
-D3Af-D3Br     MC2    4228233   3685150 0        0
-D3Af-D3Br     MC3    4309817   3864130 0        0
-JB3-JB5GED    Blank  69641     62060   0        0
-JB3-JB5GED    MC1    1236201   1157824 0        0
-JB3-JB5GED    MC2    2160885   2058441 1        0
-JB3-JB5GED    MC3    1204900   1139777 0        0
-NF1-18Sr2b    Blank  260778    218813  187776   116145
-NF1-18Sr2b    MC1    2483453   2126062 2109488  1062526
-NF1-18Sr2b    MC2    2349364   1985981 1972923  1060055
-NF1-18Sr2b    MC3    2435278   2088185 2070379  1108276
-SSUF04-SSUR22 Blank  57199     46879   0        0
-SSUF04-SSUR22 MC1    3162379   2633321 77       0
-SSUF04-SSUR22 MC2    2790363   2370732 280      0
-SSUF04-SSUR22 MC3    1953138   1640045 52       0
-============= ====== ========= ======= ======== ==========
+============= ====== ========= ======= ======== ========= ==========
+#marker       sample Raw FASTQ Flash   Cutadapt Threshold Read count
+============= ====== ========= ======= ======== ========= ==========
+D3Af-D3Br     Blank  1193593   1039205 0        25        0
+D3Af-D3Br     MC1    3897994   3317661 0        25        0
+D3Af-D3Br     MC2    4228233   3685150 0        25        0
+D3Af-D3Br     MC3    4309817   3864130 0        25        0
+JB3-JB5GED    Blank  69641     62060   0        25        0
+JB3-JB5GED    MC1    1236201   1157824 0        25        0
+JB3-JB5GED    MC2    2160885   2058441 1        25        0
+JB3-JB5GED    MC3    1204900   1139777 0        25        0
+NF1-18Sr2b    Blank  260778    218813  187776   188       115419
+NF1-18Sr2b    MC1    2483453   2126062 2109488  2110      689854
+NF1-18Sr2b    MC2    2349364   1985981 1972923  1973      745031
+NF1-18Sr2b    MC3    2435278   2088185 2070379  2071      766573
+SSUF04-SSUR22 Blank  57199     46879   0        25        0
+SSUF04-SSUR22 MC1    3162379   2633321 77       25        0
+SSUF04-SSUR22 MC2    2790363   2370732 280      25        0
+SSUF04-SSUR22 MC3    1953138   1640045 52       25        0
+============= ====== ========= ======= ======== ========= ==========
 
 You should find the raw FASTQ numbers match the author's Table 5, although
 that omits the blanks - which happily are all much lower.
@@ -59,9 +60,11 @@ trimmed with the NF1-18Sr2b primers, and happily we get high numbers only for
 the NF1-18Sr2b samples, but low levels from the other samples. That could be
 barcode leakage in the demultiplexing, or actual unwanted DNA in the samples.
 
-The final column highlighted here is the "Read count" after applying our
-minimum abundance threshold - and now we only get reads from the NF1-18Sr2b
-samples.
+Then we have our "Threshold" and the final column highlighted here is the
+"Read count" after applying our minimum abundance threshold - and now we only
+get reads from the NF1-18Sr2b samples. Most of the threshold values are the
+absolute threshold picked with ``-a 25`` while the larger thresholds are via
+``-f 0.001``, meaning at least 0.1% of the reads for that primer pair.
 
 We can repeat this for the other three primer sets, and the same pattern is
 observed - strong signal only for the matching samples (with the blanks giving

--- a/examples/drained_ponds/run.sh
+++ b/examples/drained_ponds/run.sh
@@ -28,8 +28,9 @@ fi
 
 echo "Running the pipeline"
 mkdir -p intermediate/ summary/
+# Fraction 0.001 means 0.1%
 thapbi_pict pipeline -i raw_data/ expected/ -s intermediate/ \
-            -o summary/drained_ponds -y '' -a 50 -d NCBI_12S.sqlite \
+            -o summary/drained_ponds -y '' -a 50 -f 0.001 -d NCBI_12S.sqlite \
             -t metadata.tsv -x 1 -c 5,6,7,8,9,10,4,2,3
 
 echo "Done"

--- a/examples/soil_nematodes/run.sh
+++ b/examples/soil_nematodes/run.sh
@@ -66,9 +66,11 @@ echo ================
 echo Running analysis
 echo ================
 
-thapbi_pict pipeline -d references/pooled.sqlite --merged-cache tmp_merged/ \
-            -i raw_data/ expected/ -s intermediate/ --synthetic '' \
-            -o summary/ -t metadata.tsv -x 1 -c 4,3
+# Fraction 0.001 means 0.1%
+thapbi_pict pipeline -d references/pooled.sqlite --synthetic '' \
+            -i raw_data/ expected/ --merged-cache tmp_merged/ \
+            -s intermediate/ -o summary/ -a 25 -f 0.001 \
+            -t metadata.tsv -x 1 -c 4,3
 
 echo ====
 echo Done

--- a/thapbi_pict/__init__.py
+++ b/thapbi_pict/__init__.py
@@ -24,4 +24,4 @@ automatically from the ``docs/`` folder of the `software repository
 within the source code which document the Python API.
 """
 
-__version__ = "0.10.2"
+__version__ = "0.10.3"

--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -205,6 +205,7 @@ def prepare_reads(args=None):
         spike_genus=args.synthetic,
         flip=args.flip,
         min_abundance=args.abundance,
+        min_abundance_fraction=args.abundance_fraction,
         ignore_prefixes=tuple(args.ignore_prefixes),
         merged_cache=args.merged_cache,
         tmp_dir=args.temp,
@@ -386,6 +387,7 @@ def pipeline(args=None):
         spike_genus=args.synthetic,
         flip=args.flip,
         min_abundance=args.abundance,
+        min_abundance_fraction=args.abundance_fraction,
         ignore_prefixes=tuple(args.ignore_prefixes),
         merged_cache=args.merged_cache,
         tmp_dir=args.temp,
@@ -718,10 +720,20 @@ ARG_CONTROLS = dict(  # noqa: C408
 # "-a", "--abundance",
 ARG_FASTQ_MIN_ABUNDANCE = dict(  # noqa: C408
     type=int,
+    metavar="INTEGER",
     default=str(DEFAULT_MIN_ABUNDANCE),
     help="Minimum abundance applied to unique marker sequences in each sample"
-    f" (i.e. each FASTQ pair), default {DEFAULT_MIN_ABUNDANCE}."
-    " May be increased based on negative controls.",
+    f" (i.e. each FASTQ pair). Default {DEFAULT_MIN_ABUNDANCE}, may be"
+    " increased based on negative controls.",
+)
+# "-f", "--abundance-fraction",
+ARG_FASTQ_NOISE_PERC = dict(  # noqa: C408
+    type=float,
+    metavar="FLOAT",
+    default="0",
+    help="Minimum abundance fraction, low frequency noise threshold applied"
+    " to unique marker sequences in each sample. Suggest 0.001 meaning 0.1%%,"
+    " default 0. Not applied to negative controls.",
 )
 
 # Common metadata arguments
@@ -862,6 +874,7 @@ def main(args=None):
         "(FASTQ pair). Defaults to -o / --output.",
     )
     subcommand_parser.add_argument("-a", "--abundance", **ARG_FASTQ_MIN_ABUNDANCE)
+    subcommand_parser.add_argument("-f", "--abundance-fraction", **ARG_FASTQ_NOISE_PERC)
     subcommand_parser.add_argument("-d", "--database", **ARG_DB_INPUT)
     subcommand_parser.add_argument("-y", "--synthetic", **ARG_SYNTHETIC_SPIKE)
     subcommand_parser.add_argument("--flip", **ARG_FLIP)
@@ -1174,6 +1187,7 @@ def main(args=None):
         help="Output directory. Required.",
     )
     subcommand_parser.add_argument("-a", "--abundance", **ARG_FASTQ_MIN_ABUNDANCE)
+    subcommand_parser.add_argument("-f", "--abundance-fraction", **ARG_FASTQ_NOISE_PERC)
     subcommand_parser.add_argument("-y", "--synthetic", **ARG_SYNTHETIC_SPIKE)
     subcommand_parser.add_argument("-d", "--database", **ARG_DB_INPUT)
     subcommand_parser.add_argument("--flip", **ARG_FLIP)

--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -780,7 +780,7 @@ ARG_METAGROUPS = dict(  # noqa: C408
     "will be together).",
 )
 
-# "-f", "--metafields",
+# "--metafields",
 ARG_METAFIELDS = dict(  # noqa: C408
     type=int,
     default="1",
@@ -871,7 +871,7 @@ def main(args=None):
     subcommand_parser.add_argument("-c", "--metacols", **ARG_METACOLS)
     subcommand_parser.add_argument("-x", "--metaindex", **ARG_METAINDEX)
     subcommand_parser.add_argument("-g", "--metagroups", **ARG_METAGROUPS)
-    subcommand_parser.add_argument("-f", "--metafields", **ARG_METAFIELDS)
+    subcommand_parser.add_argument("--metafields", **ARG_METAFIELDS)
     subcommand_parser.add_argument("--merged-cache", **ARG_MERGED_CACHE)
     subcommand_parser.add_argument("-q", "--requiremeta", **ARG_REQUIREMETA)
     subcommand_parser.add_argument("-u", "--unsequenced", **ARG_UNSEQUENCED)
@@ -1412,7 +1412,7 @@ def main(args=None):
     subcommand_parser.add_argument("-c", "--metacols", **ARG_METACOLS)
     subcommand_parser.add_argument("-x", "--metaindex", **ARG_METAINDEX)
     subcommand_parser.add_argument("-g", "--metagroups", **ARG_METAGROUPS)
-    subcommand_parser.add_argument("-f", "--metafields", **ARG_METAFIELDS)
+    subcommand_parser.add_argument("--metafields", **ARG_METAFIELDS)
     subcommand_parser.add_argument("-q", "--requiremeta", **ARG_REQUIREMETA)
     subcommand_parser.add_argument("-u", "--unsequenced", **ARG_UNSEQUENCED)
     subcommand_parser.add_argument("-v", "--verbose", **ARG_VERBOSE)
@@ -1528,7 +1528,7 @@ def main(args=None):
     subcommand_parser.add_argument("-e", "--metaencoding", **ARG_METAENCODING)
     subcommand_parser.add_argument("-c", "--metacols", **ARG_METACOLS)
     subcommand_parser.add_argument("-x", "--metaindex", **ARG_METAINDEX)
-    subcommand_parser.add_argument("-f", "--metafields", **ARG_METAFIELDS)
+    subcommand_parser.add_argument("--metafields", **ARG_METAFIELDS)
     subcommand_parser.add_argument(
         "--library",
         type=str,


### PR DESCRIPTION
Using e.g. 0.1% as a threshold (``-f 0.001``) makes a massive different to the high read depth ``soil_nematodes/`` example, before:

```
$ grep -c "^>" summary/*.fasta
summary/D3Af-D3Br.all_reads.fasta:3806
summary/JB3-JB5GED.all_reads.fasta:663
summary/NF1-18Sr2b.all_reads.fasta:2008
summary/SSUF04-SSUR22.all_reads.fasta:2607
```

and after:

```
$ grep -c "^>" summary/*.fasta
summary/D3Af-D3Br.all_reads.fasta:130
summary/JB3-JB5GED.all_reads.fasta:59
summary/NF1-18Sr2b.all_reads.fasta:112
summary/SSUF04-SSUR22.all_reads.fasta:97
```

This seems more useful than an absolute threshold if there was unequal loading between samples/markers. However, in that circumstance the default approach to raising the absolute threshold based on contaminated negative controls becomes more complicated...

Right now this deliberately does not apply the fraction/percentage threshold to the negative controls.