### PR TITLE
Allow singletons in pipeline

### DIFF
--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -456,7 +456,10 @@ def pipeline(args=None):
         out_dir=intermediate_dir,
         session=session,
         flip=args.flip,
-        min_abundance=2,
+        # Unless pipeline explicitly using min abundance 0 or 1
+        # (which are equivalent ways to retain singletons),
+        # at this point only want to exclude singletons:
+        min_abundance=min(2, args.abundance),
         min_abundance_fraction=0.0,
         ignore_prefixes=tuple(args.ignore_prefixes),
         merged_cache=args.merged_cache,

--- a/thapbi_pict/prepare.py
+++ b/thapbi_pict/prepare.py
@@ -718,11 +718,17 @@ def marker_cut(
                 skipped_samples.add(stem)
                 if debug:
                     sys.stderr.write(f"Skipping {fasta_name} as already done\n")
-            else:
+            elif min_a > 1:
                 sys.stderr.write(
                     f"Sample {stem} has {uniq_count} unique {marker} sequences,"
                     f" or {accepted_total}/{marker_total}"
                     f" reads over abundance threshold {min_a}\n"
+                )
+            else:
+                assert accepted_total == marker_total
+                sys.stderr.write(
+                    f"Sample {stem} has {uniq_count} unique {marker} sequences,"
+                    f" or {accepted_total} reads (abundance threshold {min_a})\n"
                 )
         time_abundance += time() - start
         if debug:


### PR DESCRIPTION
Special case how we call prepare-reads so as to to allow singletons though the pipeline if explicitly requested.