### PR TITLE
Use RapidFuzz cdist instead of Levenshtein distance in inner loop

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,6 @@ cutadapt >=4.0
 matplotlib
 networkx >=2.4,!=2.8.3,!=2.8.4
 pydot
-rapidfuzz >=2.0.0
+rapidfuzz >=2.4.0
 sqlalchemy
 xlsxwriter

--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,7 @@ setup(
         "matplotlib",
         "networkx >=2.4,!=2.8.3,!=2.8.4",
         "pydot",
-        "rapidfuzz >=2.0.0",
+        "rapidfuzz >=2.4.0",
         "sqlalchemy",
         "xlsxwriter",
     ],

--- a/thapbi_pict/classify.py
+++ b/thapbi_pict/classify.py
@@ -15,6 +15,7 @@ from collections import Counter
 from collections import OrderedDict
 
 from Bio.SeqIO.FastaIO import SimpleFastaParser
+from numpy import int8
 from rapidfuzz.distance import Levenshtein
 from rapidfuzz.process import cdist
 
@@ -422,12 +423,13 @@ def dist_in_db(session, marker_name, seq, debug=False):
     best = set()
     # Any matches are at least 2bp away, will take genus only.
     # Fall back on brute force! But only on a minority of cases
+    assert max_dist_genus >= 2, max_dist_genus
     dists = cdist(
         [seq],
         db_seqs,
         scorer=Levenshtein.distance,
-        # dtype=int8,
-        # score_cutoff=max_dist_genus + 1,
+        dtype=int8,
+        score_cutoff=max_dist_genus,
     )[0, :]
     min_dist = min(dists)
     assert min_dist > 1  # Should have caught via onebp_match_in_db!


### PR DESCRIPTION
This speeds up the distance based classifiers by moving the Levenshtein distance inner loop from Python to compiled code. Now uses RapidFuzz cdist instead of calling Levenshtein distance function in an inner loop.

With refactoring, could make a single cdist call to compare all the query sequences to all the databases sequences in one go. For now, still have the outer loop over the query sequences.

Requires rapidfuzz>=2.4.0 to use with score_cutoff for better speed,
see https://github.com/maxbachmann/RapidFuzz/issues/259
