### PR TITLE
Make a single call to mamba install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
             # For installing the Python requirements either conda or pip should work,
             # but conda preferable if there are packages with C code but no wheel
             # python -m pip install -r requirements.txt
-            mamba install curl --file requirements.txt -file requirements-ext.txt
+            mamba install curl --file requirements.txt --file requirements-ext.txt
       - run:
           name: Installation
           command: |


### PR DESCRIPTION
Should be faster than conda install.