### PR TITLE
Confirm bootstrapped DB unchanged without git-diff

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,11 +36,12 @@ jobs:
             echo "Bootstrapping to build DB"
             python -m pip install -e .
             rm -rf dist/* thapbi_pict/ITS1_DB.sqlite
+            mv database/ITS1_DB.fasta database/expected_DB.fasta
             cd database
             bash build_ITS1_DB.sh
             cd ..
-            echo "Confirming with git that database/ITS1_DB.fasta is unchanged"
-            git diff origin/master database/ITS1_DB.fasta
+            echo "Confirming database/ITS1_DB.fasta is unchanged"
+            diff database/expected_DB.fasta  database/ITS1_DB.fasta
             cp database/ITS1_DB.sqlite thapbi_pict/ITS1_DB.sqlite
             chmod a-w thapbi_pict/ITS1_DB.sqlite
             echo "DB ready, uninstalling THAPBI PICT..."


### PR DESCRIPTION
This should fix the recent failure on CirceCL where the git diff command is timing out. Closes #626.