### PR TITLE
Sample tally tweaks

### DIFF
--- a/thapbi_pict/sample_tally.py
+++ b/thapbi_pict/sample_tally.py
@@ -358,6 +358,8 @@ def main(
             sys.stderr.write(
                 f"DEBUG: {sample} in pool {pool} gets threshold {threshold}\n"
             )
+    del pool_absolute_threshold
+    del pool_fraction_threshold
 
     new_counts = defaultdict(int)
     new_totals = defaultdict(int)

--- a/thapbi_pict/sample_tally.py
+++ b/thapbi_pict/sample_tally.py
@@ -352,7 +352,7 @@ def main(
                 * pool_fraction_threshold.get(pool, min_abundance_fraction)
             ),
         )
-        if debug:
+        if debug and not controls:
             sys.stderr.write(
                 f"DEBUG: {sample} in pool {pool} gets threshold {threshold}\n"
             )

--- a/thapbi_pict/sample_tally.py
+++ b/thapbi_pict/sample_tally.py
@@ -533,7 +533,9 @@ def main(
     else:
         fasta_handle = None
     for count, seq in values:
-        data = "\t".join(str(counts[seq, sample]) for sample in samples)
+        # This is the last time we'll use the counts[seq, *] values,
+        # so use pop to gradually reduce the data held in memory.
+        data = "\t".join(str(counts.pop((seq, sample), 0)) for sample in samples)
         md5 = md5seq(seq)
         if md5 in chimeras:
             out_handle.write(

--- a/thapbi_pict/sample_tally.py
+++ b/thapbi_pict/sample_tally.py
@@ -106,7 +106,6 @@ def main(
 
     totals = Counter()
     counts = Counter()
-    sample_counts = Counter()
     sample_cutadapt = {}  # before any thresholds
     samples = set()
     sample_pool = {}
@@ -144,7 +143,6 @@ def main(
                     a = abundance_from_read_name(_.split(None, 1)[0])
                     totals[seq] += a
                     counts[seq, sample] += a
-                    sample_counts[sample] += a
 
     if totals:
         sys.stderr.write(


### PR DESCRIPTION
This was running far more slowly than I expected locally, so I was looking at more logging and memory usage. (Turns out a rogue conda instance was bogging the machine down).

Worth noting that spike-in synthetic control detection is a bit slower than I'd like when using no or a very low abundance filter, but we're talking something like a minute overhead.