### PR TITLE
Sample report missing field fix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Release History
 ======= ========== ============================================================================
 Version Date       Notes
 ======= ========== ============================================================================
+v0.12.1 2022-05-18 Fix missing field regression on reports including unsequenced samples.
 v0.12.0 2022-04-19 Synthetic spike-ins can set fractional abundance threshold. Cutadapt v4.0+.
 v0.11.6 2022-03-09 Fix regression on reports including unsequenced samples.
 v0.11.5 2022-02-18 Reporting enhancements when using spike-in (synthetic) controls.

--- a/tests/summary_meta/summary-qu.samples.1s3g.tsv
+++ b/tests/summary_meta/summary-qu.samples.1s3g.tsv
@@ -4,5 +4,5 @@ A	Alpha	A2	Phytophthora andina(*), Phytophthora infestans(*), Phytophthora ipomo
 B	Beta	B1	Phytophthora plurivora, Phytophthora rubi	5159	4547	4544	100	1789	2	0	0	976	0	813	0
 B	Beta	B1r	Phytophthora plurivora, Phytophthora rubi	5193	4781	4642	100	1803	2	0	0	1013	0	790	0
 C	Gamma	C1	Phytophthora agathidicida(*), Phytophthora castaneae(*), Phytophthora pseudocryptogea	3289	3547	3584	100	597	2	298	0	0	299	0	0
-D	Delta	-	-	-	-	-	-	-	-	-	-	-	-	-
-E	Epsilon	-	-	-	-	-	-	-	-	-	-	-	-	-
+D	Delta	-	-	-	-	-	-	-	-	-	-	-	-	-	-
+E	Epsilon	-	-	-	-	-	-	-	-	-	-	-	-	-	-

--- a/tests/summary_meta/summary-u.samples.1s3g.tsv
+++ b/tests/summary_meta/summary-u.samples.1s3g.tsv
@@ -4,7 +4,7 @@ A	Alpha	A2	Phytophthora andina(*), Phytophthora infestans(*), Phytophthora ipomo
 B	Beta	B1	Phytophthora plurivora, Phytophthora rubi	5159	4547	4544	100	1789	2	0	0	0	976	0	813	0
 B	Beta	B1r	Phytophthora plurivora, Phytophthora rubi	5193	4781	4642	100	1803	2	0	0	0	1013	0	790	0
 C	Gamma	C1	Phytophthora agathidicida(*), Phytophthora castaneae(*), Phytophthora pseudocryptogea	3289	3547	3584	100	597	2	298	0	0	0	299	0	0
-D	Delta	-	-	-	-	-	-	-	-	-	-	-	-	-	-
-E	Epsilon	-	-	-	-	-	-	-	-	-	-	-	-	-	-
+D	Delta	-	-	-	-	-	-	-	-	-	-	-	-	-	-	-
+E	Epsilon	-	-	-	-	-	-	-	-	-	-	-	-	-	-	-
 		X1	Phytophthora agathidicida(*), Phytophthora castaneae(*), Phytophthora pseudocryptogea	3159	3547	3544	100	597	2	298	0	0	0	299	0	0
 		Y1	Phytophthora capsici(*), Phytophthora glovera(*)	2159	2547	2544	100	290	1	0	0	290	0	0	0	0

--- a/thapbi_pict/__init__.py
+++ b/thapbi_pict/__init__.py
@@ -24,4 +24,4 @@ automatically from the ``docs/`` folder of the `software repository
 within the source code which document the Python API.
 """
 
-__version__ = "0.12.0"
+__version__ = "0.12.1"

--- a/thapbi_pict/summary.py
+++ b/thapbi_pict/summary.py
@@ -254,7 +254,7 @@ def sample_summary(
         if not sample_batch and show_unsequenced:
             human.write("Has not been sequenced.\n\n")
             # Missing data in TSV:
-            blanks = len(stats_fields) + 3 + len(species_predictions)
+            blanks = len(stats_fields) + 4 + len(species_predictions)
             # Using "-" for missing data, could use "NA" or "?"
             handle.write("\t".join(metadata) + ("\t" + MISSING_DATA) * blanks + "\n")
             # Missing data in Excel:


### PR DESCRIPTION
Looks like an oversight in the v0.11.6 fix, was left with one less field than should have been present for unsequenced samples. Spotted this as the missing field was breaking the pooling script (and the ``xsv table`` command).