### PR TITLE
Refresh API doc index

### DIFF
--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -12,14 +12,15 @@ Python API
    thapbi_pict.assess
    thapbi_pict.classify
    thapbi_pict.conflicts
-   thapbi_pict.denoise
    thapbi_pict.db_import
    thapbi_pict.db_orm
+   thapbi_pict.denoise
    thapbi_pict.dump
    thapbi_pict.edit_graph
+   thapbi_pict.ena_submit
    thapbi_pict.fasta_nr
-   thapbi_pict.sample_tally
    thapbi_pict.prepare
+   thapbi_pict.sample_tally
    thapbi_pict.summary
    thapbi_pict.taxdump
    thapbi_pict.utils

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,7 +69,7 @@ autodoc_default_values = {
     "member-order": "bysource",
     "exclude-members": "__dict__,__weakref__,__module__",
 }
-autodoc_mock_imports = ["sqlalchemy"]
+autodoc_mock_imports = ["sqlalchemy", "matplotlib"]
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/setup.py
+++ b/setup.py
@@ -110,6 +110,7 @@ setup(
     install_requires=[
         "biopython >=1.82",
         "cutadapt >=4.0",
+        "xopen !=2.0.0",
         "matplotlib >=3.7",
         "networkx >=2.4,!=2.8.3,!=2.8.4",
         "pydot",


### PR DESCRIPTION
Was missing ``ena_submit``, and wasn't sorted.

Trying to include ``__init__`` and ``__main__`` is non-trivial, unclear why. Probably a side effect of who I configured this originally - might be worth revisiting that as an automatic index would be better.