### PR TITLE
Always replace classifier output

### DIFF
--- a/examples/clean_all.sh
+++ b/examples/clean_all.sh
@@ -15,7 +15,8 @@ for example in `grep "/index" ../docs/examples/index.rst | cut -f 1 -d "/" | cut
     # Do not touch woody_hosts/intermediate.tar.bz2
     rm -rf $example/intermediate $example/intermediate_*
 
-    # The classifier TSV is not (currently) overwritten by default:
+    # Originally classifier TSV wasn't overwritten by default:
+    rm -rf $example/summary/*.all_reads.fasta
     rm -rf $example/summary/*.all_reads.*.tsv
 
     # The XGMML files are not overwritten by default

--- a/thapbi_pict/classify.py
+++ b/thapbi_pict/classify.py
@@ -767,6 +767,11 @@ def main(
         else:
             output_name = os.path.join(out_dir, f"{stem}.{method}.tsv")
 
+        if output_name in classifier_output:
+            sys.exit(
+                f"ERROR: Filename stem clash, multiple outputs named {output_name}"
+            )
+
         classifier_output.append(output_name)
 
         if setup_fn:

--- a/thapbi_pict/classify.py
+++ b/thapbi_pict/classify.py
@@ -769,27 +769,6 @@ def main(
 
         classifier_output.append(output_name)
 
-        if output_name is not None and os.path.isfile(output_name):
-            skipped_samples.add(output_name)
-            if debug:
-                sys.stderr.write(f"Skipping {output_name} as already done\n")
-            # Count the number of sequences and matches
-            with open(output_name) as handle:
-                for line in handle:
-                    if line.startswith("#"):
-                        continue
-                    parts = line.rstrip("\n").split("\t")
-                    # MD5_abundance, taxids, species, notes
-                    a = abundance_from_read_name(parts[0])
-                    if min_abundance and a < min_abundance:
-                        del a
-                        continue
-                    seq_count += a
-                    if parts[2].strip():
-                        match_count += a
-                    del a, parts
-            continue
-
         if setup_fn:
             # There are some files still to process, do setup now (once only)
             setup_fn(session, marker_name, shared_tmp, debug, cpu)


### PR DESCRIPTION
The old behaviour made sense when we had one TSV per sample (interrupting and resuming a large sample set), but is not helpful with the current pipeline pooling all samples into ``<stem>.all_reads.fasta`` as input to the classifier.