### PR TITLE
Option to filter reports to only samples of interest via metadata

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ https://github.com/peterjc/thapbi-pict/releases for more detailed release notes.
 ======= ========== ============================================================================
 Version Date       Notes
 ======= ========== ============================================================================
+v1.0.16 *Pending*  New ``--metafilter`` summary and pipeline argument for sub-reports.
 v1.0.15 2024-09-05 Additional curated entries in default DB, many from Jung *et al.* (2024).
 v1.0.14 2024-08-26 Added a fifth synthetic control to the default DB.
 v1.0.13 2024-05-22 Updated NCBI taxonomy and bulk genus-only entries in default DB.

--- a/scripts/sample_filter.py
+++ b/scripts/sample_filter.py
@@ -12,7 +12,7 @@ import sys
 from collections import Counter
 
 if "-v" in sys.argv or "--version" in sys.argv:
-    print("v0.0.1")
+    print("v0.0.2")
     sys.exit(0)
 
 # Parse Command Line
@@ -22,6 +22,10 @@ optionally with classifier output included (taxid and genus-species columns).
 The output is a subset filtering the sample names according to the regex. e.g.
 
 $ python sample_filter.py -i input.onebp.tsv -o subet.onebp.tsv -r "^N[00-99]-"
+
+This has largely been superseded by the --metafilter argument for the pipeline
+and summary commands added in THAPBI PICT v1.0.16, although that requires the
+use of a metadata table to filter on.
 """
 
 # TODO - Offer -a for minimum per seq per sample abundance threshold?

--- a/tests/test_woody_hosts.sh
+++ b/tests/test_woody_hosts.sh
@@ -129,6 +129,27 @@ if [ "$(grep -c -v "^#" $TMP/summary/with-metadata.reads.onebp.tsv)" -ne 100 ]; 
 fi
 # Expect 99 + total line
 
+echo "Checking metadata filter works..."
+# There are only 34 Urban samples, no total line in sample report currently
+# This is with the filter column as one being reported on:
+time thapbi_pict summary -i $TMP/woody_hosts.onebp.tsv \
+    -o $TMP/summary/urban-only \
+    -t examples/woody_hosts/metadata.tsv --metafilter 3:Urban \
+    -c 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15 -x 16
+if [ "$(grep -c -v "^#" $TMP/summary/urban-only.samples.onebp.tsv)" -ne 34 ]; then
+    echo "Wrong sample count"
+    false
+fi
+# This is with the filter column not being reported on:
+time thapbi_pict summary -i $TMP/woody_hosts.onebp.tsv \
+    -o $TMP/summary/urban-only-lite \
+    -t examples/woody_hosts/metadata.tsv --metafilter 3:Urban \
+    -c 1,2,4,5,6,7,8,9,10,11,12,13,14,15 -x 16
+if [ "$(grep -c -v "^#" $TMP/summary/urban-only-lite.samples.onebp.tsv)" -ne 34 ]; then
+    echo "Wrong sample count"
+    false
+fi
+
 echo "=============================="
 echo "Running woody hosts edit-graph"
 echo "=============================="

--- a/thapbi_pict/__init__.py
+++ b/thapbi_pict/__init__.py
@@ -23,4 +23,4 @@ automatically from the ``docs/`` folder of the `software repository
 within the source code which document the Python API.
 """
 
-__version__ = "1.0.15"
+__version__ = "1.0.16"

--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -1,5 +1,6 @@
 # Copyright 2018-2024 by Peter Cock, The James Hutton Institute.
 # Revisions copyright 2024 by Peter Cock.
+# Revisions copyright 2024 by Peter Cock, University of Strathclyde.
 # All rights reserved.
 # This file is part of the THAPBI Phytophthora ITS1 Classifier Tool (PICT),
 # and is released under the "MIT License Agreement". Please see the LICENSE

--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -401,6 +401,7 @@ def summary(args=None):
         metadata_groups=args.metagroups,
         metadata_fieldnames=args.metafields,
         metadata_index=args.metaindex,
+        metadata_filter=args.metafilter,
         require_metadata=args.requiremeta,
         show_unsequenced=args.unsequenced,
         ignore_prefixes=tuple(args.ignore_prefixes),
@@ -601,6 +602,7 @@ def pipeline(args=None):
             metadata_groups=args.metagroups,
             metadata_fieldnames=args.metafields,
             metadata_index=args.metaindex,
+            metadata_filter=args.metafilter,
             require_metadata=args.requiremeta,
             show_unsequenced=args.unsequenced,
             ignore_prefixes=tuple(args.ignore_prefixes),
@@ -1077,6 +1079,16 @@ ARG_METAFIELDS = dict(  # noqa: C408
     "Use in conjunction with -m / --metadata argument.",
 )
 
+# "--metafilter"
+ARG_METAFILTER = dict(  # noqa: C408
+    type=str,
+    default="",
+    metavar="FILTER",
+    help="Optional report sample filter applied via the metadata, expressed "
+    "as column number, colon, then a regular expression. e.g. '4:Scotland' "
+    "would report only samples with Scotland as part of column 4.",
+)
+
 # "-q", "--requiremeta",
 ARG_REQUIREMETA = dict(  # noqa: C408
     action="store_true",
@@ -1166,6 +1178,7 @@ def main(args=None):
     subcommand_parser.add_argument("-g", "--metagroups", **ARG_METAGROUPS)
     subcommand_parser.add_argument("--metafields", **ARG_METAFIELDS)
     subcommand_parser.add_argument("--merged-cache", **ARG_MERGED_CACHE)
+    subcommand_parser.add_argument("--metafilter", **ARG_METAFILTER)
     subcommand_parser.add_argument("-q", "--requiremeta", **ARG_REQUIREMETA)
     subcommand_parser.add_argument("-u", "--unsequenced", **ARG_UNSEQUENCED)
     subcommand_parser.add_argument("-b", "--biom", **ARG_BIOM)
@@ -1786,6 +1799,7 @@ def main(args=None):
     subcommand_parser.add_argument("-x", "--metaindex", **ARG_METAINDEX)
     subcommand_parser.add_argument("-g", "--metagroups", **ARG_METAGROUPS)
     subcommand_parser.add_argument("--metafields", **ARG_METAFIELDS)
+    subcommand_parser.add_argument("--metafilter", **ARG_METAFILTER)
     subcommand_parser.add_argument("-q", "--requiremeta", **ARG_REQUIREMETA)
     subcommand_parser.add_argument("-u", "--unsequenced", **ARG_UNSEQUENCED)
     subcommand_parser.add_argument("-b", "--biom", **ARG_BIOM)

--- a/thapbi_pict/ena_submit.py
+++ b/thapbi_pict/ena_submit.py
@@ -151,6 +151,7 @@ def main(
         _,
         meta_names,
         group_col,
+        _,
     ) = load_metadata(
         metadata_file,
         metadata_encoding,

--- a/thapbi_pict/ena_submit.py
+++ b/thapbi_pict/ena_submit.py
@@ -1,4 +1,5 @@
 # Copyright 2019-2024 by Peter Cock, The James Hutton Institute.
+# Revisions copyright 2024 by Peter Cock, University of Strathclyde.
 # All rights reserved.
 # This file is part of the THAPBI Phytophthora ITS1 Classifier Tool (PICT),
 # and is released under the "MIT License Agreement". Please see the LICENSE

--- a/thapbi_pict/summary.py
+++ b/thapbi_pict/summary.py
@@ -900,13 +900,15 @@ def main(
 
     for filename in classifications_tsv:
         seqs, seq_meta, sample_headers, counts = parse_sample_tsv(
-            filename, min_abundance=min_abundance, debug=debug
+            filename,
+            min_abundance=min_abundance,
+            accept_samples=set(stem_to_meta) if require_metadata else None,
+            ignore_samples=set(filter_out) if filter_out else None,
+            debug=debug,
         )
         for sample, fasta_header in sample_headers.items():
             if sample in filter_out:
-                if debug:
-                    sys.stderr.write(f"DEBUG: Dropping {sample} via metadata filter\n")
-                continue
+                sys.exit(f"ERROR: Failed to drop {sample} via metadata filter\n")
             if sample not in stem_to_meta:
                 if require_metadata:
                     if debug:

--- a/thapbi_pict/summary.py
+++ b/thapbi_pict/summary.py
@@ -1,4 +1,5 @@
 # Copyright 2019-2024 by Peter Cock, The James Hutton Institute.
+# Revisions copyright 2024 by Peter Cock, University of Strathclyde.
 # All rights reserved.
 # This file is part of the THAPBI Phytophthora ITS1 Classifier Tool (PICT),
 # and is released under the "MIT License Agreement". Please see the LICENSE


### PR DESCRIPTION
Use case is reporting on "sub-projects" within a larger dataset, where they can easily be subset from the full dataset by a single column in the metadata.

This turns out to be a bit fiddly as for any given sample:

- if in metadata, check the new filter
- if not in metadata, check the flag for if we require metadata to show a sample

These interact and we won't want to mask the samples leaving zero abundance ASVs present!