### PR TITLE
BIOM export of the read report

### DIFF
--- a/tests/test_summary.sh
+++ b/tests/test_summary.sh
@@ -87,16 +87,25 @@ for M in identity onebp blast; do
     rm -rf $TMP/test-case.samples.$M.*
     thapbi_pict summary -m $M -a 99 --output $TMP/test-case --input tests/classify/
     diff $TMP/test-case.samples.$M.tsv tests/summary/classify.$M.tsv
+    if [ -x "$(command -v biom)" ]; then
+        biom validate-table -i $TMP/test-case.reads.$M.biom
+    fi
     # And again, but with metadata
     rm -rf $TMP/test-case.samples.$M.*
     thapbi_pict summary -m $M -a 99 -o $TMP/test-case -i tests/classify/ \
         -t tests/classify/P-infestans-T30-4.meta.tsv -x 1 -c 2,3,4,5
     diff $TMP/test-case.samples.$M.tsv tests/summary/classify-meta.$M.tsv
+    if [ -x "$(command -v biom)" ]; then
+        biom validate-table -i $TMP/test-case.reads.$M.biom
+    fi
     # Now require metadata...
     rm -rf $TMP/test-case.samples.$M.*
     thapbi_pict summary -m $M -a 99 -o $TMP/test-case -i tests/classify/ -q \
         -t tests/classify/P-infestans-T30-4.meta.tsv -x 1 -c 2,3,4,5
     diff $TMP/test-case.samples.$M.tsv tests/summary/classify-meta-req.$M.tsv
+    if [ -x "$(command -v biom)" ]; then
+        biom validate-table -i $TMP/test-case.reads.$M.biom
+    fi
 done
 
 echo "$0 - test_summary.sh passed"

--- a/thapbi_pict/summary.py
+++ b/thapbi_pict/summary.py
@@ -392,8 +392,7 @@ def read_summary(
                 key: {"genus-species": ";".join(sorted(value))}
                 for key, value in marker_md5_species.items()
             },
-            # User-suppolied sample data,
-            # TODO - include sample data from the pipeline:
+            # User-suppolied sample data, plus stats from the pipeline:
             {
                 sample: dict(
                     list(zip(meta_names, stem_to_meta[sample]))

--- a/thapbi_pict/utils.py
+++ b/thapbi_pict/utils.py
@@ -490,7 +490,8 @@ def export_sample_biom(output_file, seqs, seq_meta, sample_meta, counts, gzipped
         # BIOM wants single string names for sequences
         [f"{marker}/{md5}" for (marker, md5) in seq_meta],
         list(sample_meta),
-        seq_meta.values(),
+        # Add the sequence itself to the metadata dict for BIOM export:
+        [dict([("Sequence", seqs[k])] + list(v.items())) for k, v in seq_meta.items()],
         sample_meta.values(),
         # Required attribute in BIOM format:
         type="OTU table",


### PR DESCRIPTION
Follow up to #551, also exports a BIOM version of the read report - essentially the same as the classifier BIOM output plus the user-supplied sample-metadata. Although currently lacking the NCBI taxids (not shown in the TSV/Excel). Also now includes the sequence itself in the metadata.

Note the HDF5 BIOM files seem to be about 10x the size on disk of the Excel read report, and perhaps 20x the size of the TSV versions. Perhaps this should be off by default, requested via a new ``--biom`` switch?