### PR TITLE
Fix dynamic k-mer threshold

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Release History
 ======= ========== ============================================================================
 Version Date       Notes
 ======= ========== ============================================================================
+v0.11.3 2022-02-01 Fix dynamic *k*-mer threshold for synthetic spike-in control sequences.
 v0.11.2 2022-01-20 Windows testing on AppVeyor, with minor Windows specific fixes.
 v0.11.1 2022-01-18 Using ``rapidfuzz`` rather than ``python-Levenshtein``.
 v0.11.0 2022-01-13 Multi-marker reports, pooling predictions from each marker.

--- a/thapbi_pict/__init__.py
+++ b/thapbi_pict/__init__.py
@@ -24,4 +24,4 @@ automatically from the ``docs/`` folder of the `software repository
 within the source code which document the Python API.
 """
 
-__version__ = "0.11.2"
+__version__ = "0.11.3"

--- a/thapbi_pict/prepare.py
+++ b/thapbi_pict/prepare.py
@@ -383,7 +383,7 @@ def is_spike_in(sequence, spikes):
             return spike_name
         # This will not work when len(spike) <~ kmer length
         # (fail gracefully with an impossible to meet value of 10)
-        threshold = min((len(spike_seq) - KMER_LENGTH) / 3, 10)
+        threshold = max((len(spike_seq) - KMER_LENGTH) / 3, 10)
         if has_enough_kmers(sequence, spike_kmers, threshold, KMER_LENGTH):
             return spike_name
     return ""


### PR DESCRIPTION
This fixes the k-mer threshold for finding spike-in sequences, problem traced to a min vs max typo.
    
The original code was wrongly using 10 all the time, meaning with 31-mers a match could be called with just a 40bp match.
    
This was not picked up on our own spike-in datasets, but did raise a false match on Palmer et al. (2018) for a *Saccharomyces cerevisiae* sequence in BioMockStds SRR7109326, where the last 40bp matched their mock_2. Note their synthetic spike-in sequences were based on *Saccharomyces cerevisiae*, so this makes sense.

