### PR TITLE
Accept .fq or .fq.gz in addition to .fastq(.gz)

### DIFF
--- a/tests/test_prepare-reads.sh
+++ b/tests/test_prepare-reads.sh
@@ -65,16 +65,16 @@ echo "Generating mock control file"
 rm -rf $TMP/pool/
 mkdir  $TMP/pool/
 cp tests/reads/DNAMIX_S95_L001_*.fastq.gz $TMP/pool/
-# Using just 50 real reads (50 * 4 = 200 lines)
+# Using just 50 real reads (50 * 4 = 200 lines), and alternative extension
 set +o pipefail
-cat tests/reads/DNAMIX_S95_L001_R1_001.fastq.gz | gunzip | head -n 200 > $TMP/pool/MOCK_CONTROL_R1.fastq
-cat tests/reads/DNAMIX_S95_L001_R2_001.fastq.gz | gunzip | head -n 200 > $TMP/pool/MOCK_CONTROL_R2.fastq
+cat tests/reads/DNAMIX_S95_L001_R1_001.fastq.gz | gunzip | head -n 200 > $TMP/pool/MOCK_CONTROL_R1.fq
+cat tests/reads/DNAMIX_S95_L001_R2_001.fastq.gz | gunzip | head -n 200 > $TMP/pool/MOCK_CONTROL_R2.fq
 set -o pipefail
 
 # Starting low threshold, should be increased to 19, so get new output count...
 rm -rf $TMP/ITS1
 rm -rf $TMP/MOCK_CONTROL.fasta
-thapbi_pict prepare-reads -o $TMP -i $TMP/pool/ -a 5 -n $TMP/pool/MOCK_CONTROL_R?.fastq
+thapbi_pict prepare-reads -o $TMP -i $TMP/pool/ -a 5 -n $TMP/pool/MOCK_CONTROL_R?.fq
 if [ `grep -c "^>" $TMP/MOCK_CONTROL.fasta` -ne "1" ]; then echo "Wrong FASTA control output count"; false; fi
 if [ `grep -c "^>" $TMP/ITS1/DNAMIX_S95_L001.fasta` -ne "9" ]; then echo "Wrong FASTA output count"; false; fi
 

--- a/thapbi_pict/prepare.py
+++ b/thapbi_pict/prepare.py
@@ -39,7 +39,10 @@ KMER_LENGTH = 31
 
 
 def find_fastq_pairs(
-    filenames_or_folders, ext=(".fastq", ".fastq.gz"), ignore_prefixes=None, debug=False
+    filenames_or_folders,
+    ext=(".fastq", ".fastq.gz", ".fq", ".fq.gz"),
+    ignore_prefixes=None,
+    debug=False,
 ):
     """Interpret a list of filenames and/or foldernames.
 


### PR DESCRIPTION
Does not add tests, does not check if the extensions match - e.g. should/would ``example_R1.fastq.gz`` with ``example_R2.fq.gz`` work?