### PR TITLE
python-Levenshtein --> rapidfuzz

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Release History
 ======= ========== ============================================================================
 Version Date       Notes
 ======= ========== ============================================================================
+v0.11.1 2022-01-18 Using ``rapidfuzz`` rather than ``python-Levenshtein``.
 v0.11.0 2022-01-13 Multi-marker reports, pooling predictions from each marker.
 v0.10.6 2022-01-12 Fixed slow-down in v0.10.0 on large datasets with small DB.
 v0.10.5 2021-12-23 Default for ``-f`` / ``--abundance-fraction`` is now 0.001, meaning 0.1%.

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,6 @@ cutadapt >= 3.4
 matplotlib
 networkx >= 2.4
 pydot
-python-levenshtein
+rapidfuzz
 sqlalchemy
 xlsxwriter

--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,7 @@ setup(
         "matplotlib",
         "networkx",
         "pydot",
-        "python-levenshtein",
+        "rapidfuzz",
         "sqlalchemy",
         "xlsxwriter",
     ],

--- a/thapbi_pict/__init__.py
+++ b/thapbi_pict/__init__.py
@@ -24,4 +24,4 @@ automatically from the ``docs/`` folder of the `software repository
 within the source code which document the Python API.
 """
 
-__version__ = "0.11.0"
+__version__ = "0.11.1"

--- a/thapbi_pict/classify.py
+++ b/thapbi_pict/classify.py
@@ -15,7 +15,7 @@ from collections import Counter
 from collections import OrderedDict
 
 from Bio.SeqIO.FastaIO import SimpleFastaParser
-from Levenshtein import distance as levenshtein
+from rapidfuzz.string_metric import levenshtein
 
 from .db_orm import MarkerDef
 from .db_orm import MarkerSeq

--- a/thapbi_pict/edit_graph.py
+++ b/thapbi_pict/edit_graph.py
@@ -14,7 +14,7 @@ import matplotlib.pyplot as plt
 import networkx as nx
 import numpy as np
 from Bio.SeqIO.FastaIO import SimpleFastaParser
-from Levenshtein import distance as levenshtein
+from rapidfuzz.string_metric import levenshtein
 from sqlalchemy.orm import aliased
 from sqlalchemy.orm import contains_eager
 


### PR DESCRIPTION
The original python-Levenshtein library we were using https://github.com/ztane/python-Levenshtein was not being maintained, with no pre-compiled wheels available on PyPI, nor Python 3.10 support.

The fork https://github.com/maxbachmann/Levenshtein/ did have wheels but changed the name on PyPI and is not (yet) available on conda. However, it was now a wrapper for the author's https://github.com/maxbachmann/RapidFuzz which we can call directly.

RapidFuzz is availble on both PyPI (with wheels) and conda (again, via conda-forge).

This should help with installation on Windows, issue #426.