### PR TITLE
Restore Python 3.8 support (and test this)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,8 +9,7 @@ init:
 
 environment:
   matrix:
-    - PYTHON: "C:\\Python310-x64"
-    # - PYTHON: "C:\\Python310"
+    - PYTHON: "C:\\Python312-x64"
 
 matrix:
   fast_finish: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
             conda config --add channels bioconda
             conda config --add channels conda-forge
             conda info -a
-            conda create -q -n testing python=3.9 mamba
+            conda create -q -n testing python=3.8 mamba
             source activate testing
             python --version
             # For installing the Python requirements either conda or pip should work,

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,9 +35,10 @@ repos:
             '--fix',
             '--exit-non-zero-on-fix',
             '--extend-select=B,PIE,D,I,ISC,UP',
-            '--extend-ignore=D203,D213,UP031',
+            '--extend-ignore=D203,D213,UP007,UP031',
             '--config=lint.isort.force-single-line=true',
             '--config=lint.isort.order-by-type=false',
+            '--config=lint.pyupgrade.keep-runtime-typing=true'
         ]
     # Run the Ruff formatter (black alternative):
     -   id: ruff-format

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Release History
 ======= ========== ============================================================================
 Version Date       Notes
 ======= ========== ============================================================================
-v1.0.12 *Pending*  More robust import of genus in SINTAX style FASTA files.
+v1.0.12 *Pending*  Restored Python 3.8 support. More robust import of SINTAX style FASTA files.
 v1.0.11 2024-03-05 Harmonize ASV naming in BIOM output, optional ``sample-tally`` BIOM output.
 v1.0.10 2024-02-26 Sample report 'Unique' column is now the unique ASV count. Misc updates.
 v1.0.9  2024-02-12 Using Python type annotations (internal code change). Python 3.9 onwards.

--- a/setup.py
+++ b/setup.py
@@ -48,9 +48,9 @@ except ImportError:
 
 
 # Make sure we have the right Python version.
-if sys.version_info[:2] < (3, 9):  # noqa: UP036
+if sys.version_info[:2] < (3, 8):  # noqa: UP036
     sys.exit(
-        "THAPBI PICT requires Python 3.9 or later. "
+        "THAPBI PICT requires Python 3.8 or later. "
         "Python %d.%d detected.\n" % sys.version_info[:2]
     )
 
@@ -103,7 +103,7 @@ setup(
         "Topic :: Scientific/Engineering :: Bio-Informatics",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
-    python_requires=">=3.9",
+    python_requires=">=3.8",
     entry_points={"console_scripts": ["thapbi_pict = thapbi_pict.__main__:main"]},
     packages=find_packages(),
     include_package_data=True,

--- a/tests/test_edit-graph.sh
+++ b/tests/test_edit-graph.sh
@@ -34,6 +34,10 @@ if [ `thapbi_pict edit-graph -d '' -i tests/sample-tally/DNAMIX_S95_L001.tally.t
 if [ `thapbi_pict edit-graph -d '' -i tests/sample-tally/DNAMIX_S95_L001.tally.tsv -t 200 -f gml | grep -c "  edge \["` -ne 1 ]; then echo echo "Wrong edge count"; false; fi
 
 # Same example, but PDF output (more dependencies):
-thapbi_pict edit-graph -d '' -i tests/sample-tally/DNAMIX_S95_L001.tally.tsv -t 200 -f pdf | grep "%PDF-1.4"
+if ! [ -x "$(command -v fdp)" ]; then
+    echo "Skipping testing PDF output using GraphViz fdp"
+else
+    thapbi_pict edit-graph -d '' -i tests/sample-tally/DNAMIX_S95_L001.tally.tsv -t 200 -f pdf | grep "%PDF-1.4"
+fi
 
 echo "$0 - test_edit-graph.sh passed"

--- a/thapbi_pict/assess.py
+++ b/thapbi_pict/assess.py
@@ -8,6 +8,8 @@
 This implements the ``thapbi_pict assess ...`` command.
 """
 
+from __future__ import annotations
+
 import sys
 from collections import Counter
 

--- a/thapbi_pict/classify.py
+++ b/thapbi_pict/classify.py
@@ -8,6 +8,8 @@
 This implements the ``thapbi_pict classify ...`` command.
 """
 
+from __future__ import annotations
+
 import os
 import shutil
 import sys

--- a/thapbi_pict/conflicts.py
+++ b/thapbi_pict/conflicts.py
@@ -5,6 +5,8 @@
 # file that should have been included as part of this package.
 """Explore conflicts at species and genus level."""
 
+from __future__ import annotations
+
 import sys
 
 from sqlalchemy.orm import aliased

--- a/thapbi_pict/db_import.py
+++ b/thapbi_pict/db_import.py
@@ -9,6 +9,8 @@ This code is used for importing NCBI formatted FASTA files, our curated ITS1
 sequence FASTA file databases, and other other FASTA naming conventions.
 """
 
+from __future__ import annotations
+
 import os
 import re
 import sys

--- a/thapbi_pict/denoise.py
+++ b/thapbi_pict/denoise.py
@@ -10,6 +10,8 @@ version of the ``thapbi_pict sample-tally ...`` command intended to be easier
 to use outside the THAPBI PICT pipeline.
 """
 
+from __future__ import annotations
+
 import gzip
 import os
 import sys

--- a/thapbi_pict/dump.py
+++ b/thapbi_pict/dump.py
@@ -8,6 +8,8 @@
 This implements the ``thapbi_pict dump ...`` command.
 """
 
+from __future__ import annotations
+
 import sys
 from typing import Optional
 

--- a/thapbi_pict/edit_graph.py
+++ b/thapbi_pict/edit_graph.py
@@ -32,6 +32,7 @@ from .utils import md5seq
 from .utils import parse_sample_tsv
 from .utils import species_level
 from .versions import check_rapidfuzz
+from .versions import check_tools
 
 genus_color = {
     # From the VGA colors, in order of DB abundance,
@@ -68,6 +69,8 @@ genus_color = {
 def write_pdf(G, handle) -> None:
     """Render NetworkX graph to PDF using GraphViz fdp."""
     # TODO: Try "sfdp" but need GraphViz built with triangulation library
+    check_tools(["fdp"], debug=False)
+
     default = G.graph["node_default"]["color"]
     node_colors = [G.nodes[_].get("color", default) for _ in G]
 

--- a/thapbi_pict/edit_graph.py
+++ b/thapbi_pict/edit_graph.py
@@ -8,6 +8,8 @@
 This implements the ``thapbi_pict edit-graph ...`` command.
 """
 
+from __future__ import annotations
+
 import sys
 from collections import Counter
 from typing import Optional

--- a/thapbi_pict/ena_submit.py
+++ b/thapbi_pict/ena_submit.py
@@ -8,6 +8,8 @@
 This implements the ``thapbi_pict ena-submit ...`` command.
 """
 
+from __future__ import annotations
+
 import os
 import shutil
 import sys

--- a/thapbi_pict/fasta_nr.py
+++ b/thapbi_pict/fasta_nr.py
@@ -9,6 +9,8 @@ This implements the ``thapbi_pict fasta-nr ...`` command, using some of the
 same code internally as the ``thapbi_pict prepare-reads`` command.
 """
 
+from __future__ import annotations
+
 import os
 import sys
 from collections import Counter

--- a/thapbi_pict/prepare.py
+++ b/thapbi_pict/prepare.py
@@ -8,6 +8,8 @@
 This implements the ``thapbi_pict prepare-reads ...`` command.
 """
 
+from __future__ import annotations
+
 import gzip
 import os
 import shutil

--- a/thapbi_pict/sample_tally.py
+++ b/thapbi_pict/sample_tally.py
@@ -8,6 +8,8 @@
 This implements the ``thapbi_pict sample-tally ...`` command.
 """
 
+from __future__ import annotations
+
 import gzip
 import os
 import shutil

--- a/thapbi_pict/summary.py
+++ b/thapbi_pict/summary.py
@@ -14,6 +14,8 @@ each sample like the number of raw reads in the original FASTQ
 files (via header lines in the intermediate FASTA files).
 """
 
+from __future__ import annotations
+
 import os
 import sys
 from collections import Counter

--- a/thapbi_pict/taxdump.py
+++ b/thapbi_pict/taxdump.py
@@ -9,6 +9,8 @@ The code is needed initially for loading an NCBI taxdump folder (files
 ``names.dmp``, ``nodes.dmp``, ``merged.dmp`` etc) into a marker database.
 """
 
+from __future__ import annotations
+
 import os
 import sys
 from collections import defaultdict

--- a/thapbi_pict/utils.py
+++ b/thapbi_pict/utils.py
@@ -5,6 +5,8 @@
 # file that should have been included as part of this package.
 """Helper functions for THAPB-PICT code."""
 
+from __future__ import annotations
+
 import gzip
 import hashlib
 import os

--- a/thapbi_pict/versions.py
+++ b/thapbi_pict/versions.py
@@ -19,6 +19,8 @@ likely an indication of a major version change, meaning the tool ought to be
 re-evaluated for use with THAPBI-PICT.
 """
 
+from __future__ import annotations
+
 import sys
 from subprocess import getoutput
 from typing import Optional

--- a/thapbi_pict/versions.py
+++ b/thapbi_pict/versions.py
@@ -61,6 +61,7 @@ def check_tools(names: list[str], debug: bool) -> list[str]:
         "blastn": version_blast,
         "cutadapt": version_cutadapt,
         "flash": version_flash,
+        "fdp": version_graphviz_fdp,
         "makeblastdb": version_blast,
         "usearch": version_usearch,
         "vsearch": version_vsearch,
@@ -85,6 +86,29 @@ def check_tools(names: list[str], debug: bool) -> list[str]:
         sys.exit("ERROR: Missing external tool(s): " + ",".join(missing))
     else:
         return versions
+
+
+def version_graphviz_fdp(cmd: str = "fdp") -> Optional[str]:
+    """Return the version of the GraphViz tool fdp (as a short string).
+
+    Depends on the -V switch::
+
+        $ fdp -V
+        fdp - graphviz version 9.0.0 (0)
+
+    In the above example, it would behave as follows:
+
+    >>> version_graphviz_fdp()
+    '9.0.0'
+
+    If the command is not on the path, returns None.
+    """
+    text = getoutput(cmd + " -V")
+    for line in text.splitlines():
+        if line.startswith("fdp - graphviz version "):
+            words = line.strip().split()
+            return words[4]
+    return None
 
 
 def version_blast(cmd: str = "blastn") -> Optional[str]:


### PR DESCRIPTION
Addresses the regression in v1.0.9 with type annotation additions requiring Python 3.9.

Not worrying about Python 3.7 (our previous minimum version) as that is already EOL.