### PR TITLE
Revert to building variant cloud for small DB

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Release History
 ======= ========== ============================================================================
 Version Date       Notes
 ======= ========== ============================================================================
+v0.10.6 2022-01-12 Fixed slow-down in v0.10.0 on large datasets with small DB.
 v0.10.5 2021-12-23 Default for ``-f`` / ``--abundance-fraction`` is now 0.001, meaning 0.1%.
 v0.10.4 2021-11-24 Updates to default curated DB, including newer NCBI taxonomy.
 v0.10.3 2021-11-19 New ``-f`` / ``--abundance-fraction`` setting, off by default.

--- a/thapbi_pict/__init__.py
+++ b/thapbi_pict/__init__.py
@@ -24,4 +24,4 @@ automatically from the ``docs/`` folder of the `software repository
 within the source code which document the Python API.
 """
 
-__version__ = "0.10.5"
+__version__ = "0.10.6"


### PR DESCRIPTION
Closes #414, this optimisation is important for large query sets (e.g. low abundance threshold, or vast number of samples), especially with smaller databases (e.g. exploring a new dataset and building an ad-hoc DB).

Also reverts to storing integer MD5 hashes in the fuzzy dict, not plain sequence strings, with the values a list of matches.

(I suspect the old code missed a corner case for close IUPAC ambiguous sequences)