### PR TITLE
Bug fix for an empty sample

### DIFF
--- a/thapbi_pict/prepare.py
+++ b/thapbi_pict/prepare.py
@@ -621,14 +621,15 @@ def prepare_sample(
         )
     assert bool(sum(max_spike_abundance.values())) == bool(accepted_uniq_count)
     if debug:
-        sys.stderr.write(
-            "DEBUG:"
-            f" FASTQ pairs {count_raw}; flash -> {count_flash};"
-            f" cutadapt -> {count_cutadapt} [{uniq_count} unique];"
-            f" min abundance {min_abundance} -> {accepted_total}"
-            f" [{accepted_uniq_count} unique]"
-            f", or {accepted_total*100.0/count_raw:0.1f}%\n"
-        )
+        if count_raw:
+            sys.stderr.write(
+                "DEBUG:"
+                f" FASTQ pairs {count_raw}; flash -> {count_flash};"
+                f" cutadapt -> {count_cutadapt} [{uniq_count} unique];"
+                f" min abundance {min_abundance} -> {accepted_total}"
+                f" [{accepted_uniq_count} unique]"
+                f", or {accepted_total*100.0/count_raw:0.1f}%\n"
+            )
         if accepted_uniq_count:
             sys.stderr.write(
                 f"From {count_raw} paired FASTQ reads,"

--- a/thapbi_pict/prepare.py
+++ b/thapbi_pict/prepare.py
@@ -719,19 +719,29 @@ def marker_cut(
             )
             time_flash += time() - start
 
-            # Run cutadapt to cut primers (giving one output per marker)
-            start = time()
-            unique_merged_, unique_cutadapt_ = run_cutadapt(
-                merged_fasta_gz,
-                os.path.join(
-                    tmp, stem + ".{name}.fasta"
-                ),  # template - leave {name} as is!
-                marker_definitions,
-                flip=flip,
-                debug=debug,
-                cpu=cpu,
-            )
-            time_cutadapt += time() - start
+            if count_flash:
+                # Run cutadapt to cut primers (giving one output per marker)
+                start = time()
+                unique_merged_, unique_cutadapt_ = run_cutadapt(
+                    merged_fasta_gz,
+                    # Here {name} is the cutadapt filename template:
+                    os.path.join(tmp, stem + ".{name}.fasta"),
+                    marker_definitions,
+                    flip=flip,
+                    debug=debug,
+                    cpu=cpu,
+                )
+                time_cutadapt += time() - start
+            else:
+                # More fiddly, but could skip the abundance code below too?
+                # Just make an empty file for prepare_sample to parse.
+                if debug:
+                    sys.stderr.write("DEBUG: Skipping cutadapt as no reads\n")
+                for marker in marker_definitions:
+                    with open(
+                        os.path.join(tmp, f"{stem}.{marker}.fasta"), "w"
+                    ) as handle:
+                        handle.write("#Nothing\n")
 
         # Apply abundance thresholds
         start = time()


### PR DESCRIPTION
One of our datasets has "empty" samples, one of which has literally zero merged FASTQ pairs after flash.

That caused a divide by zero error in a debug message, and there was no point in calling cutadapt on that sample (and doing so was failing cryptically). 