### PR TITLE
Use sample-tally TSV in place of FASTA inputs to edit-graph

### DIFF
--- a/docs/examples/woody_hosts/edit_graph.rst
+++ b/docs/examples/woody_hosts/edit_graph.rst
@@ -14,11 +14,12 @@ This is not run as part of the pipeline command, but must be run separately:
     ...
 
 This command does not use metadata, but can optionally use the intermediate
-TSV files. It requires the FASTA files:
+TSV files. It requires the sample tally file:
 
 .. code:: console
 
-    $ thapbi_pict edit-graph -i intermediate/ -o summary/thapbi-pict.edit-graph.onebp.xgmml
+    $ thapbi_pict edit-graph -i summary/thapbi-pict.ITS1.tally.tsv \
+        -o summary/thapbi-pict.edit-graph.onebp.xgmml
     ...
 
 This will generate an XGMML (eXtensible Graph Markup and Modeling Language)
@@ -27,7 +28,8 @@ file by default, but you can also request other formats including PDF
 
 .. code:: console
 
-    $ thapbi_pict edit-graph -i intermediate/ -o summary/thapbi-pict.edit-graph.onebp.pdf -f pdf
+    $ thapbi_pict edit-graph -i summary/thapbi-pict.ITS1.tally.tsv \
+          -o summary/thapbi-pict.edit-graph.onebp.pdf -f pdf
     ...
 
 .. WARNING:

--- a/docs/examples/woody_hosts/pipeline.rst
+++ b/docs/examples/woody_hosts/pipeline.rst
@@ -27,6 +27,7 @@ command as follows, and should get multiple output report files:
     summary/thapbi-pict.ITS1.reads.onebp.xlsx
     summary/thapbi-pict.ITS1.samples.onebp.tsv
     summary/thapbi-pict.ITS1.samples.onebp.xlsx
+    summary/thapbi-pict.ITS1.tally.tsv
     summary/thapbi-pict.edit-graph.onebp.pdf
     summary/thapbi-pict.edit-graph.onebp.xgmml
 
@@ -69,6 +70,7 @@ against any expected sample species classifications:
     summary/with-metadata.ITS1.reads.onebp.xlsx
     summary/with-metadata.ITS1.samples.onebp.tsv
     summary/with-metadata.ITS1.samples.onebp.xlsx
+    summary/with-metadata.ITS1.tally.tsv
 
 Here we also used ``-o`` (or ``--output``) to specify a different stem for the
 report filenames.

--- a/examples/fecal_sequel/run.sh
+++ b/examples/fecal_sequel/run.sh
@@ -38,8 +38,7 @@ thapbi_pict pipeline -d COI_430_bats.sqlite \
 # Default edit-graph has very few DB nodes, so run another edit-graph
 # including all DB marker entries too
 thapbi_pict edit-graph -d COI_430_bats.sqlite -k COI \
-    -i intermediate/COI/*.fasta \
-   summary/430_bats.COI.all_reads.onebp.tsv \
+    -i summary/430_bats.COI.tally.tsv summary/430_bats.COI.all_reads.onebp.tsv \
     -o summary/430_bats.COI.edit-graph.xgmml
 
 echo ---------------------------------------------------------------

--- a/examples/fungal_mock/run.sh
+++ b/examples/fungal_mock/run.sh
@@ -45,7 +45,7 @@ function edit_graph {
     # Including relevant DB entries with -k / --marker argument
     # Do not show the classifier output using -m with "-"
     thapbi_pict edit-graph -d $DB -k $MARKER \
-                -i intermediate/${LIBRARY}/${MARKER}/ -a 75 -m - \
+                -i summary/${LIBRARY}.${MARKER}.tally.tsv -a 75 -m - \
                 -o summary/${LIBRARY}.${MARKER}.edit-graph.a75.xgmml
 }
 
@@ -84,7 +84,7 @@ LIBRARY=AL2
 analyse  # call function above
 
 MARKER=BITS-B58S3
-edit_graph  # call function abover
+edit_graph  # call function above
 
 DB=fungi_duo.sqlite
 if [ ! -f $DB ]; then

--- a/examples/great_lakes/run.sh
+++ b/examples/great_lakes/run.sh
@@ -63,16 +63,19 @@ for NAME in MOL16S SPH16S; do
         -o summary/$NAME.assess.onebp.tsv
 done
 
+echo ===========
+echo Edit graphs
+echo ===========
+
 for NAME in MOL16S SPH16S; do
     # Run an edit graph at the default -a 100 setting,
     # without showing the DB entries
-    thapbi_pict edit-graph -d pooled.sqlite \
-        -i intermediate/$NAME/ -a 100 \
-        -o summary/$NAME.edit-graph.a100.xgmml
+    thapbi_pict edit-graph -d pooled.sqlite -a 100 \
+        -i summary/$NAME.tally.tsv -o summary/$NAME.edit-graph.a100.xgmml
 done
 
 # Edit graph of just the 7 MOL16S mock community samples:
-thapbi_pict edit-graph -d pooled.sqlite -a 100 \
+thapbi_pict sample-tally -d pooled.sqlite -a 10 -f 0 \
     -i intermediate/MOL16S/SRR5534972.* \
        intermediate/MOL16S/SRR5534973.* \
        intermediate/MOL16S/SRR5534974.* \
@@ -80,13 +83,19 @@ thapbi_pict edit-graph -d pooled.sqlite -a 100 \
        intermediate/MOL16S/SRR5534976.* \
        intermediate/MOL16S/SRR5534977.* \
        intermediate/MOL16S/SRR5534979.* \
+    -o summary/MOL16S.mocks.tally.tsv
+thapbi_pict edit-graph -d pooled.sqlite -a 100 \
+    -i summary/MOL16S.mocks.tally.tsv \
     -o summary/MOL16S.mocks.edit-graph.a100.xgmml
 
 # Edit graph of just the 3 SPH16S mock community samples:
-thapbi_pict edit-graph -d pooled.sqlite -a 100 \
+thapbi_pict sample-tally -d pooled.sqlite -a 10 -f 0 \
     -i intermediate/SPH16S/SRR5534978.* \
        intermediate/SPH16S/SRR5534980.* \
        intermediate/SPH16S/SRR5534981.* \
+    -o summary/SPH16S.mocks.tally.tsv
+thapbi_pict edit-graph -d pooled.sqlite -a 100 \
+    -i summary/SPH16S.mocks.tally.tsv \
     -o summary/SPH16S.mocks.edit-graph.a100.xgmml
 
 echo ====

--- a/examples/synthetic_mycobiome/run.sh
+++ b/examples/synthetic_mycobiome/run.sh
@@ -76,7 +76,7 @@ thapbi_pict pipeline -d references.sqlite \
     -t metadata.tsv -x 1 -c 3,4 -m 1s5g
 
 thapbi_pict edit-graph -d references.sqlite -m 1s5g \
-    -i summary/ctrl.ITS2.all_reads.1s5g.tsv intermediate_ctrl/ \
+    -i summary/ctrl.ITS2.all_reads.1s5g.tsv summary/ctrl.ITS2.tally.tsv \
     -o summary/ctrl.ITS2.edit-graph.1s5g.xgmml
 
 echo =======================================
@@ -93,7 +93,7 @@ thapbi_pict pipeline -d references.sqlite \
     -t metadata.tsv -x 1 -c 3,4 -m 1s5g
 
 thapbi_pict edit-graph -d references.sqlite -m 1s5g \
-    -i summary/defaults.ITS2.all_reads.1s5g.tsv intermediate/ \
+    -i summary/defaults.ITS2.all_reads.1s5g.tsv summary/defaults.ITS2.tally.tsv \
     -o summary/defaults.ITS2.edit-graph.1s5g.xgmml
 
 echo ====

--- a/tests/test_edit-graph.sh
+++ b/tests/test_edit-graph.sh
@@ -19,7 +19,7 @@ thapbi_pict edit-graph -d '' 2>&1 | grep "Require -d / --database and/or -i / --
 set -o pipefail
 
 # No database, small FASTA file, have to use explicit total abundance threshold
-diff --strip-trailing-cr tests/edit-graph/DNAMIX_S95_L001.xgmml <(thapbi_pict edit-graph -d '' -i tests/prepare-reads/DNAMIX_S95_L001.fasta -t 200 -m - )
+diff --strip-trailing-cr tests/edit-graph/DNAMIX_S95_L001.xgmml <(thapbi_pict edit-graph -d '' -i tests/sample-tally/DNAMIX_S95_L001.tally.tsv -t 200 -m - )
 # Loaded 7 unique sequences from 1 FASTA files.
 # Minimum total abundance threshold 200 left 7 sequences from FASTA files.
 # Computed 42 Levenshtein edit distances between 7 sequences.
@@ -28,12 +28,12 @@ diff --strip-trailing-cr tests/edit-graph/DNAMIX_S95_L001.xgmml <(thapbi_pict ed
 # 1
 
 # Same example as above with default xgmml output, but here different output formats:
-diff --strip-trailing-cr tests/edit-graph/DNAMIX_S95_L001.tsv <(thapbi_pict edit-graph -d '' -i tests/prepare-reads/DNAMIX_S95_L001.fasta -t 200 -m - -f matrix)
-if [ `thapbi_pict edit-graph -d '' -i tests/prepare-reads/DNAMIX_S95_L001.fasta -t 200 -m - -f graphml | grep -c "<edge "` -ne 1 ]; then echo echo "Wrong edge count"; false; fi
-if [ `thapbi_pict edit-graph -d '' -i tests/prepare-reads/DNAMIX_S95_L001.fasta -t 200 -m - -f gexf | grep -c "<edge "` -ne 1 ]; then echo echo "Wrong edge count"; false; fi
-if [ `thapbi_pict edit-graph -d '' -i tests/prepare-reads/DNAMIX_S95_L001.fasta -t 200 -m - -f gml | grep -c "  edge \["` -ne 1 ]; then echo echo "Wrong edge count"; false; fi
+diff --strip-trailing-cr tests/edit-graph/DNAMIX_S95_L001.tsv <(thapbi_pict edit-graph -d '' -i tests/sample-tally/DNAMIX_S95_L001.tally.tsv -t 200 -m - -f matrix)
+if [ `thapbi_pict edit-graph -d '' -i tests/sample-tally/DNAMIX_S95_L001.tally.tsv -t 200 -m - -f graphml | grep -c "<edge "` -ne 1 ]; then echo echo "Wrong edge count"; false; fi
+if [ `thapbi_pict edit-graph -d '' -i tests/sample-tally/DNAMIX_S95_L001.tally.tsv -t 200 -m - -f gexf | grep -c "<edge "` -ne 1 ]; then echo echo "Wrong edge count"; false; fi
+if [ `thapbi_pict edit-graph -d '' -i tests/sample-tally/DNAMIX_S95_L001.tally.tsv -t 200 -m - -f gml | grep -c "  edge \["` -ne 1 ]; then echo echo "Wrong edge count"; false; fi
 
 # Same example, but PDF output (more dependencies):
-thapbi_pict edit-graph -d '' -i tests/prepare-reads/DNAMIX_S95_L001.fasta -t 200 -m - -f pdf | grep "%PDF-1.4"
+thapbi_pict edit-graph -d '' -i tests/sample-tally/DNAMIX_S95_L001.tally.tsv -t 200 -m - -f pdf | grep "%PDF-1.4"
 
 echo "$0 - test_edit-graph.sh passed"

--- a/tests/test_edit-graph.sh
+++ b/tests/test_edit-graph.sh
@@ -36,15 +36,4 @@ if [ `thapbi_pict edit-graph -d '' -i tests/prepare-reads/DNAMIX_S95_L001.fasta 
 # Same example, but PDF output (more dependencies):
 thapbi_pict edit-graph -d '' -i tests/prepare-reads/DNAMIX_S95_L001.fasta -t 200 -m - -f pdf | grep "%PDF-1.4"
 
-
-# No database, generic FASTA file, have to use explicit abundance thresholds of 1:
-if [ `thapbi_pict edit-graph -d '' -i database/Phytophthora_ITS1_curated.fasta -a 1 -t 1 -m - | grep -c "<node "` -ne 247 ]; then echo "Wrong node count"; false; fi
-# WARNING: Sequence(s) in database/Phytophthora_ITS1_curated.fasta not using MD5_abundance naming
-# Loaded 167 unique sequences from 1 FASTA files.
-# Minimum total abundance threshold 1 left 167 sequences from FASTA files.
-# Computed 13861 Levenshtein edit distances between 167 sequences.
-# Will draw 104 nodes with at least one edge (63 are isolated sequences).
-# Including high abundance isolated sequences, will draw 167 nodes.
-# 167
-
 echo "$0 - test_edit-graph.sh passed"

--- a/tests/test_woody_hosts.sh
+++ b/tests/test_woody_hosts.sh
@@ -96,7 +96,7 @@ if [ `grep -c -v "^#" $TMP/summary/with-metadata.reads.onebp.tsv` -ne 100 ]; the
 echo "=============================="
 echo "Running woody hosts edit-graph"
 echo "=============================="
-time thapbi_pict edit-graph -i $TMP/intermediate/ $TMP/woody_hosts.all_reads.onebp.tsv -o $TMP/summary/no-metadata.edit-graph.xgmml
+time thapbi_pict edit-graph -i $TMP/woody_hosts.tally.tsv $TMP/woody_hosts.all_reads.onebp.tsv -o $TMP/summary/no-metadata.edit-graph.xgmml
 if [ `grep -c "<node " $TMP/summary/no-metadata.edit-graph.xgmml` -ne 99 ]; then echo "Wrong node count"; false; fi
 if [ `grep -c "<edge " $TMP/summary/no-metadata.edit-graph.xgmml` -ne 69 ]; then echo "Wrong edge count"; false; fi
 


### PR DESCRIPTION
Other than the corner case of wanting to make an edit-graph from an arbitrary FASTA file, this seems pragmatic given my current restructuring around sample-tally (see #527, #528, etc).
