### PR TITLE
Cap tools by available CPUs

### DIFF
--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -679,9 +679,9 @@ ARG_VERBOSE = dict(action="store_true", help="Verbose logging.")  # noqa: C408
 # "--cpu",
 ARG_CPU = dict(  # noqa: C408
     type=int,
-    default=4,
+    default=1,
     help="Number of parallel threads to use in called tools. "
-    "Use zero for all available. Default 4.",
+    "Use zero for all available. Default 1.",
 )
 
 # Common import arguments

--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -679,9 +679,9 @@ ARG_VERBOSE = dict(action="store_true", help="Verbose logging.")  # noqa: C408
 # "--cpu",
 ARG_CPU = dict(  # noqa: C408
     type=int,
-    default=0,
+    default=4,
     help="Number of parallel threads to use in called tools. "
-    "Default zero is use all available.",
+    "Use zero for all available. Default 4.",
 )
 
 # Common import arguments

--- a/thapbi_pict/prepare.py
+++ b/thapbi_pict/prepare.py
@@ -281,9 +281,8 @@ def run_flash(trimmed_R1, trimmed_R2, output_dir, output_prefix, debug=False, cp
     # Also, some of our samples are mostly 'outies' rather than 'innies', so -O
     cmd = ["flash", "-O", "-M", "300"]
     if cpu:
-        cmd += ["--threads", str(cpu)]
-    else:
-        cmd += ["-t", "1"]  # Default is all CPUs
+        # Default is all CPUs
+        cmd += ["-t", str(cpu)]
     cmd += ["-d", output_dir, "-o", output_prefix, trimmed_R1, trimmed_R2]
     return parse_flash_stdout(run(cmd, debug=debug).stdout)
 


### PR DESCRIPTION
Note can't use ``os.sched_getaffinity(...)`` on macOS or Windows but this works nicely under SLURM (etc) on Linux.

What should our default be though? Currently it is effectively 1 for both ``flash`` (via our code) and ``blastn`` (their default).