### PR TITLE
Switch from miniconda to miniforge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: continuumio/miniconda3
+      - image: condaforge/miniforge3 
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: condaforge/miniforge3 
+      - image: condaforge/miniforge3
     steps:
       - checkout
       - run:


### PR DESCRIPTION
Want to avoid the AnaConda defaults channel, which is not free (with somewhat unclear exceptions).

MiniForge https://github.com/conda-forge/miniforge is setup with just the conda-forge channel.