### PR TITLE
Ignore controls not part of the input argument

### DIFF
--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -829,19 +829,20 @@ ARG_SYN_CONTROLS = dict(  # noqa: C408
     metavar="FASTQ",
     # Does accept folder names, but kind of pointless
     # (as would be applied only to that folder)
-    help="One or more synthetic control paired FASTQ filenames "
-    "(may also appear in the inputs). High non-synthetic marker levels "
-    "will increase the fractional abundance threshold of other "
-    "FASTQ files in the same folder. Can use '-' for none.",
+    help="One or more synthetic control paired FASTQ filenames (which must "
+    "also appear in the inputs or they will be ignored). High non-synthetic "
+    "marker levels will increase the fractional abundance threshold of other "
+    "FASTQ files in the folder. Can use '-' for none.",
 )
 ARG_SYN_CONTROLS_FASTA = dict(  # noqa: C408
     type=str,
     nargs="+",
     metavar="FASTA",
-    help="One or more synthetic control FASTA filenames (may also appear in "
-    "inputs). High non-synthetic marker levels will increase the fractional "
-    "abundance threshold of other FASTA files from the same threshold pool "
-    "(set in FASTA header metadata). Can use '-' for none.",
+    help="One or more synthetic control FASTA filenames (which must also "
+    "appear in inputs or they will be ignored). High non-synthetic marker "
+    "levels will increase the fractional abundance threshold of other FASTA "
+    "files from the same threshold pool (set in FASTA header metadata). "
+    "Can use '-' for none.",
 )
 
 # "-n", "--negctrls",
@@ -851,19 +852,20 @@ ARG_NEG_CONTROLS = dict(  # noqa: C408
     metavar="FASTQ",
     # Does accept folder names, but kind of pointless
     # (as would be applied only to that folder)
-    help="One or more negative control paired FASTQ filenames "
-    "(may also appear in the inputs). High non-synthetic levels "
-    "will increase the absolute minimum abundance threshold of other "
+    help="One or more negative control paired FASTQ filenames (which must "
+    "also appear in the inputs or they will be ignored). High non-synthetic "
+    "levels will increase the absolute minimum abundance threshold of other "
     "FASTQ files in the same folder. Can use '-' for none.",
 )
 ARG_NEG_CONTROLS_FASTA = dict(  # noqa: C408
     type=str,
     nargs="+",
     metavar="FASTA",
-    help="One or more synthetic control FASTA filenames (may also appear in "
-    "inputs). High non-synthetic marker levels will increase the absolute "
-    "abundance threshold of other FASTA files from the same threshold pool "
-    "(set in FASTA header metadata). Can use '-' for none.",
+    help="One or more synthetic control FASTA filenames (which must also "
+    "appear in the inputs or they will be ignored). High non-synthetic marker "
+    "levels will increase the absolute abundance threshold of other FASTA "
+    "files from the same threshold pool (set in FASTA header metadata). "
+    "Can use '-' for none.",
 )
 
 # "-a", "--abundance",

--- a/thapbi_pict/prepare.py
+++ b/thapbi_pict/prepare.py
@@ -1051,15 +1051,26 @@ def main(
 
     marker_definitions = load_marker_defs(session, spike_genus)
 
-    syn_control_file_pairs = find_fastq_pairs(
-        synthetic_controls, ignore_prefixes=ignore_prefixes, debug=debug
-    )
-    neg_control_file_pairs = find_fastq_pairs(
-        negative_controls, ignore_prefixes=ignore_prefixes, debug=debug
-    )
     fastq_file_pairs = find_fastq_pairs(
         fastq, ignore_prefixes=ignore_prefixes, debug=debug
     )
+    # The controls must be in the input list, or we ignore them
+    # (Useful for job splitting inputs by folder, and shared global controls list)
+    syn_control_file_pairs = [
+        _
+        for _ in find_fastq_pairs(
+            synthetic_controls, ignore_prefixes=ignore_prefixes, debug=debug
+        )
+        if _ in fastq_file_pairs
+    ]
+    neg_control_file_pairs = [
+        _
+        for _ in find_fastq_pairs(
+            negative_controls, ignore_prefixes=ignore_prefixes, debug=debug
+        )
+        if _ in fastq_file_pairs
+    ]
+    # Now exclude the control from the input to make a sample-only list:
     fastq_file_pairs = [
         _
         for _ in fastq_file_pairs


### PR DESCRIPTION
This is to faciliate splitting a large experiment by plate for the prepare-reads step, and using a common global controls list.