### PR TITLE
Use ruff for import sorting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,6 +41,9 @@ repos:
         ]
     # Run the Ruff formatter (black alternative):
     -   id: ruff-format
+        args: [
+            '--config=format.docstring-code-format=true'
+        ]
 -   repo: https://github.com/PyCQA/flake8
     rev: 7.0.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,16 +78,6 @@ repos:
     -   id: doc8
         additional_dependencies: [pygments]
         args: [--quiet,--ignore=D001]
--   repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.1
-    hooks:
-    -   id: pyupgrade
-        # Still would like setup to run under Python 2 (and fail nicely)
-        exclude: setup.py
-        args: [
-           --py37-plus,
-           --keep-percent-format,
-        ]
 -   repo: https://github.com/codespell-project/codespell
     rev: v2.2.6
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,15 +27,17 @@ repos:
         language: pygrep
         files: \.(py|sh|rst|yml|yaml)$
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.2.0
+    rev: v0.3.0
     hooks:
     # Run the Ruff linter (flake8 alternative):
     -   id: ruff
         args: [
             '--fix',
             '--exit-non-zero-on-fix',
-            '--extend-select=B,PIE,D,ISC,UP',
+            '--extend-select=B,PIE,D,I,ISC,UP',
             '--extend-ignore=D203,D213,UP031',
+            '--config=lint.isort.force-single-line=true',
+            '--config=lint.isort.order-by-type=false',
         ]
     # Run the Ruff formatter (black alternative):
     -   id: ruff-format
@@ -76,10 +78,6 @@ repos:
     -   id: doc8
         additional_dependencies: [pygments]
         args: [--quiet,--ignore=D001]
--   repo: https://github.com/asottile/reorder-python-imports
-    rev: v3.12.0
-    hooks:
-    -   id: reorder-python-imports
 -   repo: https://github.com/asottile/pyupgrade
     rev: v3.15.1
     hooks:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,5 @@
 """Configuration file for the Sphinx documentation builder."""
+
 import os
 import sys
 

--- a/examples/pest_insects/figure3reproduction.py
+++ b/examples/pest_insects/figure3reproduction.py
@@ -6,6 +6,7 @@ format as ``figure3.tsv`` (Batovska et al. 2021 data underlying Figure 3,
 exported using our ``figure3.R`` script). Either TSV file can be plotted in
 the style of Figure 3 using the ``recreate_figure3.py`` Python script.
 """
+
 import numpy as np
 
 species_key = [

--- a/examples/pest_insects/recreate_figure3.py
+++ b/examples/pest_insects/recreate_figure3.py
@@ -43,6 +43,7 @@ Additionally some of the control samples are asterisked where all species are
 correctly identified, and coloured (+) and (-) entries have been added in some
 of the bars for false positives and false negatives respectively.
 """
+
 import argparse
 import sys
 

--- a/examples/recycled_water/make_meta.py
+++ b/examples/recycled_water/make_meta.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 """Convert PRJNA417859.txt into metadata.tsv for THAPBI PICT."""
+
 import os
 
 months = {

--- a/scripts/blast_to_fasta.py
+++ b/scripts/blast_to_fasta.py
@@ -23,6 +23,7 @@ does drop uncultured and unidentified entries, and environmental samples.
 WARNING: This may result in duplicated identifiers where the end points
 of a matched sequence differ slightly from the BLAST matches.
 """
+
 import os
 import sys
 from typing import Dict

--- a/scripts/gg_to_sintax.py
+++ b/scripts/gg_to_sintax.py
@@ -4,6 +4,7 @@
 As of v0.2.0 of the script, the input files can optionally be provided inside
 Qiime QZA files (ZIP files with a single in a .../data/... subdirectory).
 """
+
 import argparse
 import gzip
 import io

--- a/scripts/make_nr.py
+++ b/scripts/make_nr.py
@@ -12,6 +12,7 @@ The output is sorted by sequence (case in-sensitive sort).
 
 See also the thapbi_pict fasta-nr and various import commands.
 """
+
 import sys
 from typing import Dict
 

--- a/scripts/make_nr_ctrl_a.py
+++ b/scripts/make_nr_ctrl_a.py
@@ -1,4 +1,5 @@
 """Make FASTA files non-redundant using Ctrl+A separator."""
+
 import sys
 from typing import Dict
 

--- a/scripts/md5.py
+++ b/scripts/md5.py
@@ -10,6 +10,7 @@ Expected usage, where a TSV file has been download from the ENA::
 
 This requires at least the "fastq_md" and "fastq_ftp" columns be present.
 """
+
 import os
 import sys
 

--- a/scripts/missed_refs.py
+++ b/scripts/missed_refs.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Extract references for unknown FASTA."""
+
 import argparse
 import sys
 from collections import defaultdict

--- a/scripts/plot_reduction.py
+++ b/scripts/plot_reduction.py
@@ -6,6 +6,7 @@ paper in PeerJ, using matplotlib. This figure replaced the equivalent figure
 in the preprint https://doi.org/10.1101/2023.03.24.534090 created with
 Microsoft Excel.
 """
+
 import argparse
 import sys
 

--- a/scripts/pooling.py
+++ b/scripts/pooling.py
@@ -5,6 +5,7 @@
 # and is released under the "MIT License Agreement". Please see the LICENSE
 # file that should have been included as part of this package.
 """Pool THAPBI PICT sample report using metadata."""
+
 import argparse
 import sys
 

--- a/scripts/rst_doc_test.py
+++ b/scripts/rst_doc_test.py
@@ -18,6 +18,7 @@ a simple RST table (with and without a header row respectively).
 
 STRONG WARNING: Do not use this on untrusted input files!
 """
+
 # TODO - Configurable skipped commands prefix/suffix list?
 import os
 import subprocess

--- a/scripts/sample_filter.py
+++ b/scripts/sample_filter.py
@@ -5,6 +5,7 @@
 # and is released under the "MIT License Agreement". Please see the LICENSE
 # file that should have been included as part of this package.
 """Pool THAPBI PICT sample report using metadata."""
+
 import argparse
 import re
 import sys

--- a/scripts/swarm2usearch.py
+++ b/scripts/swarm2usearch.py
@@ -7,6 +7,7 @@ with the output being ">identifier;size=abundance [optional text]" instead.
     $ python swarm2usearch.py swarm.fasta > usearch.fasta
 
 """
+
 import os
 import sys
 

--- a/scripts/unknowns.py
+++ b/scripts/unknowns.py
@@ -5,6 +5,7 @@
 # and is released under the "MIT License Agreement". Please see the LICENSE
 # file that should have been included as part of this package.
 """Extract FASTA of unknowns from THAPBI PICT TSV output."""
+
 import argparse
 import sys
 

--- a/setup.py
+++ b/setup.py
@@ -31,13 +31,15 @@ Or start it as a module::
 
 Either should find the installed copy of the Python code.
 """
+
 from __future__ import print_function  # noqa: UP010
 from __future__ import with_statement  # noqa: UP010
 
 import sys
 
 try:
-    from setuptools import setup, find_packages
+    from setuptools import find_packages
+    from setuptools import setup
 except ImportError:
     sys.exit(
         "We need the Python library setuptools to be installed. "

--- a/thapbi_pict/__init__.py
+++ b/thapbi_pict/__init__.py
@@ -15,7 +15,6 @@ top level package currently only defines the tool version:
 
     >>> from thapbi_pict import __version__
     >>> print(__version__)
-    ...
 
 The `tool documentation <https://thapbi-pict.readthedocs.io/>`_ is
 hosted by `Read The Docs <https://readthedocs.org/>`_, generated

--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -9,6 +9,7 @@ This works via ``setup.py`` where under ``entry_points`` we define a
 ``console_scripts`` entry for ``thapbi_pict`` (executable name) pointing to
 the ``main()`` function define in this Python file.
 """
+
 import argparse
 import os
 import sys

--- a/thapbi_pict/assess.py
+++ b/thapbi_pict/assess.py
@@ -7,6 +7,7 @@
 
 This implements the ``thapbi_pict assess ...`` command.
 """
+
 import sys
 from collections import Counter
 

--- a/thapbi_pict/classify.py
+++ b/thapbi_pict/classify.py
@@ -7,6 +7,7 @@
 
 This implements the ``thapbi_pict classify ...`` command.
 """
+
 import os
 import shutil
 import sys

--- a/thapbi_pict/conflicts.py
+++ b/thapbi_pict/conflicts.py
@@ -4,6 +4,7 @@
 # and is released under the "MIT License Agreement". Please see the LICENSE
 # file that should have been included as part of this package.
 """Explore conflicts at species and genus level."""
+
 import sys
 
 from sqlalchemy.orm import aliased

--- a/thapbi_pict/db_import.py
+++ b/thapbi_pict/db_import.py
@@ -8,6 +8,7 @@
 This code is used for importing NCBI formatted FASTA files, our curated ITS1
 sequence FASTA file databases, and other other FASTA naming conventions.
 """
+
 import os
 import re
 import sys

--- a/thapbi_pict/db_import.py
+++ b/thapbi_pict/db_import.py
@@ -46,11 +46,11 @@ def parse_ncbi_fasta_entry(
     Returns a two-tuple: taxid (always zero), presumed genus-species (may be
     the empty string).
 
-    >>> parse_ncbi_fasta_entry('LC159493.1 Phytophthora drechsleri genes ...')
+    >>> parse_ncbi_fasta_entry("LC159493.1 Phytophthora drechsleri genes ...")
     (0, 'Phytophthora drechsleri')
-    >>> parse_ncbi_fasta_entry('A57915.1 Sequence 20 from Patent EP0751227')
+    >>> parse_ncbi_fasta_entry("A57915.1 Sequence 20 from Patent EP0751227")
     (0, '')
-    >>> parse_ncbi_fasta_entry('Y08654.1 P.cambivora ribosomal internal ...')
+    >>> parse_ncbi_fasta_entry("Y08654.1 P.cambivora ribosomal internal ...")
     (0, '')
 
     If a list of known species are used, then right most word is dropped until
@@ -131,9 +131,9 @@ def parse_ncbi_taxid_entry(
     Uses a regular expression based on taxid=<digits>, and
     only considers the first match:
 
-    >>> parse_ncbi_taxid_entry('HQ013219 Phytophthora arenaria [taxid=]')
+    >>> parse_ncbi_taxid_entry("HQ013219 Phytophthora arenaria [taxid=]")
     (0, '')
-    >>> parse_ncbi_taxid_entry('HQ013219 Phytophthora arenaria [taxid=123] [taxid=456]')
+    >>> parse_ncbi_taxid_entry("HQ013219 Phytophthora arenaria [taxid=123] [taxid=456]")
     (123, '')
     """
     match = taxid_regex.search(text)
@@ -164,13 +164,13 @@ def parse_curated_fasta_entry(
 
     Returns a two-tuple of taxid (0 unless taxid=... entry found), genus-species.
 
-    >>> parse_curated_fasta_entry('HQ013219 Phytophthora arenaria')
+    >>> parse_curated_fasta_entry("HQ013219 Phytophthora arenaria")
     (0, 'Phytophthora arenaria')
 
     Will look for an NCBI taxid after the species name (and ignore anything
     following that, such as other key=value entries):
 
-    >>> parse_curated_fasta_entry('P13660 Phytophthora aff infestans taxid=907744 etc')
+    >>> parse_curated_fasta_entry("P13660 Phytophthora aff infestans taxid=907744 etc")
     (907744, 'Phytophthora aff infestans')
 
     In this example we expect the NCBI taxid will be matched to a pre-loaded

--- a/thapbi_pict/db_orm.py
+++ b/thapbi_pict/db_orm.py
@@ -9,6 +9,7 @@ Using SQLalchemy, the Python classes defined here give us a
 database schema and the code to import/export the data as
 Python objects.
 """
+
 from sqlalchemy import Column
 from sqlalchemy import create_engine
 from sqlalchemy import ForeignKey

--- a/thapbi_pict/db_orm.py
+++ b/thapbi_pict/db_orm.py
@@ -140,7 +140,7 @@ class SeqSource(Base):
 def connect_to_db(*args, **kwargs):
     """Create engine and return session bound to it.
 
-    >>> Session = connect_to_db('sqlite:///:memory:', echo=True)
+    >>> Session = connect_to_db("sqlite:///:memory:", echo=True)
     >>> session = Session()
     """
     engine = create_engine(*args, **kwargs)

--- a/thapbi_pict/denoise.py
+++ b/thapbi_pict/denoise.py
@@ -9,6 +9,7 @@ This implements the ``thapbi_pict denoise ...`` command, which is a simplified
 version of the ``thapbi_pict sample-tally ...`` command intended to be easier
 to use outside the THAPBI PICT pipeline.
 """
+
 import gzip
 import os
 import sys

--- a/thapbi_pict/dump.py
+++ b/thapbi_pict/dump.py
@@ -7,6 +7,7 @@
 
 This implements the ``thapbi_pict dump ...`` command.
 """
+
 import sys
 from typing import Optional
 

--- a/thapbi_pict/edit_graph.py
+++ b/thapbi_pict/edit_graph.py
@@ -7,6 +7,7 @@
 
 This implements the ``thapbi_pict edit-graph ...`` command.
 """
+
 import sys
 from collections import Counter
 

--- a/thapbi_pict/ena_submit.py
+++ b/thapbi_pict/ena_submit.py
@@ -7,6 +7,7 @@
 
 This implements the ``thapbi_pict ena-submit ...`` command.
 """
+
 import os
 import shutil
 import sys

--- a/thapbi_pict/fasta_nr.py
+++ b/thapbi_pict/fasta_nr.py
@@ -8,6 +8,7 @@
 This implements the ``thapbi_pict fasta-nr ...`` command, using some of the
 same code internally as the ``thapbi_pict prepare-reads`` command.
 """
+
 import os
 import sys
 from collections import Counter

--- a/thapbi_pict/prepare.py
+++ b/thapbi_pict/prepare.py
@@ -156,7 +156,9 @@ def find_fastq_pairs(
 def parse_cutadapt_stdout(stdout: str) -> tuple[int, int]:
     r"""Extract FASTA count before and after cutadapt.
 
-    >>> parse_cutadapt_stdout("...\nTotal reads processed: 5,869\n...\nReads written (passing filters): 5,861 (99.9%)\n...")
+    >>> parse_cutadapt_stdout(
+    ...     "...\nTotal reads processed: 5,869\n...\nReads written (passing filters): 5,861 (99.9%)\n..."
+    ... )
     (5869, 5861)
     """  # noqa: E501
     before = None
@@ -249,7 +251,9 @@ def run_cutadapt(
 def parse_flash_stdout(stdout: str) -> tuple[int, int]:
     r"""Extract FASTQ pair count before/after running flash.
 
-    >>> parse_flash_stdout("...\n[FLASH] Read combination statistics:[FLASH]     Total pairs:      6105\n[FLASH]     Combined pairs:   5869\n...")
+    >>> parse_flash_stdout(
+    ...     "...\n[FLASH] Read combination statistics:[FLASH]     Total pairs:      6105\n[FLASH]     Combined pairs:   5869\n..."
+    ... )
     (6105, 5869)
     """  # noqa: E501
     before = None

--- a/thapbi_pict/prepare.py
+++ b/thapbi_pict/prepare.py
@@ -157,7 +157,11 @@ def parse_cutadapt_stdout(stdout: str) -> tuple[int, int]:
     r"""Extract FASTA count before and after cutadapt.
 
     >>> parse_cutadapt_stdout(
-    ...     "...\nTotal reads processed: 5,869\n...\nReads written (passing filters): 5,861 (99.9%)\n..."
+    ...     "...\n"
+    ...     "Total reads processed: 5,869\n"
+    ...     "...\n"
+    ...     "Reads written (passing filters): 5,861 (99.9%)\n"
+    ...     "..."
     ... )
     (5869, 5861)
     """  # noqa: E501
@@ -252,7 +256,10 @@ def parse_flash_stdout(stdout: str) -> tuple[int, int]:
     r"""Extract FASTQ pair count before/after running flash.
 
     >>> parse_flash_stdout(
-    ...     "...\n[FLASH] Read combination statistics:[FLASH]     Total pairs:      6105\n[FLASH]     Combined pairs:   5869\n..."
+    ...     "...\n"
+    ...     "[FLASH] Read combination statistics:[FLASH]     Total pairs:      6105\n"
+    ...     "[FLASH]     Combined pairs:   5869\n"
+    ...     "..."
     ... )
     (6105, 5869)
     """  # noqa: E501

--- a/thapbi_pict/prepare.py
+++ b/thapbi_pict/prepare.py
@@ -7,6 +7,7 @@
 
 This implements the ``thapbi_pict prepare-reads ...`` command.
 """
+
 import gzip
 import os
 import shutil

--- a/thapbi_pict/sample_tally.py
+++ b/thapbi_pict/sample_tally.py
@@ -7,6 +7,7 @@
 
 This implements the ``thapbi_pict sample-tally ...`` command.
 """
+
 import gzip
 import os
 import sys

--- a/thapbi_pict/summary.py
+++ b/thapbi_pict/summary.py
@@ -13,6 +13,7 @@ and statistics for the internally tracked information about
 each sample like the number of raw reads in the original FASTQ
 files (via header lines in the intermediate FASTA files).
 """
+
 import os
 import sys
 from collections import Counter

--- a/thapbi_pict/taxdump.py
+++ b/thapbi_pict/taxdump.py
@@ -8,6 +8,7 @@
 The code is needed initially for loading an NCBI taxdump folder (files
 ``names.dmp``, ``nodes.dmp``, ``merged.dmp`` etc) into a marker database.
 """
+
 import os
 import sys
 from collections import defaultdict

--- a/thapbi_pict/utils.py
+++ b/thapbi_pict/utils.py
@@ -4,6 +4,7 @@
 # and is released under the "MIT License Agreement". Please see the LICENSE
 # file that should have been included as part of this package.
 """Helper functions for THAPB-PICT code."""
+
 import gzip
 import hashlib
 import os

--- a/thapbi_pict/versions.py
+++ b/thapbi_pict/versions.py
@@ -18,6 +18,7 @@ If we cannot parse the output, again the commands return None - which is
 likely an indication of a major version change, meaning the tool ought to be
 re-evaluated for use with THAPBI-PICT.
 """
+
 import sys
 from subprocess import getoutput
 from typing import Optional


### PR DESCRIPTION
This resolves the conflict between ruff v0.3.0 (and 2024 releases of black) which wants a blank line between the docstring and imports, and reorder-python-imports which removes the blank line.

Could resolve this by using isort, but the ruff import sorting functionality is enough.

Closes #606.