### PR TITLE
Add -k markers argument to conflicts command.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ https://github.com/peterjc/thapbi-pict/releases for more detailed release notes.
 ======= ========== ============================================================================
 Version Date       Notes
 ======= ========== ============================================================================
+v1.0.23 *Pending*  Add ``-k`` / ``--markers`` argument to conflicts command.
 v1.0.22 2026-03-05 Bug fix for unsequenced samples in metadata appearing unwanted in reports.
 v1.0.21 2026-01-05 Updated NCBI taxonomy in default DB, and version of VSEARCH used in tests.
 v1.0.20 2024-12-31 ``sample_filter.py`` script now accepts multiple (classified) tally files.

--- a/tests/test_conflicts.sh
+++ b/tests/test_conflicts.sh
@@ -30,7 +30,7 @@ diff $TMP/conflicts.tsv tests/conflicts/default.tsv
 export DB=$TMP/dup_seqs.sqlite
 rm -rf $DB
 thapbi_pict import -x -d $DB -i tests/curated-import/dup_seqs.fasta -c ncbi -s $'\001' -k ITS1 -l "N" -r "N"
-thapbi_pict conflicts -d $TMP/dup_seqs.sqlite -o $TMP/dup_seqs.tsv
+thapbi_pict conflicts -d $TMP/dup_seqs.sqlite -o $TMP/dup_seqs.tsv -k ITS1
 diff $TMP/dup_seqs.tsv tests/conflicts/dup_seqs.tsv
 
 echo "$0 - test_conflicts.sh passed"

--- a/thapbi_pict/__main__.py
+++ b/thapbi_pict/__main__.py
@@ -221,9 +221,18 @@ def conflicts(args=None):
     """Subcommand to look for taxonomic conflicts in a database."""
     from .conflicts import main
 
+    if args.markers:
+        # Connect to the DB,
+        db = expand_database_argument(args.database, exist=True, hyphen_default=True)
+        session = connect_to_db(db)
+
+        markers = sorted(_.name for _ in session.query(MarkerDef))
+        markers = validate_markers(markers, args.markers)
+
     return main(
         db_url=expand_database_argument(args.database, exist=True, hyphen_default=True),
         output_filename=args.output,
+        markers=args.markers,
         debug=args.verbose,
     )
 
@@ -1407,6 +1416,7 @@ def main(args=None):
         formatter_class=cmd_formatter,
     )
     subcommand_parser.add_argument("-d", "--database", **ARG_DB_INPUT)
+    subcommand_parser.add_argument("-k", "--markers", **ARG_MARKER_PICK_SOME)
     subcommand_parser.add_argument(
         "-o",
         "--output",

--- a/thapbi_pict/conflicts.py
+++ b/thapbi_pict/conflicts.py
@@ -18,10 +18,16 @@ from .db_orm import MarkerDef
 from .db_orm import MarkerSeq
 from .db_orm import SeqSource
 from .db_orm import Taxonomy
+from .prepare import load_marker_defs
 from .utils import genus_species_name
 
 
-def main(db_url: str, output_filename: str, debug: bool = False) -> int:
+def main(
+    db_url: str,
+    output_filename: str,
+    markers: list[str] | None = None,
+    debug: bool = False,
+) -> int:
     """Implement the ``thapbi_pict conflicts`` subcommand.
 
     Looks for taxonomy conflicts at marker, genus or species level, with the
@@ -58,6 +64,10 @@ def main(db_url: str, output_filename: str, debug: bool = False) -> int:
         .options(contains_eager(SeqSource.marker_definition, alias=marker_def))
         .options(contains_eager(SeqSource.taxonomy, alias=cur_tax))
     )
+    if markers:
+        marker_definitions = load_marker_defs(session, filter=markers)
+        view = view.filter(marker_def.name.in_(marker_definitions))
+
     md5_to_seq: dict[str, str] = {}
     md5_to_marker: dict[str, set[str]] = {}
     md5_to_genus: dict[str, set[str]] = {}
@@ -89,9 +99,11 @@ def main(db_url: str, output_filename: str, debug: bool = False) -> int:
     marker_conflicts = 0
     genus_conflicts = 0
     out_handle.write("#MD5\tLevel\tConflicts\n")
-    for md5, markers in sorted(md5_to_marker.items()):
-        if len(markers) > 1:
-            out_handle.write(f"{md5}\tmarker\t{';'.join(sorted(markers))}\n")
+    for md5, conflicting_markers in sorted(md5_to_marker.items()):
+        if len(conflicting_markers) > 1:
+            out_handle.write(
+                f"{md5}\tmarker\t{';'.join(sorted(conflicting_markers))}\n"
+            )
             marker_conflicts += 1
     for md5, genus in sorted(md5_to_genus.items()):
         if len(genus) > 1:


### PR DESCRIPTION
The soil-nematodes example with four markers is a good test case.

```
$ thapbi_pict conflicts -d examples/soil_nematodes/references/pooled.sqlite -k D3Af-D3Br
WARNING: Only looking at a subset of the markers defined in the DB (1 of 4)
WARNING - Not looking for marker JB3-JB5GED
WARNING - Not looking for marker NF1-18Sr2b
WARNING - Not looking for marker SSUF04-SSUR22
#MD5    Level   Conflicts
0673e10230c0dc5313e7a87e5f02f3f3        species Xiphinema bakeri;Xiphinema diversicaudatum;Xiphinema japonicum;Xiphinema sp.
4c5fd0aa01ebe89e1c14025470b71971        species Globodera pallida;Globodera rostochiensis
507a6a1677fd69b5fdbf0e0623108dee        species Globodera pallida;Globodera rostochiensis;Globodera sp.
51fcd0514a479e9eabc66abbb7d62a6e        species Ditylenchus gigas;Ditylenchus weischeri
823f8f652a14f3a1f78be287e2c4d1d3        species Anatonchus tridentatus;Anatonchus tridentatus clone AnatTri large subunit ribosomal RNA gene,
cd779357e8f7ee06a089701f134307b7        species Trichodorus primitivus;Trichodorus primitivus partial
```

```
$ thapbi_pict conflicts -d examples/soil_nematodes/references/pooled.sqlite -k JB3-JB5GED
WARNING: Only looking at a subset of the markers defined in the DB (1 of 4)
WARNING - Not looking for marker D3Af-D3Br
WARNING - Not looking for marker NF1-18Sr2b
WARNING - Not looking for marker SSUF04-SSUR22
#MD5    Level   Conflicts
497277e0ee2a2d84f0b722367e76d885        species Steinernema abbasi;Steinernema carpocapsae
```

```
$ thapbi_pict conflicts -d examples/soil_nematodes/references/pooled.sqlite -k JB3-JB5GED,D3Af-D3Br
WARNING: Only looking at a subset of the markers defined in the DB (2 of 4)
WARNING - Not looking for marker NF1-18Sr2b
WARNING - Not looking for marker SSUF04-SSUR22
#MD5    Level   Conflicts
0673e10230c0dc5313e7a87e5f02f3f3        species Xiphinema bakeri;Xiphinema diversicaudatum;Xiphinema japonicum;Xiphinema sp.
497277e0ee2a2d84f0b722367e76d885        species Steinernema abbasi;Steinernema carpocapsae
4c5fd0aa01ebe89e1c14025470b71971        species Globodera pallida;Globodera rostochiensis
507a6a1677fd69b5fdbf0e0623108dee        species Globodera pallida;Globodera rostochiensis;Globodera sp.
51fcd0514a479e9eabc66abbb7d62a6e        species Ditylenchus gigas;Ditylenchus weischeri
823f8f652a14f3a1f78be287e2c4d1d3        species Anatonchus tridentatus;Anatonchus tridentatus clone AnatTri large subunit ribosomal RNA gene,
cd779357e8f7ee06a089701f134307b7        species Trichodorus primitivus;Trichodorus primitivus partial
```

Versus default to show all marker's conflicts:

```
$ thapbi_pict conflicts -d examples/soil_nematodes/references/pooled.sqlite
/mnt/apps/users/pcock/repositories/biopython/Bio/__init__.py:138: BiopythonWarning: You may be importing Biopython from inside the source tree. This is bad practice and might lead to downstream issues. In particular, you might encounter ImportErrors due to missing compiled C extensions. We recommend that you try running your code from outside the source tree. If you are outside the source tree then you have a pyproject.toml file in an unexpected directory: /mnt/apps/users/pcock/repositories/biopython
  warnings.warn(
#MD5    Level   Conflicts
01062f2e246e03a9bed8d0cd5b830284        species Prionchulus muscorum;Prionchulus punctatus
0673e10230c0dc5313e7a87e5f02f3f3        species Xiphinema bakeri;Xiphinema diversicaudatum;Xiphinema japonicum;Xiphinema sp.
0e4e1c7315f41d039ff1c0d397530946        species Globodera achilleae;Globodera artemisiae;Globodera mexicana;Globodera pallida;Globodera rostochiensis;Globodera sp.;Globodera tabacum
11edff1cbe5ea70d9173e023377e2df7        species Ditylenchus dipsaci;Ditylenchus weischeri
208f4bbbf163abf02b401d564487da16        species Xiphinema bakeri;Xiphinema coxi europaeum;Xiphinema diversicaudatum;Xiphinema japonicum;Xiphinema pseudocoxi;Xiphinema vuittenezi
305f15f2285d71e87693ae4edebf6c70        species Xiphinema iranicum;Xiphinema vuittenezi
497277e0ee2a2d84f0b722367e76d885        species Steinernema abbasi;Steinernema carpocapsae
4c5fd0aa01ebe89e1c14025470b71971        species Globodera pallida;Globodera rostochiensis
507a6a1677fd69b5fdbf0e0623108dee        species Globodera pallida;Globodera rostochiensis;Globodera sp.
51fcd0514a479e9eabc66abbb7d62a6e        species Ditylenchus gigas;Ditylenchus weischeri
552cbb12d2228a002bdc540ad696275f        species Tripyla bioblitz;Tripyla filicaudata;Tripyla sp.
55d42ce94f42dd92da7d38afcf8573e1        species Longidorus caespiticola;Longidorus macrosoma
5826255ef05b5df9f186c6e1a5d947a5        species Meloidogyne enterolobii;Meloidogyne incognita
65dbc4c74167d085780f1630bfeeec57        species Meloidogyne ethiopica;Meloidogyne incognita
6a93578ec5967e44e734c98c83409e2a        species Longidorus kheirii;Longidorus pini;Longidorus uroshis
7a7e22fcaf94da1c41b93358e98ba21f        species Prionchulus cf. punctatus TSH-2005;Prionchulus muscorum;Prionchulus punctatus
823f8f652a14f3a1f78be287e2c4d1d3        species Anatonchus tridentatus;Anatonchus tridentatus clone AnatTri large subunit ribosomal RNA gene,
9e8113f08191f257459f609538b43f2c        species Xiphinema andalusiense;Xiphinema baetica
a295dc82d7b827c2e5f7633e34822261        species Trichodorus cylindricus;Trichodorus similis
b239482d3c3c65a092d079e5e2a2d48e        species Steinernema carpocapsae;Steinernema monticolum;Steinernema sp.;Steinernema websteri
c765e576059db709fd96a6827dc1f15a        species Tripyla glomerans;Tripyla sp.
cd779357e8f7ee06a089701f134307b7        species Trichodorus primitivus;Trichodorus primitivus partial
dce00308cba3b2b7e78f9562178dfc44        species Longidorus attenuatus;Longidorus cf. intermedius JH-2004;Longidorus elongatus
ea53548e219648fb3f49602b7533c292        species Tripyla daviesae;Tripyla sp.
```


Note this does not (yet) include the marker name in the output list of conflicts...