### PR TITLE
Bump minimum Python to 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2022 by Peter Cock, The James Hutton Institute.
+# Copyright 2018-2023 by Peter Cock, The James Hutton Institute.
 # All rights reserved.
 # This file is part of the THAPBI Phytophthora ITS1 Classifier Tool (PICT),
 # and is released under the "MIT License Agreement". Please see the LICENSE

--- a/setup.py
+++ b/setup.py
@@ -46,9 +46,9 @@ except ImportError:
 
 
 # Make sure we have the right Python version.
-if sys.version_info[:2] < (3, 6):
+if sys.version_info[:2] < (3, 7):
     sys.exit(
-        "THAPBI PICT requires Python 3.6 or later. "
+        "THAPBI PICT requires Python 3.7 or later. "
         "Python %d.%d detected.\n" % sys.version_info[:2]
     )
 
@@ -96,14 +96,12 @@ setup(
         "Operating System :: MacOS :: MacOS X",
         "Operating System :: POSIX :: Linux",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3",
         "Topic :: Scientific/Engineering",
         "Topic :: Scientific/Engineering :: Bio-Informatics",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     entry_points={"console_scripts": ["thapbi_pict = thapbi_pict.__main__:main"]},
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
Python 3.6 is already end-of-life, with Python 3.7 nearly so.