### PR TITLE
Apply minimum total abundance in sample-tally

### DIFF
--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -278,6 +278,7 @@ def sample_tally(args=None):
         fasta=args.fasta,
         min_abundance=args.abundance,
         min_abundance_fraction=args.abundance_fraction,
+        total_min_abundance=args.total,
         min_length=args.minlen,
         max_length=args.maxlen,
         debug=args.verbose,
@@ -485,6 +486,8 @@ def pipeline(args=None):
             fasta=all_fasta,
             min_abundance=args.abundance,
             min_abundance_fraction=args.abundance_fraction,
+            # Historical behaviour, discards rare control-only ASVs:
+            total_min_abundance=args.abundance,
             # min_length=args.minlen,
             # max_length=args.maxlen,
             debug=args.verbose,
@@ -1456,6 +1459,14 @@ def main(args=None):
     subcommand_parser.add_argument("--synthetic", **ARG_SYNTHETIC_SPIKE)
     subcommand_parser.add_argument("-a", "--abundance", **ARG_FASTQ_MIN_ABUNDANCE)
     subcommand_parser.add_argument("-f", "--abundance-fraction", **ARG_FASTQ_NOISE_PERC)
+    subcommand_parser.add_argument(
+        "-t",
+        "--total",
+        type=int,
+        default="0",
+        help="Minimum total abundance for sequences. "
+        "Applied after per-sample thresholds. Default 0 (not used).",
+    )
     subcommand_parser.add_argument("--minlen", **ARG_MIN_LENGTH)
     subcommand_parser.add_argument("--maxlen", **ARG_MAX_LENGTH)
     subcommand_parser.add_argument("-v", "--verbose", **ARG_VERBOSE)

--- a/thapbi_pict/sample_tally.py
+++ b/thapbi_pict/sample_tally.py
@@ -142,6 +142,7 @@ def main(
     if controls:
         if debug:
             sys.stderr.write("DEBUG: Applying dynamic abundance thresholds...\n")
+        # Samples with zero non-spike-ins can't raise the threshold:
         for sample in max_non_spike_abundance:
             pool = sample_pool[sample]
             a = max_non_spike_abundance[sample]

--- a/thapbi_pict/sample_tally.py
+++ b/thapbi_pict/sample_tally.py
@@ -34,6 +34,7 @@ def main(
     fasta=None,
     min_abundance=100,
     min_abundance_fraction=0.001,
+    total_min_abundance=0,
     min_length=0,
     max_length=sys.maxsize,
     gzipped=False,  # output
@@ -232,6 +233,21 @@ def main(
     counts = new_counts
     totals = new_totals
     del new_totals, new_counts
+
+    if total_min_abundance:
+        new_counts = defaultdict(int)
+        new_totals = defaultdict(int)
+        for (marker, seq, sample), a in counts.items():
+            if totals[marker, seq] >= total_min_abundance:
+                new_counts[marker, seq, sample] = a
+                new_totals[marker, seq] += a
+        sys.stderr.write(
+            f"Total abundance threshold {total_min_abundance} reduced unique "
+            f"ASVs from {len(totals)} to {len(new_totals)}.\n"
+        )
+        counts = new_counts
+        totals = new_totals
+        del new_totals, new_counts
 
     samples = sorted(samples)
     values = sorted(

--- a/thapbi_pict/sample_tally.py
+++ b/thapbi_pict/sample_tally.py
@@ -200,9 +200,11 @@ def main(
                     * (0.5 if sample in negative_controls else 1.0)
                 ),
             )
-            sys.stderr.write(
-                f"DEBUG: Control {sample} in pool {pool} gets threshold {threshold}\n"
-            )
+            if debug:
+                sys.stderr.write(
+                    f"DEBUG: Control {sample} in pool {pool} gets "
+                    f"threshold {threshold}\n"
+                )
         else:
             # Apply dynamic pool threshold from controls
             pool = sample_pool[sample]

--- a/thapbi_pict/sample_tally.py
+++ b/thapbi_pict/sample_tally.py
@@ -48,6 +48,9 @@ def main(
     Arguments min_abundance and min_abundance_fraction are applied per-sample,
     increased by pool if negative or synthetic controls are given respectively.
     Comma separated string argument spike_genus is treated case insensitively.
+
+    Results are sorted by marker, decreasing abundance then alphabetically by
+    sequence.
     """
     if isinstance(inputs, str):
         inputs = [inputs]
@@ -123,6 +126,7 @@ def main(
     else:
         sys.stderr.write("WARNING: Loaded zero sequences within length range\n")
 
+    # TODO - support for multiple markers?
     pool_absolute_threshold = {}
     pool_fraction_threshold = {}
     max_spike_abundance = defaultdict(int)  # exporting in metadata
@@ -256,7 +260,7 @@ def main(
     values = sorted(
         ((marker, count, seq) for (marker, seq), count in totals.items()),
         # sort by marker, then put the highest abundance entries first:
-        key=lambda x: (x[0], -x[1], x[2:]),
+        key=lambda x: (x[0], -x[1], x[2]),
     )
     del totals
 

--- a/thapbi_pict/sample_tally.py
+++ b/thapbi_pict/sample_tally.py
@@ -94,7 +94,7 @@ def main(
         # Assuming FASTA for now
         if debug:
             sys.stderr.write(f"DEBUG: Parsing {filename}\n")
-        # Assuming just one marker for now:
+        # TODO - Assuming just one marker for now:
         sample = file_to_sample_name(filename)
         assert sample not in samples, f"ERROR: Duplicate stem from {filename}"
         samples.add(sample)
@@ -135,14 +135,16 @@ def main(
         spikes = marker_definitions[marker]["spike_kmers"]
         if is_spike_in(seq, spikes):
             for sample in samples:
-                max_spike_abundance[sample] = max(
-                    max_spike_abundance[sample], counts[marker, seq, sample]
-                )
+                if counts[marker, seq, sample]:
+                    max_spike_abundance[sample] = max(
+                        max_spike_abundance[sample], counts[marker, seq, sample]
+                    )
         else:
             for sample in samples:
-                max_non_spike_abundance[sample] = max(
-                    max_non_spike_abundance[sample], counts[marker, seq, sample]
-                )
+                if counts[marker, seq, sample]:
+                    max_non_spike_abundance[sample] = max(
+                        max_non_spike_abundance[sample], counts[marker, seq, sample]
+                    )
     if controls:
         if debug:
             sys.stderr.write("DEBUG: Applying dynamic abundance thresholds...\n")


### PR DESCRIPTION
Regression from v0.13.2 to v0.13.3 allowed marginal entries from controls to be accepted into the 'all reads' FASTA if below the given threshold but above half of it (heuristic used in prepare-reads to ensure that ``-a`` setting didn't prevent auto-increase to the ``-f`` setting, and vice versa).

In switching from ``fasta-nr`` to ``sample-tally`` to make the "all reads" FASTA, ws missing the ``-t`` / ``--total`` value in the pipeline (set to ``-a``).

TODO: Can probably drop the heuristic if move all the control-driven abundance thresholding into sample-tally only...