### PR TITLE
Add mypy configuration for basic type checking

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,0 +1,22 @@
+[mypy]
+packages = thapbi_pict
+#files = thapbi_pict,scripts
+show_error_context = True
+show_column_numbers = True
+show_error_codes = True
+pretty = True
+warn_redundant_casts = True
+warn_return_any = True
+warn_unused_configs = True
+
+[mypy-biom.*]
+ignore_missing_imports = True
+
+[mypy-matplotlib.*]
+ignore_missing_imports = True
+
+[mypy-networkx.*]
+ignore_missing_imports = True
+
+[mypy-xlsxwriter.*]
+ignore_missing_imports = True

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,6 +1,6 @@
 [mypy]
-packages = thapbi_pict
-#files = thapbi_pict,scripts
+#packages = thapbi_pict
+files = thapbi_pict,scripts
 show_error_context = True
 show_column_numbers = True
 show_error_codes = True

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -96,6 +96,13 @@ repos:
     -   id: codespell
         files: \.(py|sh|rst|yml|yaml)$
         args: ['-L', 'sintax,nin,otu']
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.8.0
+    hooks:
+    -   id: mypy
+        # equivalent to "files" in .mypy.ini
+        files: '^(thapbi_pict|scripts)/'
+        additional_dependencies: [biopython>=1.82]
 ci:
     # Settings for the https://pre-commit.ci/ continuous integration service
     autofix_prs: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@
 #
 # We assume you have the default channel, conda-forge, and bioconda.
 
-biopython
+biopython >=1.82
 cutadapt >=4.0
 matplotlib >=3.7
 networkx >=2.4,!=2.8.3,!=2.8.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,5 @@ matplotlib >=3.7
 networkx >=2.4,!=2.8.3,!=2.8.4
 pydot
 rapidfuzz >=2.4.0
-sqlalchemy
+sqlalchemy >=2.0
 xlsxwriter

--- a/scripts/blast_to_fasta.py
+++ b/scripts/blast_to_fasta.py
@@ -25,13 +25,14 @@ of a matched sequence differ slightly from the BLAST matches.
 """
 import os
 import sys
+from typing import Dict
 
 if len(sys.argv) != 2 or (
     sys.argv[1] != "/dev/stdin" and not os.path.isfile(sys.argv[1])
 ):
     sys.exit("ERROR: Require a BLAST TSV filename as input.")
 
-seq_to_entry = {}
+seq_to_entry: Dict[str, set[str]] = {}
 for line in open(sys.argv[1]):
     parts = line.rstrip("\n").split("\t")
     if len(parts) != 4:
@@ -65,6 +66,6 @@ for line in open(sys.argv[1]):
     except KeyError:
         seq_to_entry[sseq] = {entry}
 
-for sseq, entry in sorted(seq_to_entry.items()):
-    print(">" + ";".join(sorted(entry)))
+for sseq, entries in sorted(seq_to_entry.items()):
+    print(">" + ";".join(sorted(entries)))
     print(sseq)

--- a/scripts/make_nr.py
+++ b/scripts/make_nr.py
@@ -13,6 +13,7 @@ The output is sorted by sequence (case in-sensitive sort).
 See also the thapbi_pict fasta-nr and various import commands.
 """
 import sys
+from typing import Dict
 
 from Bio.SeqIO.FastaIO import SimpleFastaParser
 
@@ -20,7 +21,7 @@ if len(sys.argv) == 1:
     sys.exit("ERROR: Requires one or more FASTA filenames")
 
 sep = ";"
-seq_dict = {}
+seq_dict: Dict[str, set[str]] = {}
 
 for filename in sys.argv[1:]:
     with open(filename) as handle:

--- a/scripts/make_nr_ctrl_a.py
+++ b/scripts/make_nr_ctrl_a.py
@@ -1,11 +1,12 @@
 """Make FASTA files non-redundant using Ctrl+A separator."""
 import sys
+from typing import Dict
 
 from Bio.SeqIO.FastaIO import SimpleFastaParser
 
 CTRL_A = chr(1)
 
-seq_dict = {}
+seq_dict: Dict[str, set[str]] = {}
 for filename in sys.argv[1:]:
     with open(filename) as handle:
         for title, seq in SimpleFastaParser(handle):

--- a/scripts/md5.py
+++ b/scripts/md5.py
@@ -25,6 +25,7 @@ with open(sys.argv[1]) as handle:
             checksum_col = parts.index("fastq_md5")
             url_col = parts.index("fastq_ftp")
             continue  # ignore header
+        assert checksum_col is not None and url_col is not None, "Missing header?"
         for md5, url in zip(parts[checksum_col].split(";"), parts[url_col].split(";")):
             filename = os.path.split(url)[1]
             if filename.startswith("EM"):

--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        "biopython",
+        "biopython >=1.82",
         "cutadapt >=4.0",
         "matplotlib >=3.7",
         "networkx >=2.4,!=2.8.3,!=2.8.4",

--- a/thapbi_pict/db_orm.py
+++ b/thapbi_pict/db_orm.py
@@ -15,12 +15,17 @@ from sqlalchemy import ForeignKey
 from sqlalchemy import Index
 from sqlalchemy import Integer
 from sqlalchemy import String
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import DeclarativeBase
 from sqlalchemy.orm import relationship
 from sqlalchemy.orm import sessionmaker
 
 
-Base = declarative_base()
+class Base(DeclarativeBase):
+    """Base class for SQLAlchemy ORM declarations.
+
+    See the SQLAlchemy 2.0 documentation. This is expected to be
+    compatible with type checkers like mypy.
+    """
 
 
 class DataSource(Base):


### PR DESCRIPTION
This requires updating to SQLAlchemy 2.0 (which was released Jan 2023), so probably deserves a minor version bump?

May also require Biopython 1.82 to be released (with basic type annotations), otherwise might need to explicitly ignore that too (like this ignores biom, matplotlib, networkx, and xlsswriter).