### PR TITLE
Stop using Excel freeze-panes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ https://github.com/peterjc/thapbi-pict/releases for more detailed release notes.
 ======= ========== ============================================================================
 Version Date       Notes
 ======= ========== ============================================================================
-v1.0.13 *Pending*  Updated NCBI taxonomy and bulk genus-only entries in default DB.
+v1.0.13 2024-05-22 Updated NCBI taxonomy and bulk genus-only entries in default DB.
 v1.0.12 2024-03-11 Restored Python 3.8 support. More robust import of SINTAX style FASTA files.
 v1.0.11 2024-03-05 Harmonize ASV naming in BIOM output, optional ``sample-tally`` BIOM output.
 v1.0.10 2024-02-26 Sample report 'Unique' column is now the unique ASV count. Misc updates.

--- a/thapbi_pict/summary.py
+++ b/thapbi_pict/summary.py
@@ -273,7 +273,6 @@ def sample_summary(
     col_offset += len(stats_fields)
     for offset, sp in enumerate(species_predictions):
         worksheet.write_string(current_row, col_offset + offset, _sp_display(sp))
-    worksheet.freeze_panes(current_row + 1, col_offset)
 
     # Main body
     # =========
@@ -716,8 +715,6 @@ def read_summary(
             sample_formats[s],
         )
     current_row += 1
-    # keep total line in view plus headers:
-    worksheet.freeze_panes(current_row, LEADING_COLS)
 
     # Main body
     # ---------


### PR DESCRIPTION
This functionality is no longer useful with more and more metadata (user-supplied and automatic like raw FASTQ counts), especially on smaller screens.