### PR TITLE
Multi-marker reporting WIP

### DIFF
--- a/docs/examples/fungal_mock/presence_absence.rst
+++ b/docs/examples/fungal_mock/presence_absence.rst
@@ -83,6 +83,7 @@ sequences. At the command line:
 .. code:: console
 
     $ cat intermediate/AL1/BITS-B58S3/SRR5314317.fasta
+    #marker:BITS-B58S3
     #left_primer:ACCTGCGGARGGATC
     #right_primer:GAGATCCRTTGYTRAAAGTT
     #raw_fastq:12564
@@ -103,6 +104,7 @@ Using a minimum of 10 has excluded lots of singletons etc here.
 .. code:: console
 
     $ cat intermediate/AL1/BITS-B58S3/SRR5314316.fasta
+    #marker:BITS-B58S3
     #left_primer:ACCTGCGGARGGATC
     #right_primer:GAGATCCRTTGYTRAAAGTT
     #raw_fastq:16297
@@ -136,6 +138,7 @@ a pale blue background in the Excel reports). Working at the terminal:
 .. code:: console
 
     $ cat intermediate/AL1/BITS-B58S3/SRR5314315.fasta
+    #marker:BITS-B58S3
     #left_primer:ACCTGCGGARGGATC
     #right_primer:GAGATCCRTTGYTRAAAGTT
     #raw_fastq:19406
@@ -152,6 +155,7 @@ The minimum abundance excluded lots of singletons etc.
 .. code:: console
 
     $ cat intermediate/AL1/BITS-B58S3/SRR5314314.fasta
+    #marker:BITS-B58S3
     #left_primer:ACCTGCGGARGGATC
     #right_primer:GAGATCCRTTGYTRAAAGTT
     #raw_fastq:7285

--- a/docs/examples/great_lakes/abundance.rst
+++ b/docs/examples/great_lakes/abundance.rst
@@ -125,6 +125,7 @@ read report - or look directly at the intermediate FASTA files:
 .. code:: console
 
     $ cat intermediate/MOL16S/SRR5534986.fasta
+    #marker:MOL16S
     #left_primer:RRWRGACRAGAAGACCCT
     #right_primer:ARTCCAACATCGAGGT
     #raw_fastq:2433
@@ -173,6 +174,7 @@ read report, or at the command line:
 .. code:: console
 
     $ cat intermediate/MOL16S/SRR5534980.fasta
+    #marker:MOL16S
     #left_primer:RRWRGACRAGAAGACCCT
     #right_primer:ARTCCAACATCGAGGT
     #raw_fastq:410780

--- a/docs/examples/recycled_water/primers.rst
+++ b/docs/examples/recycled_water/primers.rst
@@ -67,6 +67,7 @@ a reservoir. Here is with the default primer trimming:
 .. code:: console
 
     $ cat intermediate_defaults/ITS1/SRR6303586.fasta
+    #marker:ITS1
     #left_primer:GAAGGTGAAGTCGTAACAAGG
     #right_primer:GCARRGACTTTCGTCCCYRC
     #raw_fastq:70396
@@ -101,6 +102,7 @@ header, we again get four sequences passing the abundance threshold:
 .. code:: console
 
     $ cat intermediate_long/ITS1-long/SRR6303586.fasta
+    #marker:ITS1-long
     #left_primer:GAAGGTGAAGTCGTAACAAGGTTTCCGTAGGTGAACCTGCGGAAGGATCATTA
     #right_primer:AGCGTTCTTCATCGATGTGC
     #raw_fastq:70396

--- a/docs/examples/woody_hosts/prepare.rst
+++ b/docs/examples/woody_hosts/prepare.rst
@@ -82,7 +82,8 @@ the paired FASTQ files, down to just 4180 after processing.
 
 .. code:: console
 
-    $ head -n 9 intermediate/ITS1/Site_1_sample_1.fasta
+    $ head -n 10 intermediate/ITS1/Site_1_sample_1.fasta
+    #marker:ITS1
     #left_primer:GAAGGTGAAGTCGTAACAAGG
     #right_primer:GCARRGACTTTCGTCCCYRC
     #raw_fastq:6136

--- a/tests/multi_marker/intermediate/16S/EM_1_sample.fasta
+++ b/tests/multi_marker/intermediate/16S/EM_1_sample.fasta
@@ -1,3 +1,4 @@
+#marker:16S
 #left_primer:CGCCTGTTTATCAAAAACAT
 #right_primer:CCGGTCTGAACTCAGATCACGT
 #raw_fastq:264

--- a/tests/multi_marker/intermediate/ITS2/EM_1_sample.fasta
+++ b/tests/multi_marker/intermediate/ITS2/EM_1_sample.fasta
@@ -1,3 +1,4 @@
+#marker:ITS2
 #left_primer:ATGCGATACTTGGTGTGAAT
 #right_primer:GACGCTTCTCCAGACTACAAT
 #raw_fastq:264

--- a/tests/multi_marker/intermediate/Mini-16S/EM_1_sample.fasta
+++ b/tests/multi_marker/intermediate/Mini-16S/EM_1_sample.fasta
@@ -1,3 +1,4 @@
+#marker:Mini-16S
 #left_primer:AYAAGACGAGAAGACCC
 #right_primer:GATTGCGCTGTTATTCC
 #raw_fastq:264

--- a/tests/multi_marker/intermediate/Mini-COI/EM_1_sample.fasta
+++ b/tests/multi_marker/intermediate/Mini-COI/EM_1_sample.fasta
@@ -1,3 +1,4 @@
+#marker:Mini-COI
 #left_primer:GGWACWGGWTGAACWGTWTAYCCYCC
 #right_primer:TAIACYTCIGGRTGICCRAARAAYCA
 #raw_fastq:264

--- a/tests/multi_marker/intermediate/Mini-cyt-b/EM_1_sample.fasta
+++ b/tests/multi_marker/intermediate/Mini-cyt-b/EM_1_sample.fasta
@@ -1,3 +1,4 @@
+#marker:Mini-cyt-b
 #left_primer:CCATCCAACATCTCAGCATGATGAAA
 #right_primer:CCCTCAGAATGATATTTGTCCTCA
 #raw_fastq:264

--- a/tests/multi_marker/intermediate/Mini-rbcL/EM_1_sample.fasta
+++ b/tests/multi_marker/intermediate/Mini-rbcL/EM_1_sample.fasta
@@ -1,3 +1,4 @@
+#marker:Mini-rbcL
 #left_primer:GTTGGATTCAAAGCTGGTGTTA
 #right_primer:CVGTCCAMACAGTWGTCCATGT
 #raw_fastq:264

--- a/tests/multi_marker/intermediate/rbcL/EM_1_sample.fasta
+++ b/tests/multi_marker/intermediate/rbcL/EM_1_sample.fasta
@@ -1,3 +1,4 @@
+#marker:rbcL
 #left_primer:ATGTCACCACAAACAGAGACTAAAGC
 #right_primer:GTAAAATCAAGTCCACCRCG
 #raw_fastq:264

--- a/tests/multi_marker/intermediate/trnL-P6-loop/EM_1_sample.fasta
+++ b/tests/multi_marker/intermediate/trnL-P6-loop/EM_1_sample.fasta
@@ -1,3 +1,4 @@
+#marker:trnL-P6-loop
 #left_primer:GGGCAATCCTGAGCCAA
 #right_primer:CCATTGAGTCTCTGCACCTATC
 #raw_fastq:264

--- a/tests/multi_marker/intermediate/trnL-UAA/EM_1_sample.fasta
+++ b/tests/multi_marker/intermediate/trnL-UAA/EM_1_sample.fasta
@@ -1,3 +1,4 @@
+#marker:trnL-UAA
 #left_primer:CGAAATCGGTAGACGCTACG
 #right_primer:GGGGATAGAGGGACTTGAAC
 #raw_fastq:264

--- a/tests/nematodes/sample_flip_a10.fasta
+++ b/tests/nematodes/sample_flip_a10.fasta
@@ -1,3 +1,4 @@
+#marker:Nema
 #left_primer:CTGCTGCTGGATCATTACCC
 #right_primer:CGCCAGCACAGCCGTTAG
 #raw_fastq:50

--- a/tests/nematodes/sample_noflip_a10.fasta
+++ b/tests/nematodes/sample_noflip_a10.fasta
@@ -1,3 +1,4 @@
+#marker:Nema
 #left_primer:CTGCTGCTGGATCATTACCC
 #right_primer:CGCCAGCACAGCCGTTAG
 #raw_fastq:50

--- a/tests/prepare-reads/6e847180a4da6eed316e1fb98b21218f.fasta
+++ b/tests/prepare-reads/6e847180a4da6eed316e1fb98b21218f.fasta
@@ -1,3 +1,4 @@
+#marker:ITS1
 #left_primer:GAAGGTGAAGTCGTAACAAGG
 #right_primer:GCARRGACTTTCGTCCCYRC
 #raw_fastq:1

--- a/tests/prepare-reads/DNAMIX_S95_L001.fasta
+++ b/tests/prepare-reads/DNAMIX_S95_L001.fasta
@@ -1,3 +1,4 @@
+#marker:ITS1
 #left_primer:GAAGGTGAAGTCGTAACAAGG
 #right_primer:GCARRGACTTTCGTCCCYRC
 #raw_fastq:5159

--- a/tests/prepare-reads/SRR6303948_sample_default.fasta
+++ b/tests/prepare-reads/SRR6303948_sample_default.fasta
@@ -1,3 +1,4 @@
+#marker:ITS1
 #left_primer:GAAGGTGAAGTCGTAACAAGG
 #right_primer:GCARRGACTTTCGTCCCYRC
 #raw_fastq:238

--- a/tests/prepare-reads/SRR6303948_sample_primers.fasta
+++ b/tests/prepare-reads/SRR6303948_sample_primers.fasta
@@ -1,3 +1,4 @@
+#marker:ITS1
 #left_primer:GAAGGTGAAGTCGTAACAAGG
 #right_primer:AGCGTTCTTCATCGATGTGC
 #raw_fastq:238

--- a/thapbi_pict/prepare.py
+++ b/thapbi_pict/prepare.py
@@ -512,6 +512,7 @@ def merge_paired_reads(
 def prepare_sample(
     fasta_name,
     trimmed_fasta,
+    marker,
     left_primer,
     right_primer,
     min_len,
@@ -600,6 +601,7 @@ def prepare_sample(
         gzipped=False,
         spikes=spikes,
         header_dict={
+            "marker": marker,
             "left_primer": left_primer,
             "right_primer": right_primer,
             "raw_fastq": count_raw,
@@ -754,6 +756,7 @@ def marker_cut(
             uniq_count, total, max_abundance_by_spike, min_a = prepare_sample(
                 fasta_name,
                 os.path.join(tmp, f"{stem}.{marker}.fasta"),
+                marker,
                 marker_values["left_primer"],
                 marker_values["right_primer"],
                 marker_values["min_length"],


### PR DESCRIPTION
In order to produce multi-marker reports, we need to know which marker the intermediate FASTA files (and associated TSV file) belong to. This is currently implicit in the file paths, typically ``intermediate/*marker*/*sample*.fasta`` but can be added explicitly to the FASTA files' header.