### PR TITLE
Accept multiple tally files into sample_filter.py

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ https://github.com/peterjc/thapbi-pict/releases for more detailed release notes.
 ======= ========== ============================================================================
 Version Date       Notes
 ======= ========== ============================================================================
+v1.0.20 *Pending*  ``sample_filter.py`` script now accepts multiple (classified) tally files.
 v1.0.19 2024-12-05 Updated curated and NCBI bulk genus-only entries in default DB.
 v1.0.18 2024-11-25 Updated NCBI taxonomy in default DB, and ``ena-submit`` for current Webin.
 v1.0.17 2024-11-08 Requires Python 3.10. Uses ``rich-argparse`` if installed for CLI colors.

--- a/scripts/sample_filter.py
+++ b/scripts/sample_filter.py
@@ -12,16 +12,18 @@ import sys
 from collections import Counter
 
 if "-v" in sys.argv or "--version" in sys.argv:
-    print("v0.0.1")
+    print("v0.1.0")
     sys.exit(0)
 
 # Parse Command Line
 usage = """\
-The input file should be a THAPBI PICT sample-tally TSV intermediate file,
-optionally with classifier output included (taxid and genus-species columns).
+The input file should be THAPBI PICT sample-tally TSV intermediate file(s),
+optionally all with classifier output included (taxid and genus-species columns).
 The output is a subset filtering the sample names according to the regex. e.g.
 
 $ python sample_filter.py -i input.onebp.tsv -o subet.onebp.tsv -r "^N[00-99]-"
+
+When used without a regex this script simply merges the input files.
 """
 
 # TODO - Offer -a for minimum per seq per sample abundance threshold?
@@ -35,9 +37,10 @@ parser.add_argument(
     "-i",
     "--input",
     dest="input",
-    default="/dev/stdin",
     metavar="FILE",
-    help="Input TSV filename, default stdin.",
+    required=True,
+    nargs="+",
+    help="Input TSV filename(s), at least one filename required.",
 )
 parser.add_argument(
     "-o",
@@ -51,7 +54,6 @@ parser.add_argument(
     "-r",
     "--regex",
     type=str,
-    required=True,
     default="",
     metavar="REGEX",
     help="Regular expression applied to sample names.",
@@ -60,27 +62,18 @@ if len(sys.argv) == 1:
     sys.exit("ERROR: Invalid command line, try -h or --help.")
 options = parser.parse_args()
 
-
-def sample_filter(input_filename, output_filename, regex):
-    """Filter samples using a regular expression (regex)."""
-    pattern = re.compile(regex)
-
-    try:
-        from thapbi_pict.utils import parse_sample_tsv
-    except ImportError:
-        sys.exit(
-            "ERROR: Couldn't import Python function thapbi_pict.utils.parse_sample_tsv"
-        )
-
-    seqs, seq_meta, sample_headers, counts = parse_sample_tsv(input_filename)
+if not options.regex and len(options.input) == 1:
     sys.stderr.write(
-        f"Loaded counts for {len(sample_headers)} samples and {len(seqs)} sequences\n"
+        "WARNING: With one input and no regex, you can just copy the file\n"
     )
 
+
+def apply_filter(seqs, seq_meta, sample_headers, counts, compiled_regex):
+    """Apply regex filter."""
     sample_headers = {
         sample: value
         for sample, value in sample_headers.items()
-        if pattern.match(sample)
+        if compiled_regex.match(sample)
     }
     # Don't actually need to drop the redundant entries in counts dict, but can:
     counts = {
@@ -104,6 +97,39 @@ def sample_filter(input_filename, output_filename, regex):
     sys.stderr.write(
         f"Regex reduced to {len(sample_headers)} samples and {len(seqs)} sequences\n"
     )
+    return seqs, seq_meta, sample_headers, counts
+
+
+def sample_filter(input_filenames, output_filename, regex):
+    """Filter samples using a regular expression (regex)."""
+    pattern = re.compile(regex) if regex else None
+
+    try:
+        from thapbi_pict.utils import parse_sample_tsv
+    except ImportError:
+        sys.exit(
+            "ERROR: Couldn't import Python function thapbi_pict.utils.parse_sample_tsv"
+        )
+
+    all_seqs = {}
+    all_seq_meta = {}
+    all_sample_headers = {}
+    all_counts = {}
+
+    for input_filename in input_filenames:
+        seqs, seq_meta, sample_headers, counts = parse_sample_tsv(input_filename)
+        sys.stderr.write(
+            f"Loaded {len(sample_headers)} samples and {len(seqs)} sequences"
+            f" from {input_filename}\n"
+        )
+        if regex:
+            seqs, seq_meta, sample_headers, counts = apply_filter(
+                seqs, seq_meta, sample_headers, counts, pattern
+            )
+        all_seqs.update(seqs)
+        all_seq_meta.update(seq_meta)
+        all_sample_headers.update(sample_headers)
+        all_counts.update(counts)
 
     try:
         from thapbi_pict.utils import export_sample_tsv
@@ -113,7 +139,10 @@ def sample_filter(input_filename, output_filename, regex):
         )
 
     export_sample_tsv(output_filename, seqs, seq_meta, sample_headers, counts)
-    sys.stderr.write(f"Wrote counts to {output_filename}\n")
+    sys.stderr.write(
+        f"Wrote {len(all_sample_headers)} samples and {len(all_seqs)} sequences"
+        f" to {output_filename}\n"
+    )
 
 
 sample_filter(

--- a/thapbi_pict/__init__.py
+++ b/thapbi_pict/__init__.py
@@ -25,4 +25,4 @@ automatically from the ``docs/`` folder of the `software repository
 within the source code which document the Python API.
 """
 
-__version__ = "1.0.19"
+__version__ = "1.0.20"


### PR DESCRIPTION
I want to be able to run multiple plates and do per-plate denoising. Currently the pipeline/sample-tally/denoise commands were written assuming global denoising as per UNOISE paper recommendations. However, denoising per plate scales better, and importantly means old plate results will not change when new plates are added to the analysis.

This PR allows a pragmatic route to running multiple plates and doing per-plate denoising:
* Run the pipeline on each plate (don't need metadata, and the individual reports are purely for interest), with denoising per plate
* Use this script to merge the classified tally, can also select samples of interest
* Run summary command on classified tally with metadata

Previously we would do the following, but this only allows denoising globally:
* Run prepare reads on each plate (making intermediate FASTA files)
* Run the pipeline on all the plates (will use the intermediate FASTA files)
* Run this script on classified tally file to select samples of interest
* Run summary command on classified tally with metadata